### PR TITLE
Update install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -26,8 +26,9 @@ The installer for Scarb
 Usage: install.sh [OPTIONS]
 
 Options:
-    -v        Specify Scarb _requested_version to install
-    -h        Print help information
+    -h | --help             Print help information
+    -p | --no-modify-path   Skip PATH variable modification
+    -v | --version          Specify Scarb _requested_version to install
 
 For more information, check out https://docs.swmansion.com/scarb/download.
 EOF
@@ -44,10 +45,25 @@ main() {
   need_cmd tar
   need_cmd uname
 
+  # Transform long options to short ones.
+  for arg in "$@"; do
+    shift
+    case "$arg" in
+      '--help')           set -- "$@" '-h'   ;;
+      '--no-modify-path') set -- "$@" '-p'   ;;
+      '--version')        set -- "$@" '-v'   ;;
+      *)                  set -- "$@" "$arg" ;;
+    esac
+  done
+
   local _requested_ref="latest"
   local _requested_version="latest"
-  while getopts ":hv:" opt; do
+  local _do_modify_path=1
+  while getopts ":hpv:" opt; do
     case $opt in
+    p)
+      _do_modify_path=0
+      ;;
     h)
       usage
       exit 0
@@ -97,8 +113,12 @@ main() {
     echo "Scarb has been successfully installed and should be already available in your PATH."
     echo "Run 'scarb --version' to verify your installation. Happy coding!"
   else
-    add_local_bin_to_path
-    _retval=$?
+    if [ $_do_modify_path -eq 1 ]; then
+      add_local_bin_to_path
+      _retval=$?
+    else
+      echo "Skipping PATH modification, please manually add '${LOCAL_BIN_ESCAPED}' to your PATH."
+    fi
 
     echo "Then, run 'scarb --version' to verify your installation. Happy coding!"
   fi

--- a/install.sh
+++ b/install.sh
@@ -107,6 +107,35 @@ main() {
   return "$_retval"
 }
 
+# This function has been copied verbatim from rustup install script.
+check_proc() {
+    # Check for /proc by looking for the /proc/self/exe link
+    # This is only run on Linux
+    if ! test -L /proc/self/exe ; then
+        err "fatal: Unable to find /proc/self/exe.  Is /proc mounted?  Installation cannot proceed without /proc."
+    fi
+}
+
+# This function has been copied verbatim from rustup install script.
+get_bitness() {
+    need_cmd head
+    # Architecture detection without dependencies beyond coreutils.
+    # ELF files start out "\x7fELF", and the following byte is
+    #   0x01 for 32-bit and
+    #   0x02 for 64-bit.
+    # The printf builtin on some shells like dash only supports octal
+    # escape sequences, so we use those.
+    local _current_exe_head
+    _current_exe_head=$(head -c 5 /proc/self/exe )
+    if [ "$_current_exe_head" = "$(printf '\177ELF\001')" ]; then
+        echo 32
+    elif [ "$_current_exe_head" = "$(printf '\177ELF\002')" ]; then
+        echo 64
+    else
+        err "unknown platform bitness"
+    fi
+}
+
 say() {
   printf 'scarb-install: %s\n' "$1"
 }

--- a/install.sh
+++ b/install.sh
@@ -26,9 +26,9 @@ The installer for Scarb
 Usage: install.sh [OPTIONS]
 
 Options:
-    -h | --help             Print help information
-    -p | --no-modify-path   Skip PATH variable modification
-    -v | --version          Specify Scarb _requested_version to install
+  -p, --no-modify-path   Skip PATH variable modification
+  -h, --help             Print help
+  -v, --version          Specify Scarb version to install
 
 For more information, check out https://docs.swmansion.com/scarb/download.
 EOF

--- a/website/pages/docs/install.mdx
+++ b/website/pages/docs/install.mdx
@@ -30,8 +30,8 @@ Select the tab for your computer's operating system below, then follow its insta
     If you want to install a specific version of Scarb (such as a preview version), run the following with the desired
     version number.
 
-    ```shell copy /0.2.0-alpha.2/
-    curl --proto '=https' --tlsv1.2 -sSf https://docs.swmansion.com/scarb/install.sh | bash -s -- -v 0.2.0-alpha.2
+    ```shell copy /0.5.0-alpha.1/
+    curl --proto '=https' --tlsv1.2 -sSf https://docs.swmansion.com/scarb/install.sh | sh -s -- -v 0.5.0-alpha.1
     ```
 
   </Tab>


### PR DESCRIPTION
- Stop `check_proc` and `get_bitness` warnings from popping up
- Use `sh` consistently in docs instead 
- Allow skipping `PATH` modification (e.g. for docker builds)