### PR TITLE
Initialize Git repository on `scarb new` & `scarb init`

### DIFF
--- a/scarb/src/bin/scarb/args.rs
+++ b/scarb/src/bin/scarb/args.rs
@@ -145,6 +145,10 @@ pub struct InitArgs {
     /// Set the resulting package name, defaults to the directory name.
     #[arg(long)]
     pub name: Option<PackageName>,
+
+    /// Do not initialize a new Git repository.
+    #[arg(long)]
+    pub no_vcs: bool,
 }
 
 /// Arguments accepted by the `metadata` command.

--- a/scarb/src/bin/scarb/commands/init.rs
+++ b/scarb/src/bin/scarb/commands/init.rs
@@ -4,7 +4,7 @@ use anyhow::{anyhow, Result};
 use camino::Utf8PathBuf;
 
 use scarb::core::Config;
-use scarb::ops;
+use scarb::ops::{self, VersionControl};
 
 use crate::args::InitArgs;
 
@@ -17,6 +17,13 @@ pub fn run(args: InitArgs, config: &Config) -> Result<()> {
         ops::InitOptions {
             name: args.name,
             path,
+            // At the moment, we only support Git but ideally, we want to
+            // support more VCS and allow user to explicitly specify which VCS to use.
+            vcs: if args.no_vcs {
+                VersionControl::NoVcs
+            } else {
+                VersionControl::Git
+            },
         },
         config,
     )?;

--- a/scarb/src/bin/scarb/commands/new.rs
+++ b/scarb/src/bin/scarb/commands/new.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 
 use scarb::core::Config;
-use scarb::ops;
+use scarb::ops::{self, VersionControl};
 
 use crate::args::NewArgs;
 
@@ -11,6 +11,13 @@ pub fn run(args: NewArgs, config: &Config) -> Result<()> {
         ops::InitOptions {
             name: args.init.name,
             path: args.path,
+            // At the moment, we only support Git but ideally, we want to
+            // support more VCS and allow user to explicitly specify which VCS to use.
+            vcs: if args.init.no_vcs {
+                VersionControl::NoVcs
+            } else {
+                VersionControl::Git
+            },
         },
         config,
     )?;

--- a/scarb/tests/e2e/new_and_init.rs
+++ b/scarb/tests/e2e/new_and_init.rs
@@ -25,6 +25,39 @@ fn new_simple() {
     assert!(t.child("Scarb.toml").is_file());
     assert!(t.child("src/lib.cairo").is_file());
     assert!(t.child(".gitignore").is_file());
+    assert!(t.child(".git").is_dir());
+
+    let toml_manifest = TomlManifest::read_from_path(t.child("Scarb.toml").utf8_path()).unwrap();
+    assert_eq!(toml_manifest.package.unwrap().name.as_str(), "hello");
+
+    Scarb::quick_snapbox()
+        .arg("build")
+        .current_dir(&t)
+        .assert()
+        .success();
+
+    t.child("target/release/hello.sierra")
+        .assert(predicates::str::is_empty().not());
+}
+
+#[test]
+fn new_simple_without_vcs() {
+    let pt = assert_fs::TempDir::new().unwrap();
+
+    Scarb::quick_snapbox()
+        .arg("new")
+        .arg("hello")
+        .arg("--no-vcs")
+        .current_dir(&pt)
+        .assert()
+        .success();
+
+    let t = pt.child("hello");
+    assert!(t.is_dir());
+    assert!(t.child("Scarb.toml").is_file());
+    assert!(t.child("src/lib.cairo").is_file());
+    assert!(!t.child(".gitignore").exists());
+    assert!(!t.child(".git").exists());
 
     let toml_manifest = TomlManifest::read_from_path(t.child("Scarb.toml").utf8_path()).unwrap();
     assert_eq!(toml_manifest.package.unwrap().name.as_str(), "hello");
@@ -55,6 +88,39 @@ fn init_simple() {
     assert!(t.child("Scarb.toml").is_file());
     assert!(t.child("src/lib.cairo").is_file());
     assert!(t.child(".gitignore").is_file());
+    assert!(t.child(".git").is_dir());
+
+    let toml_manifest = TomlManifest::read_from_path(t.child("Scarb.toml").utf8_path()).unwrap();
+    assert_eq!(toml_manifest.package.unwrap().name.as_str(), "hello");
+
+    Scarb::quick_snapbox()
+        .arg("build")
+        .current_dir(&t)
+        .assert()
+        .success();
+
+    t.child("target/release/hello.sierra")
+        .assert(predicates::str::is_empty().not());
+}
+
+#[test]
+fn init_simple_without_vcs() {
+    let pt = assert_fs::TempDir::new().unwrap();
+    let t = pt.child("hello");
+    t.create_dir_all().unwrap();
+
+    Scarb::quick_snapbox()
+        .arg("init")
+        .arg("--no-vcs")
+        .current_dir(&t)
+        .assert()
+        .success();
+
+    assert!(t.is_dir());
+    assert!(t.child("Scarb.toml").is_file());
+    assert!(t.child("src/lib.cairo").is_file());
+    assert!(!t.child(".gitignore").exists());
+    assert!(!t.child(".git").exists());
 
     let toml_manifest = TomlManifest::read_from_path(t.child("Scarb.toml").utf8_path()).unwrap();
     assert_eq!(toml_manifest.package.unwrap().name.as_str(), "hello");


### PR DESCRIPTION
Fix #80 

Refactor `write_vcs_ignore` a bit to allow some flexibility **in case** we want to support other version control systems in the future.