### PR TITLE
Make `scarb clean` not error if target directory is not present

### DIFF
--- a/extensions/scarb-cairo-language-server/Cargo.toml
+++ b/extensions/scarb-cairo-language-server/Cargo.toml
@@ -3,6 +3,7 @@ name = "scarb-cairo-language-server"
 version.workspace = true
 rust-version.workspace = true
 edition.workspace = true
+publish = false
 
 authors.workspace = true
 categories = ["development-tools"]

--- a/scarb/src/ops/clean.rs
+++ b/scarb/src/ops/clean.rs
@@ -6,5 +6,8 @@ use crate::internal::fsx;
 #[tracing::instrument(skip_all, level = "debug")]
 pub fn clean(config: &Config) -> Result<()> {
     let path = config.target_dir().path_unchecked();
-    fsx::remove_dir_all(path).context("failed to clean generated artifacts")
+    if path.exists() {
+        fsx::remove_dir_all(path).context("failed to clean generated artifacts")?;
+    }
+    Ok(())
 }


### PR DESCRIPTION
commit-id:73e1fc5c

---

**Stack**:
- #372
- #371 ⬅
- #370


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*