### PR TITLE
Introduce `internal::serdex` module and `RelativeUtf8PathBuf` to solve TOML paths issues

### DIFF
--- a/scarb/src/core/manifest/target.rs
+++ b/scarb/src/core/manifest/target.rs
@@ -7,7 +7,7 @@ use camino::{Utf8Path, Utf8PathBuf};
 use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
 
-use crate::core::toml_merge;
+use crate::internal::serdex::toml_merge;
 
 /// See [`TargetInner`] for public fields reference.
 #[derive(Clone, Debug, Hash)]

--- a/scarb/src/core/manifest/toml_manifest.rs
+++ b/scarb/src/core/manifest/toml_manifest.rs
@@ -20,6 +20,7 @@ use crate::core::source::{GitReference, SourceId};
 use crate::core::{ManifestBuilder, ManifestCompilerConfig, PackageName};
 use crate::internal::fsx;
 use crate::internal::fsx::PathUtf8Ext;
+use crate::internal::serdex::toml_merge;
 use crate::internal::to_version::ToVersion;
 use crate::DEFAULT_SOURCE_PATH;
 
@@ -509,23 +510,4 @@ impl DetailedTomlDependency {
             source_id,
         })
     }
-}
-
-/// Merge two `toml::Value` serializable structs.
-pub fn toml_merge<'de, T, S>(target: &T, source: &S) -> Result<T>
-where
-    T: Serialize + Deserialize<'de>,
-    S: Serialize + Deserialize<'de>,
-{
-    let mut params = toml::Value::try_from(target)?;
-    let source = toml::Value::try_from(source)?;
-
-    params.as_table_mut().unwrap().extend(
-        source
-            .as_table()
-            .unwrap()
-            .iter()
-            .map(|(k, v)| (k.clone(), v.clone())),
-    );
-    Ok(toml::Value::try_into(params)?)
 }

--- a/scarb/src/internal/mod.rs
+++ b/scarb/src/internal/mod.rs
@@ -2,6 +2,7 @@ pub mod async_cache;
 pub mod cloneable_error;
 pub mod fsx;
 pub mod lazy_directory_creator;
+pub mod serdex;
 pub mod stable_hash;
 pub mod static_hash_cache;
 pub mod to_version;

--- a/scarb/src/internal/serdex.rs
+++ b/scarb/src/internal/serdex.rs
@@ -1,0 +1,20 @@
+use serde::{Deserialize, Serialize};
+
+/// Merge two `toml::Value` serializable structs.
+pub fn toml_merge<'de, T, S>(target: &T, source: &S) -> anyhow::Result<T>
+where
+    T: Serialize + Deserialize<'de>,
+    S: Serialize + Deserialize<'de>,
+{
+    let mut params = toml::Value::try_from(target)?;
+    let source = toml::Value::try_from(source)?;
+
+    params.as_table_mut().unwrap().extend(
+        source
+            .as_table()
+            .unwrap()
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone())),
+    );
+    Ok(toml::Value::try_into(params)?)
+}

--- a/scarb/tests/e2e/build_starknet_contract_allowed_libfuncs.rs
+++ b/scarb/tests/e2e/build_starknet_contract_allowed_libfuncs.rs
@@ -220,7 +220,7 @@ fn list_path() {
         .success()
         .stdout_matches(indoc! {r#"
         [..] Compiling hello v0.1.0 ([..])
-        warn: libfunc `revoke_ap_tracking` is not allowed in the libfuncs list `testing_list.json`
+        warn: libfunc `revoke_ap_tracking` is not allowed in the libfuncs list `[..]testing_list.json`
          --> contract: ExperimentalLibfunc
 
         [..]  Finished release target(s) in [..]
@@ -248,10 +248,10 @@ fn list_path_does_not_exist() {
         .failure()
         .stdout_matches(indoc! {r#"
         [..] Compiling hello v0.1.0 ([..])
-        error: failed to check allowed libfuncs for contract: ExperimentalLibfunc
+        error: failed to get absolute path of `[..]does_not_exist.json`
 
         Caused by:
-            The allowed libfuncs file 'does_not_exist.json' was not found.
+            [..]
         error: could not compile `hello` due to previous error
         "#});
 }


### PR DESCRIPTION
fix #401 