### PR TITLE
Fix global directories casing in documentation

### DIFF
--- a/website/docs/reference/global-directories.md
+++ b/website/docs/reference/global-directories.md
@@ -11,8 +11,8 @@ This is a location where Scarb will store a downloads, Git checkouts and package
 | Platform | Default Path                                    |
 | -------- | ----------------------------------------------- |
 | Linux    | `$XDG_CACHE_HOME/scarb` or `$HOME/.cache/scarb` |
-| macOS    | `$HOME/Library/Caches/com.swmansion.Scarb`      |
-| Windows  | `%LocalAppData%\swmansion\Scarb\cache`          |
+| macOS    | `$HOME/Library/Caches/com.swmansion.scarb`      |
+| Windows  | `%LocalAppData%\swmansion\scarb\cache`          |
 
 This path can be overriden via `SCARB_CACHE` environment variable.
 
@@ -23,8 +23,8 @@ This is a location where Scarb will look for global configuration in the future.
 | Platform | Default Path                                            |
 | -------- | ------------------------------------------------------- |
 | Linux    | `$XDG_CONFIG_HOME/scarb` or `$HOME/.config/scarb`       |
-| macOS    | `$HOME/Library/Application Support/com.swmansion/Scarb` |
-| Windows  | `%LocalAppData%\swmansion\Scarb\config`                 |
+| macOS    | `$HOME/Library/Application Support/com.swmansion/scarb` |
+| Windows  | `%LocalAppData%\swmansion\scarb\config`                 |
 
 This path can be overriden via `SCARB_CONFIG` environment variable.
 
@@ -36,8 +36,8 @@ Scarb will look for [subcommands] in the `bin` subdirectory.
 | Platform | Default Path                                            |
 | -------- | ------------------------------------------------------- |
 | Linux    | `$XDG_DATA_HOME/scarb` or `$HOME/.local/share/scarb`    |
-| macOS    | `$HOME/Library/Application Support/com.swmansion.Scarb` |
-| Windows  | `%LocalAppData%\swmansion\Scarb\data`                   |
+| macOS    | `$HOME/Library/Application Support/com.swmansion.scarb` |
+| Windows  | `%LocalAppData%\swmansion\scarb\data`                   |
 
 This path cannot be overriden.
 


### PR DESCRIPTION
This wasn't a big issue, because both Windows and macOS have by default case-insensitive file systems. For sanity’s sake, though, we should be consistent with source: https://github.com/software-mansion/scarb/blob/06c4dc21cc0b80274ee8d8374ee5a3b0ed10e17c/scarb/src/core/dirs.rs#L26