### PR TITLE
Change references to `quirenox` in our website to `quaireaux_math`

### DIFF
--- a/scarb/src/bin/scarb/args.rs
+++ b/scarb/src/bin/scarb/args.rs
@@ -210,8 +210,8 @@ pub struct AddArgs {
     /// Reference to a package to add as a dependency
     ///
     /// You can reference a package by:
-    /// - `<name>`, like `scarb add quaireaux` (the latest version will be used)
-    /// - `<name>@<version-req>`, like `scarb add quaireaux@1` or `scarb add quaireaux@=0.1.0`
+    /// - `<name>`, like `scarb add quaireaux_math` (the latest version will be used)
+    /// - `<name>@<version-req>`, like `scarb add quaireaux_math@1` or `scarb add quaireaux_math@=0.1.0`
     #[arg(value_name = "DEP_ID", verbatim_doc_comment)]
     pub packages: Vec<DepId>,
 

--- a/website/components/home/jumbo.tsx
+++ b/website/components/home/jumbo.tsx
@@ -16,7 +16,7 @@ export function Jumbo(): ReactElement {
         lines={[
           "scarb init --name hello_world",
           <>
-            scarb add quaireaux --git{" "}
+            scarb add quaireaux_math --git{" "}
             <span style={{ userSelect: "none" }}>
               \<br />
               &nbsp;&nbsp;&nbsp;&nbsp;

--- a/website/pages/docs/cheatsheet.mdx
+++ b/website/pages/docs/cheatsheet.mdx
@@ -56,14 +56,14 @@ Add dependency hosted on a Git repository:
 
 ```toml copy
 [dependencies]
-quaireaux = { git = "https://github.com/keep-starknet-strange/quaireaux.git" }
+quaireaux_math = { git = "https://github.com/keep-starknet-strange/quaireaux.git" }
 ```
 
 Add dependency located in local path:
 
 ```toml copy
 [dependencies]
-quaireaux = { path = "path/to/quaireaux" }
+quaireaux_math = { path = "../path-to-quaireaux-checkout/quaireaux/math" }
 ```
 
 <Callout>
@@ -84,18 +84,18 @@ quaireaux = { path = "path/to/quaireaux" }
 Add dependency hosted on a Git repository:
 
 ```shell copy
-scarb add quaireaux --git https://github.com/keep-starknet-strange/quaireaux.git
+scarb add quaireaux_math --git https://github.com/keep-starknet-strange/quaireaux.git
 ```
 
 Add dependency located in local path:
 
 ```shell copy
-scarb add quaireaux --path path/to/quaireaux
+scarb add quaireaux_math --path ../path-to-quaireaux-checkout/quaireaux/math
 ```
 
 <Callout>
-  You can specify package version like this: `quaireaux@0.1.0`, but see remarks
-  in previous section.
+  You can specify package version like this: `quaireaux_math@0.1.0`, but see
+  remarks in previous section.
 </Callout>
 
 <Callout>`--git` supports `--branch`, `--tag` and `--rev` arguments.</Callout>

--- a/website/pages/docs/guides/dependencies.mdx
+++ b/website/pages/docs/guides/dependencies.mdx
@@ -13,11 +13,11 @@ To add a dependency, simply declare it in your `Scarb.toml`.
 ## Adding a dependency
 
 If your `Scarb.toml` doesn't already have a `[dependencies]{:toml}` section, add it, then list the package name and the URL to its Git repository.
-This example adds a dependency on the [`quaireaux`](https://github.com/keep-starknet-strange/quaireaux) package:
+This example adds a dependency on the [`quaireaux_math`](https://github.com/keep-starknet-strange/quaireaux) package (note that quaireaux is a collection of multiple packages and we will use math as an example in this guide):
 
 ```toml copy filename="Scarb.toml"
 [dependencies]
-quaireaux = { git = "https://github.com/keep-starknet-strange/quaireaux.git" }
+quaireaux_math = { git = "https://github.com/keep-starknet-strange/quaireaux.git" }
 ```
 
 In fact, it is always good to pin Git dependencies to concrete commits, otherwise Scarb would try to update this dependency each time it is executed.
@@ -26,7 +26,7 @@ For example, in this guide we will pin to a concrete commit hash:
 
 ```toml copy filename="Scarb.toml"
 [dependencies]
-quaireaux = { git = "https://github.com/keep-starknet-strange/quaireaux.git", rev = "041379c" }
+quaireaux_math = { git = "https://github.com/keep-starknet-strange/quaireaux.git", rev = "4c93251" }
 ```
 
 <Callout type="info">
@@ -50,7 +50,7 @@ scarb build
     Finished release target(s) in 4 seconds
 ```
 
-You can now use the `quaireaux` library in `lib.cairo`:
+You can now use the `quaireaux_math` library in `lib.cairo`:
 
 ```cairo copy filename="src/lib.cairo"
 use quaireaux::math::fibonacci;
@@ -64,10 +64,10 @@ fn hello_world() -> felt252 {
 If you prefer, you can also ask Scarb to edit `Scarb.toml` to add a dependency automagically for you.
 The `scarb add{:shell}` command accepts many parameters, matching all possibilities of expressing dependencies.
 It can also automatically keep the list sorted, if it already is.
-For example, the above example of dependency on `quaireaux`, can be also added like this:
+For example, the above example of dependency on `quaireaux_math`, can be also added like this:
 
 ```shell copy
-scarb add quaireaux --git https://github.com/keep-starknet-strange/quaireaux.git --rev 041379c
+scarb add quaireaux_math --git https://github.com/keep-starknet-strange/quaireaux.git --rev 4c93251
 ```
 
 ## Removing a dependency
@@ -77,5 +77,5 @@ To remove a dependency, simply remove related lines from your `Scarb.toml`.
 As a quick shortcut, the `scarb remove{:shell}` (also available in short `scarb rm{:shell}`) can clean the manifest automatically:
 
 ```shell copy
-scarb rm quaireaux
+scarb rm quaireaux_math
 ```

--- a/website/pages/docs/guides/working-on-an-existing-package.mdx
+++ b/website/pages/docs/guides/working-on-an-existing-package.mdx
@@ -2,7 +2,7 @@
 
 If you download an existing package that uses Scarb, it's really easy to get going.
 
-First, get the package from somewhere. For example, the [`quaireaux`](https://github.com/keep-starknet-strange/quaireaux) package is hosted on GitHub, and we 'll clone its repository using Git.
+First, get the package from somewhere. For example, the [`quaireaux_math`](https://github.com/keep-starknet-strange/quaireaux) package is hosted on GitHub, and we 'll clone its repository using Git. Note that quaireaux is a collection of multiple packages and we will use math as an example in this guide.
 
 ```shell copy
 git clone https://github.com/keep-starknet-strange/quaireaux
@@ -17,7 +17,7 @@ scarb build
 ```
 
 ```text filename="Output"
-   Compiling quaireaux v0.1.0 (/path/to/package/quaireaux/Scarb.toml)
+   Compiling quaireaux_math v0.1.0 (/path/to/package/quaireaux/math/Scarb.toml)
     Finished release target(s) in 4 seconds
 ```
 

--- a/website/pages/docs/reference/specifying-dependencies.mdx
+++ b/website/pages/docs/reference/specifying-dependencies.mdx
@@ -8,7 +8,7 @@ To depend on a package located in a Git repository, the minimum information need
 
 ```toml copy /git/1
 [dependencies]
-quaireaux = { git = "https://github.com/keep-starknet-strange/quaireaux.git" }
+quaireaux_math = { git = "https://github.com/keep-starknet-strange/quaireaux.git" }
 ```
 
 Scarb will fetch the `git` repository at this location and then look for a `Scarb.toml` for the requested package anywhere inside the Git repository
@@ -20,7 +20,7 @@ Here is an example of specifying that you want to use the latest commit on a bra
 
 ```toml copy /branch = "next"/
 [dependencies]
-quaireaux = { git = "https://github.com/keep-starknet-strange/quaireaux.git", branch = "next" }
+quaireaux_math = { git = "https://github.com/keep-starknet-strange/quaireaux.git", branch = "next" }
 ```
 
 Anything that is not a branch or tag falls under `rev`.


### PR DESCRIPTION
Change references to `quirenox` in our website to `quaireaux_math` since they have recently changed their project structure.