### PR TITLE
Add `scarb rm`

### DIFF
--- a/scarb/src/bin/scarb/args.rs
+++ b/scarb/src/bin/scarb/args.rs
@@ -111,6 +111,11 @@ pub enum Command {
     // External should go last.
     /// Add dependencies to a Scarb.toml manifest file.
     Add(AddArgs),
+
+    /// Remove dependencies from a manifest file
+    #[command(alias = "rm")]
+    Remove(RemoveArgs),
+
     /// Compile current project.
     Build,
     /// Remove generated artifacts.
@@ -215,6 +220,22 @@ pub struct AddSourceArgs {
     /// Git reference args for `--git`.
     #[command(flatten)]
     pub git_ref: GitRefGroup,
+}
+
+/// Arguments accepted by the `remove` command.
+#[derive(Parser, Clone, Debug)]
+pub struct RemoveArgs {
+    /// Dependencies to be removed
+    #[arg(value_name = "DEP_ID", required = true)]
+    pub packages: Vec<PackageName>,
+
+    /// Do not actually write the manifest.
+    #[arg(long)]
+    pub dry_run: bool,
+
+    /// Specify package to modify.
+    #[arg(short, long)]
+    pub package: Option<PackageName>,
 }
 
 /// Git reference specification arguments.

--- a/scarb/src/bin/scarb/args.rs
+++ b/scarb/src/bin/scarb/args.rs
@@ -112,7 +112,7 @@ pub enum Command {
     /// Add dependencies to a Scarb.toml manifest file.
     Add(AddArgs),
 
-    /// Remove dependencies from a manifest file
+    /// Remove dependencies from a manifest file.
     #[command(alias = "rm")]
     Remove(RemoveArgs),
 

--- a/scarb/src/bin/scarb/args.rs
+++ b/scarb/src/bin/scarb/args.rs
@@ -225,7 +225,7 @@ pub struct AddSourceArgs {
 /// Arguments accepted by the `remove` command.
 #[derive(Parser, Clone, Debug)]
 pub struct RemoveArgs {
-    /// Dependencies to be removed
+    /// Dependencies to be removed.
     #[arg(value_name = "DEP_ID", required = true)]
     pub packages: Vec<PackageName>,
 

--- a/scarb/src/bin/scarb/commands/mod.rs
+++ b/scarb/src/bin/scarb/commands/mod.rs
@@ -16,6 +16,7 @@ pub mod init;
 pub mod manifest_path;
 pub mod metadata;
 pub mod new;
+pub mod remove;
 
 pub fn run(command: Command, config: &mut Config) -> Result<()> {
     use Command::*;
@@ -32,5 +33,6 @@ pub fn run(command: Command, config: &mut Config) -> Result<()> {
         ManifestPath => manifest_path::run(config),
         Metadata(args) => metadata::run(args, config),
         New(args) => new::run(args, config),
+        Remove(args) => remove::run(args, config),
     }
 }

--- a/scarb/src/bin/scarb/commands/remove.rs
+++ b/scarb/src/bin/scarb/commands/remove.rs
@@ -44,10 +44,6 @@ pub fn run(args: RemoveArgs, config: &mut Config) -> Result<()> {
 fn build_ops(packages: Vec<PackageName>) -> Vec<Box<dyn Op>> {
     packages
         .into_iter()
-        .map(|dep_name| -> Box<dyn Op> {
-            Box::new(RemoveDependency {
-                dep: Some(dep_name),
-            })
-        })
+        .map(|dep| -> Box<dyn Op> { Box::new(RemoveDependency { dep }) })
         .collect()
 }

--- a/scarb/src/bin/scarb/commands/remove.rs
+++ b/scarb/src/bin/scarb/commands/remove.rs
@@ -1,0 +1,53 @@
+use anyhow::{anyhow, Result};
+
+use scarb::core::{Config, PackageName};
+use scarb::manifest_editor::{EditManifestOptions, Op, RemoveDependency};
+use scarb::{manifest_editor, ops};
+
+use crate::args::RemoveArgs;
+
+#[tracing::instrument(skip_all, level = "info")]
+pub fn run(args: RemoveArgs, config: &mut Config) -> Result<()> {
+    let ws = ops::read_workspace(config.manifest_path(), config)?;
+
+    // TODO(mkaput): Extract more generic pattern for this. See `Packages` struct in Cargo.
+    let package = match args.package {
+        Some(name) => ws
+            .members()
+            .find(|pkg| pkg.id.name == name)
+            .ok_or_else(|| anyhow!("package `{name}` not found in workspace `{ws}`"))?,
+        None => ws.current_package()?.clone(),
+    };
+
+    manifest_editor::edit(
+        package.manifest_path(),
+        build_ops(args.packages),
+        EditManifestOptions {
+            config,
+            dry_run: args.dry_run,
+        },
+    )?;
+
+    if !args.dry_run {
+        // Reload the workspace since we have changed dependencies
+        let ws = ops::read_workspace(config.manifest_path(), config)?;
+
+        // Only try to resolve packages if network is allowed, which would be probably required.
+        if config.network_allowed() {
+            let _ = ops::resolve_workspace(&ws)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn build_ops(packages: Vec<PackageName>) -> Vec<Box<dyn Op>> {
+    packages
+        .into_iter()
+        .map(|dep_name| -> Box<dyn Op> {
+            Box::new(RemoveDependency {
+                dep: Some(dep_name),
+            })
+        })
+        .collect()
+}

--- a/scarb/src/manifest_editor/mod.rs
+++ b/scarb/src/manifest_editor/mod.rs
@@ -8,6 +8,7 @@ use toml_edit::Document;
 
 pub use add::AddDependency;
 pub use dep_id::DepId;
+pub use remove::RemoveDependency;
 
 use crate::core::Config;
 use crate::internal::fsx;
@@ -15,6 +16,7 @@ use crate::internal::fsx::PathBufUtf8Ext;
 
 mod add;
 mod dep_id;
+mod remove;
 mod tomlx;
 
 pub trait Op {

--- a/scarb/src/manifest_editor/remove.rs
+++ b/scarb/src/manifest_editor/remove.rs
@@ -9,7 +9,7 @@ use super::{Op, OpCtx};
 
 #[derive(Debug, Default)]
 pub struct RemoveDependency {
-    pub dep: Option<PackageName>,
+    pub dep: PackageName,
 }
 
 impl Op for RemoveDependency {

--- a/scarb/src/manifest_editor/remove.rs
+++ b/scarb/src/manifest_editor/remove.rs
@@ -1,0 +1,39 @@
+use anyhow::{anyhow, Result};
+use toml_edit::Document;
+
+use crate::core::PackageName;
+use crate::ui::Status;
+
+use super::tomlx::get_table_mut;
+use super::{Op, OpCtx};
+
+#[derive(Debug, Default)]
+pub struct RemoveDependency {
+    pub dep: Option<PackageName>,
+}
+
+impl Op for RemoveDependency {
+    #[tracing::instrument(level = "trace", skip(doc, ctx))]
+    fn apply_to(self: Box<Self>, doc: &mut Document, ctx: OpCtx<'_>) -> Result<()> {
+        let tab = get_table_mut(doc, &["dependencies"])?;
+
+        let dep_key = self
+            .dep
+            .ok_or_else(|| anyhow!("please specify package name"))?;
+
+        // section is hardcoded as there's no support for other section types yet
+        ctx.opts.config.ui().print(Status::new(
+            "Removing",
+            &format!("{dep_key} from dependencies"),
+        ));
+
+        tab.as_table_like_mut()
+            .unwrap()
+            .remove(dep_key.as_str())
+            .ok_or_else(|| {
+                anyhow!("the dependency `{dep_key}` could not be found in `dependencies`")
+            })?;
+
+        Ok(())
+    }
+}

--- a/scarb/src/manifest_editor/remove.rs
+++ b/scarb/src/manifest_editor/remove.rs
@@ -7,7 +7,7 @@ use crate::ui::Status;
 use super::tomlx::get_table_mut;
 use super::{Op, OpCtx};
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct RemoveDependency {
     pub dep: PackageName,
 }
@@ -17,21 +17,20 @@ impl Op for RemoveDependency {
     fn apply_to(self: Box<Self>, doc: &mut Document, ctx: OpCtx<'_>) -> Result<()> {
         let tab = get_table_mut(doc, &["dependencies"])?;
 
-        let dep_key = self
-            .dep
-            .ok_or_else(|| anyhow!("please specify package name"))?;
-
         // section is hardcoded as there's no support for other section types yet
         ctx.opts.config.ui().print(Status::new(
             "Removing",
-            &format!("{dep_key} from dependencies"),
+            &format!("{} from dependencies", self.dep),
         ));
 
         tab.as_table_like_mut()
             .unwrap()
-            .remove(dep_key.as_str())
+            .remove(self.dep.as_str())
             .ok_or_else(|| {
-                anyhow!("the dependency `{dep_key}` could not be found in `dependencies`")
+                anyhow!(
+                    "the dependency `{}` could not be found in `dependencies`",
+                    self.dep
+                )
             })?;
 
         Ok(())

--- a/scarb/tests/e2e/main.rs
+++ b/scarb/tests/e2e/main.rs
@@ -9,6 +9,7 @@ mod git_source_network;
 mod manifest_path;
 mod metadata;
 mod new_and_init;
+mod remove;
 mod resolver_with_git;
 mod subcommand;
 pub(crate) mod support;

--- a/scarb/tests/e2e/remove.rs
+++ b/scarb/tests/e2e/remove.rs
@@ -1,0 +1,118 @@
+use indoc::indoc;
+
+use crate::support::manifest_edit::ManifestEditHarness;
+
+#[test]
+fn remove_one() {
+    ManifestEditHarness::offline()
+        .args(["rm", "foo"])
+        .input(indoc! {r#"
+            [package]
+            name = "hello"
+            version = "1.0.0"
+
+            [dependencies]
+            dep = "1.0.0"
+            foo = "1.0.0"
+            bar = "1.0.0"
+        "#})
+        .output(indoc! {r#"
+            [package]
+            name = "hello"
+            version = "1.0.0"
+
+            [dependencies]
+            dep = "1.0.0"
+            bar = "1.0.0"
+        "#})
+        .stdout_matches("    Removing foo from dependencies\n")
+        .run();
+}
+
+#[test]
+fn multiple_deps() {
+    ManifestEditHarness::offline()
+        .args(["remove", "bar", "dep"])
+        .input(indoc! {r#"
+            [package]
+            name = "hello"
+            version = "1.0.0"
+
+            [dependencies]
+            dep = "1.0.0"
+            foo = "1.0.0"
+            bar = "1.0.0"
+        "#})
+        .output(indoc! {r#"
+            [package]
+            name = "hello"
+            version = "1.0.0"
+
+            [dependencies]
+            foo = "1.0.0"
+        "#})
+        .stdout_matches("    Removing bar from dependencies\n    Removing dep from dependencies\n")
+        .run();
+}
+
+#[test]
+fn undefined_dep() {
+    ManifestEditHarness::offline()
+        .args(["remove", "foo"])
+        .input(indoc! {r#"
+            [package]
+            name = "hello"
+            version = "1.0.0"
+
+            [dependencies]
+            dep = "1.0.0"
+            bar = "1.0.0"
+        "#})
+        .failure()
+        .stdout_matches(indoc! {r#"    Removing foo from dependencies
+            error: the dependency `foo` could not be found in `dependencies`
+        "#})
+        .run();
+}
+
+#[test]
+fn no_dependencies_section() {
+    ManifestEditHarness::offline()
+        .args(["rm", "dep"])
+        .input(indoc! {r#"
+            [package]
+            name = "hello"
+            version = "1.0.0"
+        "#})
+        .failure()
+        .stdout_matches(indoc! {r#"    Removing dep from dependencies
+            error: the dependency `dep` could not be found in `dependencies`
+        "#})
+        .run();
+}
+
+#[test]
+fn dry_run() {
+    ManifestEditHarness::offline()
+        .args(["remove", "--dry-run", "bar"])
+        .input(indoc! {r#"
+            [package]
+            name = "hello"
+            version = "1.0.0"
+
+            [dependencies]
+            bar = "1.0.0"
+        "#})
+        .output(indoc! {r#"
+            [package]
+            name = "hello"
+            version = "1.0.0"
+
+            [dependencies]
+            bar = "1.0.0"
+        "#})
+        .stdout_matches(indoc! {r#"    Removing bar from dependencies
+            warn: aborting due to dry run
+        "#})
+        .run();
+}


### PR DESCRIPTION
fix #93 

Adds `remove` command with `rm` as alias. Currently, all it does is just removing the specified dependencies from the dependency table of a manifest file. It doesn't do any workspace clean up like `cargo rm` as there's no support for proper workspace yet as well as other types of dependency (e.g., dev, build).

I tried to refer as much as possible to `cargo`, so if there's anything lacking please let me know.



