### PR TITLE
Increase test parallelism in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,14 +23,14 @@ jobs:
           path: nextest-archive.tar.zst
 
   test:
-    name: test ${{ matrix.partition }}/4
+    name: test ${{ matrix.partition }}/8
     runs-on: ubuntu-latest
     needs:
       - build-test
     strategy:
       fail-fast: false
       matrix:
-        partition: [ 1, 2, 3, 4 ]
+        partition: [ 1, 2, 3, 4, 5, 6, 7, 8 ]
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
@@ -38,8 +38,8 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: nextest-archive
-      - name: nextest partition ${{ matrix.partition }}/4
-        run: cargo nextest run --partition 'count:${{ matrix.partition }}/4' --archive-file nextest-archive.tar.zst
+      - name: nextest partition ${{ matrix.partition }}/8
+        run: cargo nextest run --partition 'count:${{ matrix.partition }}/8' --archive-file nextest-archive.tar.zst
 
   check-rust:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This shaves a handful of minutes from CI execution time. The drawback is that we will fight for concurrency more.