### PR TITLE
Properly use `Status` message when testing workspace

### DIFF
--- a/scarb/src/ops/subcommands.rs
+++ b/scarb/src/ops/subcommands.rs
@@ -46,19 +46,24 @@ pub fn execute_test_subcommand(
     args: &[OsString],
     ws: &Workspace<'_>,
 ) -> Result<()> {
-    ws.config().ui().print(Status::new(
-        "Running tests",
-        format!("for package: {}", package.id.name).as_str(),
-    ));
+    let package_name = &package.id.name;
     let env = Some(HashMap::from_iter([(
         SCARB_MANIFEST_PATH_ENV.into(),
         package.manifest_path().into(),
     )]));
     if let Some(script_definition) = package.manifest.scripts.get("test") {
         debug!("using `test` script: {script_definition}");
+        ws.config().ui().print(Status::new(
+            "Running",
+            &format!("test {package_name} ({script_definition})"),
+        ));
         ops::execute_script(script_definition, args, ws, package.root(), env)
     } else {
         debug!("no explicit `test` script found, delegating to scarb-cairo-test");
+        ws.config().ui().print(Status::new(
+            "Running",
+            &format!("cairo-test {package_name}"),
+        ));
         let args = args.iter().map(OsString::from).collect::<Vec<_>>();
         execute_external_subcommand("cairo-test", args.as_ref(), ws.config(), env)
     }

--- a/scarb/tests/test_subcommand.rs
+++ b/scarb/tests/test_subcommand.rs
@@ -23,7 +23,7 @@ fn delegates_to_cairo_test() {
         .assert()
         .success()
         .stdout_eq(indoc! {r#"
-        Running tests for package: pkg0
+             Running cairo-test pkg0
         Hello beautiful world
         "#});
 }
@@ -44,7 +44,7 @@ fn prefers_test_script() {
         .assert()
         .success()
         .stdout_eq(indoc! {r#"
-        Running tests for package: pkg0
+             Running test pkg0 (echo 'Hello from script')
         Hello from script beautiful world
         "#});
 }
@@ -67,7 +67,7 @@ fn errors_when_missing_script_and_cairo_test() {
         .assert()
         .failure()
         .stdout_eq(indoc! {r#"
-        Running tests for package: pkg0
+             Running cairo-test pkg0
         error: no such command: `cairo-test`
         "#});
 }

--- a/utils/scarb-ui/src/components/status.rs
+++ b/utils/scarb-ui/src/components/status.rs
@@ -3,6 +3,8 @@ use serde::{Serialize, Serializer};
 
 use crate::Message;
 
+/// Notes:
+/// - `status` should always be a single verb, for example _Compiling_, _Running_.
 #[derive(Serialize)]
 pub struct Status<'a> {
     status: &'a str,


### PR DESCRIPTION
- Status should always be a single verb.
- Print what command is going to be called, like Cargo does

---

**Stack**:
- #587
- #585 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*