### PR TITLE
Canonicalize Git URL in `scarb add`

### DIFF
--- a/scarb/src/manifest_editor/add.rs
+++ b/scarb/src/manifest_editor/add.rs
@@ -3,10 +3,12 @@ use std::mem;
 use anyhow::{anyhow, ensure, Result};
 use camino::{Utf8Path, Utf8PathBuf};
 use toml_edit::{value, Document, Entry, InlineTable, Item};
+use url::Url;
 
 use crate::core::{GitReference, PackageName};
 use crate::internal::fsx;
 use crate::internal::fsx::PathBufUtf8Ext;
+use crate::sources::canonical_url::CanonicalUrl;
 
 use super::tomlx::get_table_mut;
 use super::{DepId, Op, OpCtx};
@@ -126,6 +128,13 @@ impl Dep {
                 Rev(rev.into())
             } else {
                 DefaultBranch
+            };
+
+            let git = match Url::parse(&git) {
+                Ok(url) => CanonicalUrl::new(&url)
+                    .map(|git_url| git_url.as_str().to_string())
+                    .unwrap_or(git),
+                Err(_) => git,
             };
 
             Box::new(GitSource {

--- a/scarb/src/sources/git/mod.rs
+++ b/scarb/src/sources/git/mod.rs
@@ -18,7 +18,7 @@ use crate::ui::Status;
 
 use super::PathSource;
 
-mod canonical_url;
+pub mod canonical_url;
 mod client;
 
 pub struct GitSource<'c> {

--- a/scarb/tests/e2e/add.rs
+++ b/scarb/tests/e2e/add.rs
@@ -217,7 +217,7 @@ fn git() {
             version = "1.0.0"
 
             [dependencies]
-            dep = { git = "https://example.com" }
+            dep = { git = "https://example.com/" }
         "#})
         .run();
 }
@@ -237,7 +237,7 @@ fn git_version() {
             version = "1.0.0"
 
             [dependencies]
-            dep = { version = "1.0.0", git = "https://example.com" }
+            dep = { version = "1.0.0", git = "https://example.com/" }
         "#})
         .run();
 }
@@ -261,7 +261,7 @@ fn git_spec(what: &str) {
             version = "1.0.0"
 
             [dependencies]
-            dep = {{ git = "https://example.com", {what} = "abcd" }}
+            dep = {{ git = "https://example.com/", {what} = "abcd" }}
         "#})
         .run();
 }
@@ -346,7 +346,7 @@ fn overwrite_change_source_from_path_to_git() {
             version = "1.0.0"
 
             [dependencies]
-            dep = { version = "1.2.3", git = "https://example.com", branch = "abc" }
+            dep = { version = "1.2.3", git = "https://example.com/", branch = "abc" }
         "#})
         .run();
 }


### PR DESCRIPTION
Fix #108

Add trailing slash in tests because they have empty paths.