### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,18 @@ updates:
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
-      interval: "monthly"
-    ignore:
-      - dependency-name: "cairo-lang-*"
+      interval: "weekly"
+    groups:
+      cairo-lang:
+        patterns:
+          - "cairo-lang-*"
+      minor-dependencies:
+        exclude-patterns:
+          - "cairo-lang-*"
+          - "deno_task_shell"
+          - "gix"
+          - "semver"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
1. Change interval to weekly
2. Employ grouped updates for non-critical dependencies
3. Experimentally enable `cairo-lang-*` checks, though we expect to still end up being faster with manual upgrades.