### PR TITLE
Fix commands listing table cells width

### DIFF
--- a/scarb/src/bin/scarb/commands/commands.rs
+++ b/scarb/src/bin/scarb/commands/commands.rs
@@ -35,7 +35,7 @@ impl Message for CommandsList {
     fn text(self) -> String {
         let mut text = String::from("Installed Commands:\n");
         for (name, info) in self.commands {
-            text.push_str(&format!("{:<20}: {}\n", name, info));
+            text.push_str(&format!("{:<22}: {}\n", name, info));
         }
         text
     }


### PR DESCRIPTION
Before: 
```
build               : Compile current project
cairo-language-server: /Users/maciektr/Projects/scarb/target/debug/scarb-cairo-language-server
cairo-run           : /Users/maciektr/Projects/scarb/target/debug/scarb-cairo-run
```
After:
```
build                 : Compile current project
cairo-language-server : /Users/maciektr/Projects/scarb/target/debug/scarb-cairo-language-server
cairo-run             : /Users/maciektr/Projects/scarb/target/debug/scarb-cairo-run
```