### PR TITLE
Sort `[dependencies]` section on `scarb add`

### DIFF
--- a/scarb/src/manifest_editor/add.rs
+++ b/scarb/src/manifest_editor/add.rs
@@ -52,10 +52,10 @@ impl Op for AddDependency {
 
         let dep = Dep::resolve(*self, ctx)?;
 
-        let was_sorted = tab.as_table_like().map_or(true, |dep_table| {
-            let values = dep_table.get_values();
+        let was_sorted = {
+            let values = tab.as_table_like().unwrap().get_values();
             is_sorted(values.iter().map(|(key, _)| key[0]))
-        });
+        };
 
         let dep_key = dep.toml_key().to_string();
         dep.upsert(tab.as_table_like_mut().unwrap().entry(&dep_key));

--- a/scarb/tests/e2e/add.rs
+++ b/scarb/tests/e2e/add.rs
@@ -377,6 +377,62 @@ fn should_sort_if_already_sorted() {
             foo = "1.0.0"
         "#})
         .run();
+
+    ManifestEditHarness::offline()
+        .args(["add", "cat@2.0.0"])
+        .input(indoc! {r#"
+            [package]
+            name = "hello"
+            version = "1.0.0"
+
+            [dependencies]
+            bar = "1.0.0"
+            
+            dep = "1.0.0"
+            foo = "1.0.0"
+        "#})
+        .output(indoc! {r#"
+            [package]
+            name = "hello"
+            version = "1.0.0"
+
+            [dependencies]
+            bar = "1.0.0"
+            cat = "2.0.0"
+
+            dep = "1.0.0"
+            foo = "1.0.0"
+        "#})
+        .run();
+
+    ManifestEditHarness::offline()
+        .args(["add", "dog@2.0.0"])
+        .input(indoc! {r#"
+            [package]
+            name = "hello"
+            version = "1.0.0"
+
+            [dependencies]
+            bar = "1.0.0"
+            cat = "2.0.0"
+            
+            dep = "1.0.0"
+            foo = "1.0.0"
+        "#})
+        .output(indoc! {r#"
+            [package]
+            name = "hello"
+            version = "1.0.0"
+
+            [dependencies]
+            bar = "1.0.0"
+            cat = "2.0.0"
+            
+            dep = "1.0.0"
+            dog = "2.0.0"
+            foo = "1.0.0"
+        "#})
+        .run();
 }
 
 #[test]
@@ -391,7 +447,6 @@ fn should_not_sort_if_already_unsorted() {
             [dependencies]
             bar = "1.0.0"
             foo = "1.0.0"
-            
             dep = "1.0.0"
         "#})
         .output(indoc! {r#"
@@ -402,7 +457,6 @@ fn should_not_sort_if_already_unsorted() {
             [dependencies]
             bar = "1.0.0"
             foo = "1.0.0"
-            
             dep = "1.0.0"
             apple = "1.0.0"
         "#})

--- a/scarb/tests/e2e/add.rs
+++ b/scarb/tests/e2e/add.rs
@@ -350,3 +350,61 @@ fn overwrite_change_source_from_path_to_git() {
         "#})
         .run();
 }
+
+#[test]
+fn should_sort_if_already_sorted() {
+    ManifestEditHarness::offline()
+        .args(["add", "cat@2.0.0"])
+        .input(indoc! {r#"
+            [package]
+            name = "hello"
+            version = "1.0.0"
+
+            [dependencies]
+            bar = "1.0.0"
+            dep = "1.0.0"
+            foo = "1.0.0"
+        "#})
+        .output(indoc! {r#"
+            [package]
+            name = "hello"
+            version = "1.0.0"
+
+            [dependencies]
+            bar = "1.0.0"
+            cat = "2.0.0"
+            dep = "1.0.0"
+            foo = "1.0.0"
+        "#})
+        .run();
+}
+
+#[test]
+fn should_not_sort_if_already_unsorted() {
+    ManifestEditHarness::offline()
+        .args(["add", "apple@1.0.0"])
+        .input(indoc! {r#"
+            [package]
+            name = "hello"
+            version = "1.0.0"
+
+            [dependencies]
+            bar = "1.0.0"
+            foo = "1.0.0"
+            
+            dep = "1.0.0"
+        "#})
+        .output(indoc! {r#"
+            [package]
+            name = "hello"
+            version = "1.0.0"
+
+            [dependencies]
+            bar = "1.0.0"
+            foo = "1.0.0"
+            
+            dep = "1.0.0"
+            apple = "1.0.0"
+        "#})
+        .run();
+}


### PR DESCRIPTION
Fix #128 

Will sort if the `[dependencies]` section is already sorted otherwise leave it as is.