### PR TITLE
fix: .toml linting

### DIFF
--- a/scarb/src/compiler/compilers/starknet_contract.rs
+++ b/scarb/src/compiler/compilers/starknet_contract.rs
@@ -270,7 +270,7 @@ fn check_allowed_libfuncs(
                             help: try compiling with the `{experimental}` list
                              --> {scarb_toml}
                                 [[target.starknet-contract]]
-                                allowed-libfuncs-list.name = "{experimental}"
+                                allowed-libfuncs-list = { name = "experimental" }
                         "#
                     );
                 }

--- a/scarb/src/compiler/compilers/starknet_contract.rs
+++ b/scarb/src/compiler/compilers/starknet_contract.rs
@@ -270,7 +270,7 @@ fn check_allowed_libfuncs(
                             help: try compiling with the `{experimental}` list
                              --> {scarb_toml}
                                 [[target.starknet-contract]]
-                                allowed-libfuncs-list = { name = "experimental" }
+                                allowed-libfuncs-list = { name = "{experimental}" }
                         "#
                     );
                 }

--- a/scarb/tests/e2e/build_starknet_contract_allowed_libfuncs.rs
+++ b/scarb/tests/e2e/build_starknet_contract_allowed_libfuncs.rs
@@ -49,7 +49,7 @@ fn default_behaviour() {
         help: try compiling with the `experimental` list
          --> Scarb.toml
             [[target.starknet-contract]]
-            allowed-libfuncs-list.name = "experimental"
+            allowed-libfuncs-list = { name = "experimental" }
 
         [..]  Finished release target(s) in [..]
         "#});
@@ -81,7 +81,7 @@ fn check_true() {
         help: try compiling with the `experimental` list
          --> Scarb.toml
             [[target.starknet-contract]]
-            allowed-libfuncs-list.name = "experimental"
+            allowed-libfuncs-list = { name = "experimental" }
 
         [..]  Finished release target(s) in [..]
         "#});
@@ -138,7 +138,7 @@ fn deny_true() {
         help: try compiling with the `experimental` list
          --> Scarb.toml
             [[target.starknet-contract]]
-            allowed-libfuncs-list.name = "experimental"
+            allowed-libfuncs-list = { name = "experimental" }
 
         error: aborting compilation, because contracts use disallowed Sierra libfuncs
         error: could not compile `hello` due to previous error
@@ -153,7 +153,7 @@ fn pass_named_list() {
         .version("0.1.0")
         .manifest_extra(indoc! {r#"
             [[target.starknet-contract]]
-            allowed-libfuncs-list.name = "experimental"
+            allowed-libfuncs-list = { name = "experimental" }
         "#})
         .dep_starknet()
         .lib_cairo(EXPERIMENTAL_LIBFUNC)
@@ -178,7 +178,7 @@ fn unknown_list_name() {
         .version("0.1.0")
         .manifest_extra(indoc! {r#"
             [[target.starknet-contract]]
-            allowed-libfuncs-list.name = "definitely does not exist"
+            allowed-libfuncs-list = { name = "definitely does not exist" }
         "#})
         .dep_starknet()
         .lib_cairo(EXPERIMENTAL_LIBFUNC)
@@ -207,7 +207,7 @@ fn list_path() {
         .version("0.1.0")
         .manifest_extra(indoc! {r#"
             [[target.starknet-contract]]
-            allowed-libfuncs-list.path = "testing_list.json"
+            allowed-libfuncs-list = { path = "testing_list.json" }
         "#})
         .dep_starknet()
         .lib_cairo(EXPERIMENTAL_LIBFUNC)
@@ -243,7 +243,7 @@ fn list_path_does_not_exist() {
         .version("0.1.0")
         .manifest_extra(indoc! {r#"
             [[target.starknet-contract]]
-            allowed-libfuncs-list.path = "does_not_exist.json"
+            allowed-libfuncs-list = { path = "does_not_exist.json" }
         "#})
         .dep_starknet()
         .lib_cairo(EXPERIMENTAL_LIBFUNC)

--- a/website/pages/docs/starknet/contract-target.mdx
+++ b/website/pages/docs/starknet/contract-target.mdx
@@ -82,7 +82,7 @@ For example, to use the `experimental` allowlist, type the following:
 
 ```toml
 [[target.starknet-contract]]
-allowed-libfuncs-list.name = "experimental"
+allowed-libfuncs-list = { name = "experimental" }
 ```
 
 All built-in lists can be located in the [Cairo repository](https://github.com/starkware-libs/cairo/tree/main/crates/cairo-lang-starknet/src/allowed_libfuncs_lists).
@@ -93,7 +93,7 @@ It is also possible to use a user-provided allowlist, via the `allowed-libfuncs-
 
 ```toml
 [[target.starknet-contract]]
-allowed-libfuncs-list.path = "path/to/list.json"
+allowed-libfuncs-list = { path = "path/to/list.json" }
 ```
 
 User-provided lists should follow the same format as built-in ones.


### PR DESCRIPTION
Fixes .toml help messages so toml linters do not complain 

from 

`allowed-libfuncs-list.name = "{experimental}"`

to

`allowed-libfuncs-list = { name = "experimental" }`