### PR TITLE
Use `target_name` instead of `package_name` for `starknet_artifacts` map file

### DIFF
--- a/scarb/src/compiler/compilers/starknet_contract.rs
+++ b/scarb/src/compiler/compilers/starknet_contract.rs
@@ -176,8 +176,8 @@ impl Compiler for StarknetContractCompiler {
 
         let mut artifacts = StarknetArtifacts::default();
 
+        let target_name = &unit.target().name;
         for (decl, class, casm_class) in izip!(contracts, classes, casm_classes) {
-            let target_name = &unit.target().name;
             let contract_name = decl.submodule_id.name(db.upcast_mut());
             let file_stem = format!("{target_name}_{contract_name}");
 
@@ -202,7 +202,7 @@ impl Compiler for StarknetContractCompiler {
         artifacts.finish();
 
         write_json(
-            &format!("{}.starknet_artifacts.json", unit.main_package_id.name),
+            &format!("{}.starknet_artifacts.json", target_name),
             "starknet artifacts file",
             &target_dir,
             ws,

--- a/scarb/tests/e2e/build_starknet_contract.rs
+++ b/scarb/tests/e2e/build_starknet_contract.rs
@@ -174,13 +174,14 @@ fn compile_many_contracts() {
     assert_eq!(
         t.child("target/dev").files(),
         vec![
+            "a.starknet_artifacts.json",
             "a_Balance.sierra.json",
             "a_FortyTwo.sierra.json",
+            "b.starknet_artifacts.json",
             "b_Balance.sierra.json",
             "b_FortyTwo.sierra.json",
             "hello.casm",
             "hello.sierra",
-            "hello.starknet_artifacts.json"
         ]
     );
 
@@ -193,7 +194,8 @@ fn compile_many_contracts() {
         assert_is_json::<ContractClass>(&t.child("target/dev").child(json));
     }
 
-    assert_is_json::<serde_json::Value>(&t.child("target/dev/hello.starknet_artifacts.json"));
+    assert_is_json::<serde_json::Value>(&t.child("target/dev/a.starknet_artifacts.json"));
+    assert_is_json::<serde_json::Value>(&t.child("target/dev/b.starknet_artifacts.json"));
 }
 
 #[test]

--- a/website/pages/docs/starknet/contract-target.mdx
+++ b/website/pages/docs/starknet/contract-target.mdx
@@ -2,7 +2,7 @@
 
 The `starknet-contract` target allows to build the package as a [Starknet Contract](https://docs.starknet.io/documentation/getting_started/intro/).
 It searches for all contract classes in the package, and builds a separate compiled JSON file each found class.
-Generated file will be named with following pattern: `[package name]_[contract name].sierra.json`.
+Generated file will be named with following pattern: `[target name]_[contract name].sierra.json`.
 
 This target accepts several configuration arguments, beside ones [shared among all targets](../reference/targets#configuring-a-target), with default values for the default profile:
 
@@ -63,7 +63,7 @@ The off by default `casm-add-pythonic-hints{:toml}` property enables Scarb to ad
 
 ## Starknet Artifacts
 
-As part of building Starknet contracts, contract target generates a `<package_name>.starknet_artifacts.json` file
+As part of building Starknet contracts, contract target generates a `[target_name].starknet_artifacts.json` file
 containing a machine-readable data about built artifacts.
 
 Version 1 of this file has a structure like this:


### PR DESCRIPTION
- Consistent with starknet artifacts naming convention
- Avoids name collisions (target names are guaranteed to be unique across all units)