### PR TITLE
Generalize logic for getting selected package

### DIFF
--- a/scarb/src/bin/scarb/commands/add.rs
+++ b/scarb/src/bin/scarb/commands/add.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 
 use scarb::core::Config;
 use scarb::manifest_editor::{AddDependency, DepId, EditManifestOptions, Op};
@@ -10,14 +10,7 @@ use crate::args::{AddArgs, AddSourceArgs};
 pub fn run(args: AddArgs, config: &mut Config) -> Result<()> {
     let ws = ops::read_workspace(config.manifest_path(), config)?;
 
-    // TODO(#127): Extract more generic pattern for this. See `Packages` struct in Cargo.
-    let package = match args.package {
-        Some(name) => ws
-            .members()
-            .find(|pkg| pkg.id.name == name)
-            .ok_or_else(|| anyhow!("package `{name}` not found in workspace `{ws}`"))?,
-        None => ws.current_package()?.clone(),
-    };
+    let package = args.packages_filter.match_one(&ws)?;
 
     manifest_editor::edit(
         package.manifest_path(),

--- a/scarb/src/bin/scarb/commands/remove.rs
+++ b/scarb/src/bin/scarb/commands/remove.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 
 use scarb::core::{Config, PackageName};
 use scarb::manifest_editor::{EditManifestOptions, Op, RemoveDependency};
@@ -10,14 +10,7 @@ use crate::args::RemoveArgs;
 pub fn run(args: RemoveArgs, config: &mut Config) -> Result<()> {
     let ws = ops::read_workspace(config.manifest_path(), config)?;
 
-    // TODO(#127): Extract more generic pattern for this. See `Packages` struct in Cargo.
-    let package = match args.package {
-        Some(name) => ws
-            .members()
-            .find(|pkg| pkg.id.name == name)
-            .ok_or_else(|| anyhow!("package `{name}` not found in workspace `{ws}`"))?,
-        None => ws.current_package()?.clone(),
-    };
+    let package = args.packages_filter.match_one(&ws)?;
 
     manifest_editor::edit(
         package.manifest_path(),


### PR DESCRIPTION
Fix #127 

Referring to Cargo, the problem I'm seeing with this if later we want to add flags like `--exclude` / `--all` for commands like `scarb build`, we can just add new fields in `PackagesFilter`, but then we can't disable the individual flags for commands that don't require them and they'd also be shown in the help message. Or maybe that's not something we should worry about atm? Wdyt?