### PR TITLE
Clarify information about package names in docs

### DIFF
--- a/website/pages/docs/reference/manifest.mdx
+++ b/website/pages/docs/reference/manifest.mdx
@@ -28,12 +28,7 @@ It is used when listed as a dependency in another package, and as the default na
 
 The name must use only ASCII alphanumeric characters or `_`, and cannot be empty.
 It cannot also start with underscore.
-
-In other words, it must match the following regular expression:
-
-```regexp copy
-^[a-zA-Z0-9][a-zA-Z0-9_]*$
-```
+It also must not be a valid Cairo identifier.
 
 ### `version`
 


### PR DESCRIPTION
- Remove package name regex from docs
- Explicitly state that it must not be a Cairo keyword