### PR TITLE
Change resolver algorithm to always try to query for dependency candidate, in case it might end up being patched by the registry

### DIFF
--- a/scarb/tests/e2e/resolver_with_git.rs
+++ b/scarb/tests/e2e/resolver_with_git.rs
@@ -88,6 +88,7 @@ fn two_revs_of_same_dep() {
         .failure()
         .stdout_matches(indoc! {r#"
             [..] Updating git repository file://[..]/culprit
+            [..] Updating git repository file://[..]/culprit
             error: found dependencies on the same package `culprit` coming from incompatible sources:
             source 1: git+file://[..]/culprit
             source 2: git+file://[..]/culprit?branch=branchy
@@ -146,6 +147,7 @@ fn two_revs_of_same_dep_diamond() {
         .stdout_matches(indoc! {r#"
             [..] Updating git repository file://[..]/dep1
             [..] Updating git repository file://[..]/dep2
+            [..] Updating git repository file://[..]/culprit
             [..] Updating git repository file://[..]/culprit
             error: found dependencies on the same package `culprit` coming from incompatible sources:
             source 1: git+file://[..]/culprit


### PR DESCRIPTION
**Stack**:
- #358
- #357
- #350
- #356
- #355
- #354
- #353
- #352 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*