### PR TITLE
New scarb-metadata features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3108,7 +3108,7 @@ dependencies = [
  "pathdiff",
  "petgraph",
  "predicates",
- "scarb-metadata 1.2.0",
+ "scarb-metadata 1.3.0",
  "semver",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3162,6 +3162,7 @@ dependencies = [
  "assert_fs",
  "cairo-lang-filesystem",
  "camino",
+ "clap",
  "derive_builder",
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 [workspace.package]
 version = "0.2.1"
 edition = "2021"
-rust-version = "1.67"
+rust-version = "1.69"
 
 authors = ["Software Mansion <contact@swmansion.com>"]
 homepage = "https://docs.swmansion.com/scarb"

--- a/scarb-metadata/Cargo.toml
+++ b/scarb-metadata/Cargo.toml
@@ -15,6 +15,7 @@ repository.workspace = true
 
 [dependencies]
 camino.workspace = true
+clap = { workspace = true, optional = true }
 derive_builder = { workspace = true, optional = true }
 semver.workspace = true
 serde.workspace = true
@@ -30,3 +31,4 @@ snapbox.workspace = true
 default = ["command"]
 builder = ["dep:derive_builder"]
 command = ["dep:thiserror"]
+packages_filter = ["dep:clap", "dep:thiserror"]

--- a/scarb-metadata/Cargo.toml
+++ b/scarb-metadata/Cargo.toml
@@ -27,6 +27,6 @@ cairo-lang-filesystem.workspace = true
 snapbox.workspace = true
 
 [features]
-default = ["builder", "command"]
+default = ["command"]
 builder = ["dep:derive_builder"]
 command = ["dep:thiserror"]

--- a/scarb-metadata/src/command.rs
+++ b/scarb-metadata/src/command.rs
@@ -345,18 +345,22 @@ mod tests {
                 cairo: CairoVersionInfo {
                     version: Version::new(1, 0, 0),
                     commit_info: Default::default(),
+                    extra: Default::default(),
                 },
+                extra: Default::default(),
             },
             target_dir: Default::default(),
             workspace: WorkspaceMetadata {
                 manifest_path: Default::default(),
                 root: Default::default(),
                 members: Default::default(),
+                extra: Default::default(),
             },
             packages: Default::default(),
             compilation_units: Default::default(),
             current_profile: "dev".into(),
             profiles: vec!["dev".into()],
+            extra: Default::default(),
         }
     }
 }

--- a/scarb-metadata/src/lib.rs
+++ b/scarb-metadata/src/lib.rs
@@ -299,6 +299,9 @@ pub struct CompilationUnitMetadata {
     #[serde(rename = "components_data")]
     pub components: Vec<CompilationUnitComponentMetadata>,
 
+    /// List of all Cairo compiler plugins to load in this compilation.
+    pub cairo_plugins: Vec<CompilationUnitCairoPluginMetadata>,
+
     /// Items for the Cairo's `#[cfg(...)]` attribute to be enabled in this unit.
     #[serde(default)]
     pub cfg: Vec<Cfg>,
@@ -326,6 +329,21 @@ pub struct CompilationUnitComponentMetadata {
     pub name: String,
     /// Path to the root Cairo source file.
     pub source_path: Utf8PathBuf,
+
+    /// Additional data not captured by deserializer.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+/// Information about compiler plugin to load into the Cairo compiler as part of a compilation unit.
+#[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "builder", derive(Builder))]
+#[cfg_attr(feature = "builder", builder(setter(into)))]
+#[non_exhaustive]
+pub struct CompilationUnitCairoPluginMetadata {
+    /// Package ID.
+    pub package: PackageId,
 
     /// Additional data not captured by deserializer.
     #[cfg_attr(feature = "builder", builder(default))]

--- a/scarb-metadata/src/lib.rs
+++ b/scarb-metadata/src/lib.rs
@@ -17,7 +17,7 @@
 //! With the `command` feature (enabled by default), this crate also exposes an ergonomic interface
 //! to collect metadata from Scarb: [`MetadataCommand`].
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 use std::ops::Index;
 use std::path::PathBuf;
@@ -155,6 +155,11 @@ pub struct Metadata {
     /// List of all available profiles names
     #[serde(default = "profiles_default")]
     pub profiles: Vec<String>,
+
+    /// Additional data not captured by deserializer.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
 }
 
 /// Current workspace metadata.
@@ -171,6 +176,11 @@ pub struct WorkspaceMetadata {
 
     /// List of IDs of all packages that are members of this workspace.
     pub members: Vec<PackageId>,
+
+    /// Additional data not captured by deserializer.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
 }
 
 /// Metadata of single Scarb package.
@@ -206,6 +216,11 @@ pub struct PackageMetadata {
     /// Various metadata fields from `Scarb.toml`.
     #[serde(flatten)]
     pub manifest_metadata: ManifestMetadata,
+
+    /// Additional data not captured by deserializer.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
 }
 
 /// Scarb package dependency specification.
@@ -223,6 +238,11 @@ pub struct DependencyMetadata {
     pub version_req: VersionReq,
     /// Package source.
     pub source: SourceId,
+
+    /// Additional data not captured by deserializer.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
 }
 
 /// Package target information.
@@ -241,6 +261,11 @@ pub struct TargetMetadata {
     ///
     /// Default values are omitted because they are unknown to Scarb, they are applied by compilers.
     pub params: serde_json::Value,
+
+    /// Additional data not captured by deserializer.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
 }
 
 /// Scarb compilation unit information.
@@ -271,6 +296,11 @@ pub struct CompilationUnitMetadata {
     /// Items for the Cairo's `#[cfg(...)]` attribute to be enabled in this unit.
     #[serde(default)]
     pub cfg: Vec<Cfg>,
+
+    /// Additional data not captured by deserializer.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
 }
 
 /// Information to pass to the Cairo compiler about a package that is a component of a compilation
@@ -290,6 +320,11 @@ pub struct CompilationUnitComponentMetadata {
     pub name: String,
     /// Path to the root Cairo source file.
     pub source_path: Utf8PathBuf,
+
+    /// Additional data not captured by deserializer.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
 }
 
 /// Various metadata fields from package manifest.
@@ -338,6 +373,11 @@ pub struct VersionInfo {
     pub commit_info: Option<CommitInfo>,
     /// Version of the Cairo compiler bundled in Scarb.
     pub cairo: CairoVersionInfo,
+
+    /// Additional data not captured by deserializer.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
 }
 
 /// Cairo's version.
@@ -350,6 +390,11 @@ pub struct CairoVersionInfo {
     pub version: Version,
     /// Version about Git commit of Cairo if known.
     pub commit_info: Option<CommitInfo>,
+
+    /// Additional data not captured by deserializer.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
 }
 
 /// Information about the Git repository where Scarb or Cairo was built from.

--- a/scarb-metadata/src/lib.rs
+++ b/scarb-metadata/src/lib.rs
@@ -123,7 +123,7 @@ pub struct Metadata {
     /// The metadata format version.
     ///
     /// This struct will not deserialize if version does not match.
-    #[builder(setter(skip))]
+    #[cfg_attr(feature = "builder", builder(setter(skip)))]
     pub version: VersionPin,
 
     /// Path to `scarb` executable.

--- a/scarb-metadata/src/lib.rs
+++ b/scarb-metadata/src/lib.rs
@@ -16,6 +16,10 @@
 //!
 //! With the `command` feature (enabled by default), this crate also exposes an ergonomic interface
 //! to collect metadata from Scarb: [`MetadataCommand`].
+//!
+//! With the `packages_filter` feature (disabled by default), this crate provides ready to use
+//! arguments definitions for the `clap` crate that implement Scarb-compatible package selection
+//! (i.e. the `-p/--package` argument).
 
 use std::collections::{BTreeMap, HashMap};
 use std::fmt;
@@ -34,6 +38,8 @@ pub use version_pin::*;
 
 #[cfg(feature = "command")]
 mod command;
+#[cfg(feature = "packages_filter")]
+pub mod packages_filter;
 mod version_pin;
 
 /// An "opaque" identifier for a package.

--- a/scarb-metadata/src/lib.rs
+++ b/scarb-metadata/src/lib.rs
@@ -376,13 +376,23 @@ pub enum Cfg {
     Name(String),
 }
 
+impl Metadata {
+    /// Returns reference to [`PackageMetadata`] corresponding to the [`PackageId`].
+    pub fn get_package(&self, id: &PackageId) -> Option<&PackageMetadata> {
+        self.packages.iter().find(|p| p.id == *id)
+    }
+
+    /// Returns reference to [`CompilationUnitMetadata`] corresponding to the [`CompilationUnitId`].
+    pub fn get_compilation_unit(&self, id: &CompilationUnitId) -> Option<&CompilationUnitMetadata> {
+        self.compilation_units.iter().find(|p| p.id == *id)
+    }
+}
+
 impl<'a> Index<&'a PackageId> for Metadata {
     type Output = PackageMetadata;
 
     fn index(&self, idx: &'a PackageId) -> &Self::Output {
-        self.packages
-            .iter()
-            .find(|p| p.id == *idx)
+        self.get_package(idx)
             .unwrap_or_else(|| panic!("no package with this ID: {idx}"))
     }
 }
@@ -391,9 +401,7 @@ impl<'a> Index<&'a CompilationUnitId> for Metadata {
     type Output = CompilationUnitMetadata;
 
     fn index(&self, idx: &'a CompilationUnitId) -> &Self::Output {
-        self.compilation_units
-            .iter()
-            .find(|p| p.id == *idx)
+        self.get_compilation_unit(idx)
             .unwrap_or_else(|| panic!("no compilation unit with this ID: {idx}"))
     }
 }

--- a/scarb-metadata/src/packages_filter.rs
+++ b/scarb-metadata/src/packages_filter.rs
@@ -1,0 +1,205 @@
+//! [`clap`] arguments implementing Scarb-compatible package selection (`-p` flag etc.)
+
+use crate::{Metadata, PackageMetadata};
+
+/// [`clap`] structured arguments that provide package selection.
+///
+/// ## Usage
+///
+/// ```no_run
+/// # use scarb_metadata::packages_filter::PackagesFilter;
+/// #[derive(clap::Parser)]
+/// struct Args {
+///     #[command(flatten)]
+///     packages_filter: PackagesFilter,
+/// }
+/// ```
+#[derive(clap::Parser, Clone, Debug)]
+pub struct PackagesFilter {
+    /// Packages to run this command on, can be a concrete package name (`foobar`) or
+    /// a prefix glob (`foo*`).
+    #[arg(short, long, value_name = "SPEC", default_value = "*")]
+    package: String,
+}
+
+/// Error type returned from [`PackagesFilter::match_one`] and [`PackagesFilter::match_many`]
+/// functions.
+///
+/// Its internal structure is unspecified, but stringified messages convey meaningful information
+/// to application users.
+#[derive(Clone, Debug, thiserror::Error, Eq, PartialEq)]
+#[error(transparent)]
+pub struct Error(#[from] InnerError);
+
+#[derive(Clone, Debug, thiserror::Error, Eq, PartialEq)]
+enum InnerError {
+    // Matching errors.
+    #[error("package `{package_name}` not found in workspace")]
+    OneNotFound { package_name: String },
+    #[error("no workspace members match `{spec}`")]
+    ManyNotFound { spec: String },
+    #[error("workspace has no members")]
+    WorkspaceHasNoMembers,
+    #[error("could not determine which package to work on. Use the `--package` option to specify the package.")]
+    CouldNotDeterminePackageToWorkOn,
+    #[error("workspace has multiple members matching `{spec}`. Use the `--package` option to specify single package.")]
+    FoundMultiple { spec: String },
+
+    // Spec parsing errors.
+    #[error("invalid package spec: * character can only occur once in the pattern")]
+    MultipleStars,
+    #[error("invalid package spec: only `prefix*` patterns are allowed")]
+    NotPrefix,
+}
+
+impl InnerError {
+    fn not_found(spec: &Spec<'_>) -> Self {
+        match spec {
+            Spec::One(package_name) => Self::OneNotFound {
+                package_name: package_name.to_string(),
+            },
+            spec @ (Spec::All | Spec::Glob(_)) => Self::ManyNotFound {
+                spec: spec.to_string(),
+            },
+        }
+    }
+}
+
+impl PackagesFilter {
+    /// Find *exactly one* package matching the filter.
+    ///
+    /// Returns an error if no or more than one packages were found.
+    pub fn match_one<S: PackagesSource>(&self, source: &S) -> Result<S::Package, Error> {
+        let members = source.members();
+        let spec = Spec::parse(&self.package)?;
+
+        if matches!(spec, Spec::All) && members.len() > 1 {
+            return Err(InnerError::CouldNotDeterminePackageToWorkOn.into());
+        }
+
+        let found = Self::do_match::<S>(&spec, members.into_iter())?;
+
+        if found.len() > 1 {
+            return Err(InnerError::FoundMultiple {
+                spec: spec.to_string(),
+            }
+            .into());
+        }
+
+        Ok(found.into_iter().next().unwrap())
+    }
+
+    /// Find *at least one* package matching the filter.
+    ///
+    /// Returns an error if no packages were found.
+    pub fn match_many<S: PackagesSource>(&self, source: &S) -> Result<Vec<S::Package>, Error> {
+        let members = source.members();
+        let spec = Spec::parse(&self.package)?;
+        Self::do_match::<S>(&spec, members.into_iter())
+    }
+
+    fn do_match<S: PackagesSource>(
+        spec: &Spec<'_>,
+        members: impl Iterator<Item = S::Package>,
+    ) -> Result<Vec<S::Package>, Error> {
+        let mut members = members.peekable();
+
+        if members.peek().is_none() {
+            return Err(InnerError::WorkspaceHasNoMembers.into());
+        }
+
+        let matches = members
+            .filter(|pkg| spec.matches(S::package_name_of(pkg)))
+            .collect::<Vec<_>>();
+
+        if matches.is_empty() {
+            return Err(InnerError::not_found(spec).into());
+        }
+
+        Ok(matches)
+    }
+}
+
+enum Spec<'a> {
+    All,
+    One(&'a str),
+    Glob(&'a str),
+}
+
+impl<'a> Spec<'a> {
+    fn parse(string: &'a str) -> Result<Self, InnerError> {
+        let string = string.trim();
+
+        if !string.contains('*') {
+            return Ok(Self::One(string));
+        }
+
+        if string.chars().filter(|c| *c == '*').count() != 1 {
+            return Err(InnerError::MultipleStars);
+        }
+
+        if !string.ends_with('*') {
+            return Err(InnerError::NotPrefix);
+        }
+
+        let string = string.trim_end_matches('*');
+
+        if string.is_empty() {
+            Ok(Self::All)
+        } else {
+            Ok(Self::Glob(string))
+        }
+    }
+
+    fn matches(&self, name: &str) -> bool {
+        match self {
+            Spec::All => true,
+            Spec::One(pat) => name == *pat,
+            Spec::Glob(pat) => name.starts_with(pat),
+        }
+    }
+}
+
+impl<'a> ToString for Spec<'a> {
+    fn to_string(&self) -> String {
+        match self {
+            Spec::All => "*".to_owned(),
+            Spec::One(name) => name.to_string(),
+            Spec::Glob(pat) => format!("{pat}*"),
+        }
+    }
+}
+
+/// Generic interface used by [`PackagesFilter`] to pull information from.
+///
+/// This trait is Scarb's internal implementation detail, **do not implement for your own types**.
+/// Inside Scarb there are implementations for Scarb's core types, which allows Scarb to re-use
+/// [`PackagesFilter`] logic.
+pub trait PackagesSource {
+    /// Type which represents a Scarb package in this source.
+    type Package;
+
+    #[doc(hidden)]
+    fn package_name_of(package: &Self::Package) -> &str;
+
+    #[doc(hidden)]
+    fn members(&self) -> Vec<Self::Package>;
+}
+
+impl PackagesSource for Metadata {
+    type Package = PackageMetadata;
+
+    #[inline(always)]
+    fn package_name_of(package: &Self::Package) -> &str {
+        &package.name
+    }
+
+    #[inline(always)]
+    fn members(&self) -> Vec<Self::Package> {
+        self.packages
+            .iter()
+            .filter(|pkg| self.workspace.members.contains(&pkg.id))
+            .cloned()
+            .collect()
+    }
+}

--- a/scarb/Cargo.toml
+++ b/scarb/Cargo.toml
@@ -45,7 +45,7 @@ itertools.workspace = true
 once_cell.workspace = true
 pathdiff.workspace = true
 petgraph.workspace = true
-scarb-metadata = { version = "1.3.0", path = "../scarb-metadata", default-features = false, features = ["builder"] }
+scarb-metadata = { version = "1.3.0", path = "../scarb-metadata", default-features = false, features = ["builder", "packages_filter"] }
 semver.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/scarb/Cargo.toml
+++ b/scarb/Cargo.toml
@@ -45,8 +45,7 @@ itertools.workspace = true
 once_cell.workspace = true
 pathdiff.workspace = true
 petgraph.workspace = true
-# TODO(maciektr): Change this back to 1.3.0 and add path attribute.
-scarb-metadata = { version = "=1.2.0", default-features = false, features = ["builder"] }
+scarb-metadata = { version = "1.3.0", path = "../scarb-metadata", default-features = false, features = ["builder"] }
 semver.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/scarb/src/bin/scarb/args.rs
+++ b/scarb/src/bin/scarb/args.rs
@@ -5,19 +5,20 @@
 use std::collections::BTreeMap;
 use std::ffi::OsString;
 
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use camino::Utf8PathBuf;
 use clap::{CommandFactory, Parser, Subcommand};
-use scarb::compiler::Profile;
 use smol_str::SmolStr;
 use tracing::level_filters::LevelFilter;
 use tracing_log::AsTrace;
 
-use scarb::core::{Package, PackageName, Workspace};
+use scarb::compiler::Profile;
+use scarb::core::PackageName;
 use scarb::manifest_editor::DepId;
 use scarb::ui;
 use scarb::ui::OutputFormat;
 use scarb::version;
+use scarb_metadata::packages_filter::PackagesFilter;
 
 /// The Cairo package manager.
 #[derive(Parser, Clone, Debug)]
@@ -258,25 +259,6 @@ pub struct RemoveArgs {
 
     #[command(flatten)]
     pub packages_filter: PackagesFilter,
-}
-
-#[derive(Parser, Clone, Debug)]
-pub struct PackagesFilter {
-    /// Specify package to modify.
-    #[arg(short, long, value_name = "SPEC")]
-    package: Option<PackageName>,
-}
-
-impl PackagesFilter {
-    pub fn match_one(&self, ws: &Workspace<'_>) -> Result<Package> {
-        match &self.package {
-            Some(name) => ws
-                .members()
-                .find(|pkg| &pkg.id.name == name)
-                .ok_or_else(|| anyhow!("package `{name}` not found in workspace `{ws}`")),
-            None => ws.current_package().cloned(),
-        }
-    }
 }
 
 /// Git reference specification arguments.

--- a/scarb/src/core/workspace.rs
+++ b/scarb/src/core/workspace.rs
@@ -3,6 +3,8 @@ use std::fmt;
 use anyhow::Result;
 use camino::Utf8Path;
 
+use scarb_metadata::packages_filter::PackagesSource;
+
 use crate::compiler::Profile;
 use crate::core::config::Config;
 use crate::core::package::Package;
@@ -112,5 +114,17 @@ pub trait Utf8PathWorkspaceExt {
 impl Utf8PathWorkspaceExt for Utf8Path {
     fn workspace_relative(&self, ws: &Workspace<'_>) -> &Utf8Path {
         self.strip_prefix(ws.root()).unwrap_or(self)
+    }
+}
+
+impl<'c> PackagesSource for Workspace<'c> {
+    type Package = Package;
+
+    fn package_name_of(package: &Self::Package) -> &str {
+        package.id.name.as_str()
+    }
+
+    fn members(&self) -> Vec<Self::Package> {
+        Workspace::members(self).collect()
     }
 }

--- a/scarb/src/ops/metadata.rs
+++ b/scarb/src/ops/metadata.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 
 use anyhow::{bail, Result};
 use semver::Version;
@@ -177,19 +177,22 @@ fn collect_compilation_unit_metadata(
         })
         .collect::<Vec<_>>();
 
+    let components_legacy = components
+        .iter()
+        .map(|c| c.package.to_string())
+        .collect::<Vec<_>>();
+
     m::CompilationUnitMetadataBuilder::default()
         .id(compilation_unit.id())
         .package(wrap_package_id(compilation_unit.main_package_id))
         .target(collect_target_metadata(compilation_unit.target()))
-        .components_legacy(
-            components
-                .iter()
-                .map(|c| c.package.clone())
-                .collect::<Vec<_>>(),
-        )
         .components(components)
         .compiler_config(compiler_config)
         .cfg(cfg)
+        .extra(HashMap::from([(
+            "components".to_owned(),
+            serde_json::Value::from(components_legacy),
+        )]))
         .build()
         .unwrap()
 }

--- a/scarb/tests/e2e/scripts.rs
+++ b/scarb/tests/e2e/scripts.rs
@@ -1,10 +1,12 @@
+use std::collections::BTreeMap;
+use std::env;
+
 use assert_fs::prelude::*;
 use assert_fs::TempDir;
 use indoc::{formatdoc, indoc};
-use scarb::process::make_executable;
 use snapbox::cmd::Command;
-use std::collections::BTreeMap;
-use std::env;
+
+use scarb::process::make_executable;
 
 use crate::support::command::Scarb;
 use crate::support::filesystem::{path_with_temp_dir, write_script};
@@ -207,7 +209,9 @@ fn uses_package_filter() {
         .current_dir(&t)
         .assert()
         .failure()
-        .stdout_matches(r#"{"type":"error","message":"package `bar` not found in workspace [..]"#);
+        .stdout_eq(indoc! {r#"
+        {"type":"error","message":"package `bar` not found in workspace"}
+        "#});
 }
 
 #[test]


### PR DESCRIPTION
1. `extra` and `cairo_plugins` fields
2. `PackagesFilter`
3. Non-panicking getters for packages and compilation units
4. `builder` feature is not default now