### PR TITLE
Make `create-output-dir` crate not depend on `cargo-util`. Release `create-output-dir` 1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,28 +524,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cargo-util"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b75f6bfca7b85d6e8c6a42405e9b4ecadd2e63f75f94aabfb524378b57a557a4"
-dependencies = [
- "anyhow",
- "core-foundation",
- "crypto-hash",
- "filetime",
- "hex 0.4.3",
- "jobserver",
- "libc",
- "log",
- "miow",
- "same-file",
- "shell-escape",
- "tempfile",
- "walkdir",
- "winapi",
-]
-
-[[package]]
 name = "cc"
 version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -641,24 +619,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "commoncrypto"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d056a8586ba25a1e4d61cb090900e495952c7886786fc55f909ab2f819b69007"
-dependencies = [
- "commoncrypto-sys",
-]
-
-[[package]]
-name = "commoncrypto-sys"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fed34f46747aa73dfaa578069fd8279d2818ade2b55f38f22a9401c7f4083e2"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "concolor"
 version = "0.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -748,10 +708,12 @@ dependencies = [
 
 [[package]]
 name = "create-output-dir"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
- "cargo-util",
+ "core-foundation",
+ "tempfile",
+ "winapi",
 ]
 
 [[package]]
@@ -777,18 +739,6 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
-]
-
-[[package]]
-name = "crypto-hash"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a77162240fd97248d19a564a565eb563a3f592b386e4136fb300909e67dddca"
-dependencies = [
- "commoncrypto",
- "hex 0.3.2",
- "openssl",
- "winapi",
 ]
 
 [[package]]
@@ -1035,21 +985,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1203,18 +1138,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hex"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
-
-[[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1358,15 +1281,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
-name = "jobserver"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "068b1ee6743e4d11fb9c6a1e6064b3693a1b600e7f5f5988047d98b3dc9fb90b"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1475,15 +1389,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
-name = "miow"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "new_debug_unreachable"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1561,45 +1466,6 @@ name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
-
-[[package]]
-name = "openssl"
-version = "0.10.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.80"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
-dependencies = [
- "autocfg",
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "os_pipe"
@@ -1748,12 +1614,6 @@ name = "pin-project-lite"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "polling"
@@ -2169,12 +2029,6 @@ checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
 dependencies = [
  "lazy_static",
 ]
-
-[[package]]
-name = "shell-escape"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f"
 
 [[package]]
 name = "signal-hook"
@@ -2640,12 +2494,6 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ similar-asserts = { version = "1.4.2", features = ["serde"] }
 smol = "1.3.0"
 smol_str = { version = "0.1.23", features = ["serde"] }
 snapbox = { version = "0.4.3", features = ["cmd", "path"] }
+tempfile = "3.3.0"
 test-case = "2.2.2"
 thiserror = "1.0.37"
 toml_edit = { version = "0.17.1", features = ["easy", "serde"] }

--- a/scarb/Cargo.toml
+++ b/scarb/Cargo.toml
@@ -20,7 +20,7 @@ camino.workspace = true
 clap-verbosity-flag.workspace = true
 clap.workspace = true
 console.workspace = true
-create-output-dir = { version = "0.1.0", path = "../utils/create-output-dir" }
+create-output-dir = { version = "1.0.0", path = "../utils/create-output-dir" }
 directories.workspace = true
 dunce.workspace = true
 fs4.workspace = true

--- a/utils/create-output-dir/Cargo.toml
+++ b/utils/create-output-dir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "create-output-dir"
-version = "0.1.0"
+version = "1.0.0"
 description = "Create an excluded from cache directory atomically"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,4 +13,12 @@ categories = ["filesystem", "os"]
 
 [dependencies]
 anyhow.workspace = true
-cargo-util = "0.2.2"
+tempfile.workspace = true
+
+[target."cfg(target_os = \"macos\")".dependencies.core-foundation]
+version = "0.9.3"
+features = ["mac_os_10_7_support"]
+
+[target."cfg(windows)".dependencies.winapi]
+version = "0.3.9"
+features = ["minwindef"]

--- a/utils/create-output-dir/README.md
+++ b/utils/create-output-dir/README.md
@@ -3,9 +3,8 @@
 This crate provides only one function, `create_output_dir` which creates an excluded from cache directory atomically
 with its parents as needed.
 
-Under the hood, this function simply calls into [Cargo's utility crate][cargo-util], but in the future it will contain
-this code
-directly, reducing dependency build time.
+The source code of this crate has been almost verbatim copy-pasted from
+[`cargo_util::paths::create_dir_all_excluded_from_backups_atomic`][cargo-util-fn].
 
 ## Changelog
 
@@ -16,5 +15,7 @@ All notable changes to this project are documented on the [GitHub releases] page
 This crate is an extract from [`cargo-util`][cargo-util], developed by the Rust project contributors.
 
 [cargo-util]: https://crates.io/crates/cargo-util
+
+[cargo-util-fn]: https://docs.rs/cargo-util/latest/cargo_util/paths/fn.create_dir_all_excluded_from_backups_atomic.html
 
 [github releases]: https://github.com/software-mansion/scarb/releases

--- a/utils/create-output-dir/src/lib.rs
+++ b/utils/create-output-dir/src/lib.rs
@@ -1,16 +1,17 @@
 //! This crate provides only one function, `create_output_dir` which creates an excluded from cache
 //! directory atomically with its parents as needed.
 //!
-//! Under the hood, this function simply calls
-//! [`cargo_util::paths::create_dir_all_excluded_from_backups_atomic`],
-//! but in the future it will contain this code directly, reducing dependency build time.
+//! The source code of this crate has been almost verbatim copy-pasted from
+//! [`cargo_util::paths::create_dir_all_excluded_from_backups_atomic`][cargo-util-fn].
+//!
+//! [cargo-util-fn]: https://docs.rs/cargo-util/latest/cargo_util/paths/fn.create_dir_all_excluded_from_backups_atomic.html
 
+use std::ffi::OsStr;
 use std::path::Path;
+use std::{env, fs};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 
-// TODO(mkaput): Copy-paste implementation here so that we don't pull and compile unnecessary
-//   stuff from the `cargo_util` crate.
 /// Creates an excluded from cache directory atomically with its parents as needed.
 ///
 /// The atomicity only covers creating the leaf directory and exclusion from cache. Any missing
@@ -19,5 +20,129 @@ use anyhow::Result;
 /// This function is idempotent and in addition to that it won't exclude `path` from cache if it
 /// already exists.
 pub fn create_output_dir(path: &Path) -> Result<()> {
-    cargo_util::paths::create_dir_all_excluded_from_backups_atomic(path)
+    if path.is_dir() {
+        return Ok(());
+    }
+
+    let parent = path.parent().unwrap();
+    let base = path.file_name().unwrap();
+    fs::create_dir_all(parent)
+        .with_context(|| format!("failed to create directory `{}`", parent.display()))?;
+
+    // We do this in two steps: first create a temporary directory and exclude it from backups,
+    // then rename it to the desired name.
+    // If we created the directory directly where it should be and then excluded it from backups
+    // we would risk a situation where the application is interrupted right after the directory
+    // creation, but before the exclusion, and the directory would remain non-excluded from backups.
+    //
+    // We need a temporary directory created in `parent` instead of `$TMP`, because only then we
+    // can be easily sure that `fs::rename()` will succeed (the new name needs to be on the same
+    // mount point as the old one).
+    let tempdir = tempfile::Builder::new().prefix(base).tempdir_in(parent)?;
+    exclude_from_backups(tempdir.path());
+    exclude_from_content_indexing(tempdir.path());
+
+    // Previously `fs::create_dir_all()` was used here to create the directory directly and
+    // `fs::create_dir_all()` explicitly treats the directory being created concurrently by another
+    // thread or process as success, hence the check below to follow the existing behavior.
+    // If we get an error at `fs::rename()` and suddenly the directory (which didn't exist a moment
+    // earlier) exists we can infer from it that another application process is doing work here.
+    if let Err(e) = fs::rename(tempdir.path(), path) {
+        if !path.exists() {
+            return Err(e.into());
+        }
+    }
+
+    Ok(())
+}
+
+/// Marks the directory as excluded from archives/backups.
+///
+/// This is recommended to prevent derived/temporary files from bloating backups.
+/// There are two mechanisms used to achieve this right now:
+/// * A dedicated resource property excluding from Time Machine backups on macOS.
+/// * `CACHEDIR.TAG` files supported by various tools in a platform-independent way.
+fn exclude_from_backups(path: &Path) {
+    exclude_from_time_machine(path);
+    let _ = fs::write(
+        path.join("CACHEDIR.TAG"),
+        format!(
+            "Signature: 8a477f597d28d172789f06886806bc55
+# This file is a cache directory tag{}.
+# For information about cache directory tags see https://bford.info/cachedir/
+",
+            match guess_application_name() {
+                None => String::new(),
+                Some(name) => format!(" created by {}", name),
+            }
+        ),
+    );
+    // Similarly to exclude_from_time_machine() we ignore errors here as it's an optional feature.
+}
+
+/// Marks the directory as excluded from content indexing.
+///
+/// This is recommended to prevent the content of derived/temporary files from being indexed.
+/// This is very important for Windows users, as the live content indexing may significantly slow
+/// I/O operations or compilers etc.
+///
+/// This is currently a no-op on non-Windows platforms.
+fn exclude_from_content_indexing(path: &Path) {
+    #[cfg(windows)]
+    {
+        use std::iter::once;
+        use std::os::windows::prelude::OsStrExt;
+        use winapi::um::fileapi::{GetFileAttributesW, SetFileAttributesW};
+        use winapi::um::winnt::FILE_ATTRIBUTE_NOT_CONTENT_INDEXED;
+
+        let path: Vec<u16> = path.as_os_str().encode_wide().chain(once(0)).collect();
+        unsafe {
+            SetFileAttributesW(
+                path.as_ptr(),
+                GetFileAttributesW(path.as_ptr()) | FILE_ATTRIBUTE_NOT_CONTENT_INDEXED,
+            );
+        }
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = path;
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn exclude_from_time_machine(_: &Path) {}
+
+/// Marks files or directories as excluded from Time Machine on macOS.
+#[cfg(target_os = "macos")]
+fn exclude_from_time_machine(path: &Path) {
+    use core_foundation::base::TCFType;
+    use core_foundation::{number, string, url};
+    use std::ptr;
+
+    // For compatibility with 10.7 a string is used instead of global kCFURLIsExcludedFromBackupKey
+    let is_excluded_key: std::result::Result<string::CFString, _> =
+        "NSURLIsExcludedFromBackupKey".parse();
+    let path = url::CFURL::from_path(path, false);
+    if let (Some(path), Ok(is_excluded_key)) = (path, is_excluded_key) {
+        unsafe {
+            url::CFURLSetResourcePropertyForKey(
+                path.as_concrete_TypeRef(),
+                is_excluded_key.as_concrete_TypeRef(),
+                number::kCFBooleanTrue as *const _,
+                ptr::null_mut(),
+            );
+        }
+    }
+    // Errors are ignored, since it's an optional feature and failure
+    // shouldn't prevent applications from working.
+}
+
+fn guess_application_name() -> Option<String> {
+    let exe = env::current_exe().ok()?;
+    let file_name = if exe.extension() == Some(OsStr::new(env::consts::EXE_EXTENSION)) {
+        exe.file_stem()
+    } else {
+        exe.file_name()
+    }?;
+    Some(file_name.to_string_lossy().into_owned())
 }


### PR DESCRIPTION
fix #25