### PR TITLE
Poor man implementation of `scarb-ui` in `scarb cairo-run`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3950,6 +3950,7 @@ dependencies = [
  "scarb-metadata 1.6.0",
  "scarb-test-support",
  "scarb-ui",
+ "serde",
  "serde_json",
  "snapbox",
 ]

--- a/extensions/scarb-cairo-run/Cargo.toml
+++ b/extensions/scarb-cairo-run/Cargo.toml
@@ -15,6 +15,7 @@ clap.workspace = true
 indoc.workspace = true
 scarb-metadata = { path = "../../scarb-metadata" }
 scarb-ui = { path = "../../utils/scarb-ui" }
+serde.workspace = true
 serde_json.workspace = true
 
 [dev-dependencies]

--- a/utils/scarb-ui/src/message.rs
+++ b/utils/scarb-ui/src/message.rs
@@ -5,6 +5,8 @@ use super::Ui;
 
 const JSON_SKIP_MESSAGE: &str = "UI_INTERNAL_SKIP";
 
+// NOTE: The `print_*` low-level methods functions are doc hidden,
+//   because they are not considered stable.
 pub trait Message {
     /// Return textual representation of this message.
     ///
@@ -14,6 +16,17 @@ pub trait Message {
         Self: Sized,
     {
         String::new()
+    }
+
+    #[doc(hidden)]
+    fn print_text(self)
+    where
+        Self: Sized,
+    {
+        let text = self.text();
+        if !text.is_empty() {
+            println!("{text}");
+        }
     }
 
     /// Serialize this structured message to a serializer which is routed to [`Ui`] output stream.
@@ -28,20 +41,6 @@ pub trait Message {
         // so that it will not be populated by editors.
         let _ = ser;
         Err(serde::ser::Error::custom(JSON_SKIP_MESSAGE))
-    }
-
-    // NOTE: These two most low-level functions are doc hidden,
-    //   because they are not considered stable.
-
-    #[doc(hidden)]
-    fn print_text(self)
-    where
-        Self: Sized,
-    {
-        let text = self.text();
-        if !text.is_empty() {
-            println!("{text}");
-        }
     }
 
     #[doc(hidden)]


### PR DESCRIPTION
Extra: reordered methods in `Message` trait to group them by medium, so that linters will not yell, as this new order makes more sense.

---

**Stack**:
- #585
- #584
- #583
- #582


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*