### PR TITLE
Deprecate `packages_filter` feature in `scarb-metadata`

### DIFF
--- a/scarb-metadata/Cargo.toml
+++ b/scarb-metadata/Cargo.toml
@@ -31,6 +31,3 @@ default = ["command"]
 builder = ["dep:derive_builder"]
 command = ["dep:thiserror"]
 packages_filter = ["dep:clap", "dep:thiserror"]
-
-[package.metadata.docs.rs]
-features = ["command", "packages_filter"]

--- a/scarb-metadata/src/lib.rs
+++ b/scarb-metadata/src/lib.rs
@@ -16,10 +16,6 @@
 //!
 //! With the `command` feature (enabled by default), this crate also exposes an ergonomic interface
 //! to collect metadata from Scarb: [`MetadataCommand`].
-//!
-//! With the `packages_filter` feature (disabled by default), this crate provides ready to use
-//! arguments definitions for the `clap` crate that implement Scarb-compatible package selection
-//! (i.e. the `-p/--package` argument).
 
 use std::collections::{BTreeMap, HashMap};
 use std::fmt;
@@ -33,6 +29,7 @@ use semver::{Version, VersionReq};
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "packages_filter")]
+#[allow(deprecated)]
 use crate::packages_filter::WithManifestPath;
 #[cfg(feature = "command")]
 pub use command::*;
@@ -490,6 +487,7 @@ impl PackageMetadata {
 }
 
 #[cfg(feature = "packages_filter")]
+#[allow(deprecated)]
 impl WithManifestPath for PackageMetadata {
     fn manifest_path(&self) -> &Utf8Path {
         &self.manifest_path

--- a/scarb-metadata/src/packages_filter.rs
+++ b/scarb-metadata/src/packages_filter.rs
@@ -1,7 +1,14 @@
 //! [`clap`] arguments implementing Scarb-compatible package selection (`-p` flag etc.)
 
-use crate::{Metadata, PackageMetadata};
+#![deprecated(
+    since = "1.7.0",
+    note = "This module has been moved to `scarb-ui` crate hosted in Scarb repository. \
+    Removal from `scarb-metadata` is planned in when no usage will be present in open source projects."
+)]
+
 use camino::{Utf8Path, Utf8PathBuf};
+
+use crate::{Metadata, PackageMetadata};
 
 /// [`clap`] structured arguments that provide package selection.
 ///


### PR DESCRIPTION
fix #385

---

**Stack**:
- #587
- #585
- #584 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*