### PR TITLE
Support import sorting via manifest configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -478,8 +478,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-casm"
 version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc7f7cb89bc3f52c2c738f3e87c8f8773bd3456cae1d322d100d4b0da584f3c"
+source = "git+https://github.com/starkware-libs/cairo?branch=main#dc7f0d5ca76b7409816d99772033abf58975a872"
 dependencies = [
  "cairo-lang-utils",
  "indoc",
@@ -495,8 +494,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-compiler"
 version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4f2c54b065f7fd97bf8d5df76cbcbbd01d8a8c319d281796ee20ecc48e16ca8"
+source = "git+https://github.com/starkware-libs/cairo?branch=main#dc7f0d5ca76b7409816d99772033abf58975a872"
 dependencies = [
  "anyhow",
  "cairo-lang-defs",
@@ -521,8 +519,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-debug"
 version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "873ba77d4c3f780c727c7d6c738cded22b3f6d4023e30546dfe14f97a087887e"
+source = "git+https://github.com/starkware-libs/cairo?branch=main#dc7f0d5ca76b7409816d99772033abf58975a872"
 dependencies = [
  "cairo-lang-utils",
 ]
@@ -530,8 +527,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-defs"
 version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5031fff038c27ed43769b73a6f5d41aeaea34df9af862e024c23fbb4f076249"
+source = "git+https://github.com/starkware-libs/cairo?branch=main#dc7f0d5ca76b7409816d99772033abf58975a872"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-diagnostics",
@@ -548,8 +544,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-diagnostics"
 version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b6cb1492e5784e1076320a5018ce7584f391b2f3b414bc0a8ab7c289fa118ce"
+source = "git+https://github.com/starkware-libs/cairo?branch=main#dc7f0d5ca76b7409816d99772033abf58975a872"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-filesystem",
@@ -561,8 +556,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-eq-solver"
 version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c35dddbc63b2a4870891cc74498726aa32bfaa518596352f9bb101411cc4c584"
+source = "git+https://github.com/starkware-libs/cairo?branch=main#dc7f0d5ca76b7409816d99772033abf58975a872"
 dependencies = [
  "cairo-lang-utils",
  "good_lp",
@@ -573,8 +567,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-filesystem"
 version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32ce0b8e66a6085ae157d43b5c162d60166f0027d6f125c50ee74e4dc7916ff6"
+source = "git+https://github.com/starkware-libs/cairo?branch=main#dc7f0d5ca76b7409816d99772033abf58975a872"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-utils",
@@ -587,8 +580,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-formatter"
 version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79535d235d17f3be2a2d7e82b92709ed4cb60978e8d96c92520178a795162969"
+source = "git+https://github.com/starkware-libs/cairo?branch=main#dc7f0d5ca76b7409816d99772033abf58975a872"
 dependencies = [
  "anyhow",
  "cairo-lang-diagnostics",
@@ -602,14 +594,14 @@ dependencies = [
  "itertools 0.11.0",
  "log",
  "salsa",
+ "serde",
  "smol_str",
 ]
 
 [[package]]
 name = "cairo-lang-language-server"
 version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4793c9799857c94ddd8f7146220fd82b4a4402fa8597f49d48b705747f9ee05"
+source = "git+https://github.com/starkware-libs/cairo?branch=main#dc7f0d5ca76b7409816d99772033abf58975a872"
 dependencies = [
  "anyhow",
  "cairo-lang-compiler",
@@ -641,8 +633,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-lowering"
 version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29cc679f501725e03ee703559ed27d084c6f4031bd51ff86378cf845a85ee207"
+source = "git+https://github.com/starkware-libs/cairo?branch=main#dc7f0d5ca76b7409816d99772033abf58975a872"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -667,8 +658,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-parser"
 version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcadb046659134466bc7e11961ea8a56969dae8a54d8f985955ce0b95185c7f"
+source = "git+https://github.com/starkware-libs/cairo?branch=main#dc7f0d5ca76b7409816d99772033abf58975a872"
 dependencies = [
  "cairo-lang-diagnostics",
  "cairo-lang-filesystem",
@@ -688,8 +678,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-plugins"
 version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4632790cd4ea11d4849934456a400eae7ed419f6d721f24a6b637df67b7e902f"
+source = "git+https://github.com/starkware-libs/cairo?branch=main#dc7f0d5ca76b7409816d99772033abf58975a872"
 dependencies = [
  "cairo-lang-defs",
  "cairo-lang-diagnostics",
@@ -708,8 +697,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-proc-macros"
 version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "170838817fc33ddb65e0a9480526df0b226b148a0fca0a5cd7071be4c6683157"
+source = "git+https://github.com/starkware-libs/cairo?branch=main#dc7f0d5ca76b7409816d99772033abf58975a872"
 dependencies = [
  "cairo-lang-debug",
  "quote",
@@ -719,8 +707,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-project"
 version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4162ee976c61fdeb3b621f4a76fd256e46a5c0890f750a3a9d2c9560a3bc1daf"
+source = "git+https://github.com/starkware-libs/cairo?branch=main#dc7f0d5ca76b7409816d99772033abf58975a872"
 dependencies = [
  "cairo-lang-filesystem",
  "cairo-lang-utils",
@@ -733,8 +720,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-runner"
 version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d66ef01350e2e7f7e6b2b43b865da2513a42600082ee1a2975d3af3da7f0ca"
+source = "git+https://github.com/starkware-libs/cairo?branch=main#dc7f0d5ca76b7409816d99772033abf58975a872"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -770,8 +756,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-semantic"
 version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e544fa9a222bf2d007df2b5fc9b21c2a20ab7e17d6fefbcbc193de209451cd"
+source = "git+https://github.com/starkware-libs/cairo?branch=main#dc7f0d5ca76b7409816d99772033abf58975a872"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -795,9 +780,9 @@ dependencies = [
 [[package]]
 name = "cairo-lang-sierra"
 version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5e136b79e95a14ef38a2be91a67ceb85317407d336a5b0d418c33b23c78596a"
+source = "git+https://github.com/starkware-libs/cairo?branch=main#dc7f0d5ca76b7409816d99772033abf58975a872"
 dependencies = [
+ "anyhow",
  "cairo-lang-utils",
  "const-fnv1a-hash",
  "convert_case",
@@ -818,8 +803,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-sierra-ap-change"
 version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "511ca7708faa7ba8d14ae26e1d60ead2d02028c8f664baf5ecb0fd6a0d1e20f6"
+source = "git+https://github.com/starkware-libs/cairo?branch=main#dc7f0d5ca76b7409816d99772033abf58975a872"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
@@ -832,8 +816,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-sierra-gas"
 version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "351a25bc010b910919c01d5c57e937b0c3d330fc30d92702c0cb4061819df8df"
+source = "git+https://github.com/starkware-libs/cairo?branch=main#dc7f0d5ca76b7409816d99772033abf58975a872"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
@@ -846,8 +829,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-sierra-generator"
 version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "114091bb971c06fd072aca816af1c3f62566cd8a4b1453c786155161a36c7bce"
+source = "git+https://github.com/starkware-libs/cairo?branch=main#dc7f0d5ca76b7409816d99772033abf58975a872"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -873,8 +855,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-sierra-to-casm"
 version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa1c799de62972dfd7112d563000695be94305b6f7d9bedd29f347799bf03e1c"
+source = "git+https://github.com/starkware-libs/cairo?branch=main#dc7f0d5ca76b7409816d99772033abf58975a872"
 dependencies = [
  "assert_matches",
  "cairo-felt",
@@ -895,8 +876,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-sierra-type-size"
 version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fe73d9d58aaf9088f6ba802bcf43ce9ca4bd198190cf5bf91caa7d408dd11a"
+source = "git+https://github.com/starkware-libs/cairo?branch=main#dc7f0d5ca76b7409816d99772033abf58975a872"
 dependencies = [
  "cairo-lang-sierra",
  "cairo-lang-utils",
@@ -905,8 +885,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-starknet"
 version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75df624e71e33a31a924e799dd2a9a8284204b41d8db9c51803317bd9edff81f"
+source = "git+https://github.com/starkware-libs/cairo?branch=main#dc7f0d5ca76b7409816d99772033abf58975a872"
 dependencies = [
  "anyhow",
  "cairo-felt",
@@ -946,8 +925,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-syntax"
 version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b1af0ae21f9e539f97cfdf56f5ce0934dae5d87f568fd778c3d624a102f8dbb"
+source = "git+https://github.com/starkware-libs/cairo?branch=main#dc7f0d5ca76b7409816d99772033abf58975a872"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-filesystem",
@@ -963,8 +941,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-syntax-codegen"
 version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822ffabf24f6a5506262edcece315260a82d9dfba3abe6548791a6d654563ad0"
+source = "git+https://github.com/starkware-libs/cairo?branch=main#dc7f0d5ca76b7409816d99772033abf58975a872"
 dependencies = [
  "genco",
  "xshell",
@@ -973,8 +950,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-test-runner"
 version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43323524d8bcae023e66c9c6f3e857ae73cddc86bb2cc7ea6d739ef54beacb19"
+source = "git+https://github.com/starkware-libs/cairo?branch=main#dc7f0d5ca76b7409816d99772033abf58975a872"
 dependencies = [
  "anyhow",
  "cairo-felt",
@@ -1008,8 +984,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-utils"
 version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f974b6e859f0b09c0f13ec8188c96e9e8bbb5da04214f911dbb5bcda67cb812b"
+source = "git+https://github.com/starkware-libs/cairo?branch=main#dc7f0d5ca76b7409816d99772033abf58975a872"
 dependencies = [
  "env_logger",
  "indexmap 2.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,18 +28,18 @@ repository = "https://github.com/software-mansion/scarb"
 anyhow = "1.0.75"
 assert_fs = "1.0.13"
 async-trait = "0.1.73"
-cairo-lang-compiler = "2.2.0"
-cairo-lang-defs = "2.2.0"
-cairo-lang-filesystem = "2.2.0"
-cairo-lang-formatter = "2.2.0"
-cairo-lang-language-server = "2.2.0"
-cairo-lang-runner = "2.2.0"
-cairo-lang-semantic = "2.2.0"
-cairo-lang-sierra = "2.2.0"
-cairo-lang-sierra-to-casm = "2.2.0"
-cairo-lang-starknet = "2.2.0"
-cairo-lang-test-runner = "2.2.0"
-cairo-lang-utils = { version = "2.2.0", features = ["env_logger"] }
+cairo-lang-compiler = { git = "https://github.com/starkware-libs/cairo", branch = "main" }
+cairo-lang-defs = { git = "https://github.com/starkware-libs/cairo", branch = "main" }
+cairo-lang-filesystem = { git = "https://github.com/starkware-libs/cairo", branch = "main" }
+cairo-lang-formatter = { git = "https://github.com/starkware-libs/cairo", branch = "main" }
+cairo-lang-language-server = { git = "https://github.com/starkware-libs/cairo", branch = "main" }
+cairo-lang-runner = { git = "https://github.com/starkware-libs/cairo", branch = "main" }
+cairo-lang-semantic = { git = "https://github.com/starkware-libs/cairo", branch = "main" }
+cairo-lang-sierra = { git = "https://github.com/starkware-libs/cairo", branch = "main" }
+cairo-lang-sierra-to-casm = { git = "https://github.com/starkware-libs/cairo", branch = "main" }
+cairo-lang-starknet = { git = "https://github.com/starkware-libs/cairo", branch = "main" }
+cairo-lang-test-runner = { git = "https://github.com/starkware-libs/cairo", branch = "main" }
+cairo-lang-utils = { git = "https://github.com/starkware-libs/cairo", branch = "main", features = ["env_logger"] }
 camino = { version = "1.1.6", features = ["serde1"] }
 cargo_metadata = "0.17.0"
 clap = { version = "4.4.2", features = ["derive", "env", "string"] }

--- a/scarb/tests/build.rs
+++ b/scarb/tests/build.rs
@@ -75,7 +75,7 @@ fn compile_with_syntax_error() {
         .code(1)
         .stdout_matches(indoc! {r#"
                Compiling hello v0.1.0 ([..]Scarb.toml)
-            error: Skipped tokens. Expected: Const/Module/Use/FreeFunction/ExternFunction/ExternType/Trait/Impl/Struct/Enum/TypeAlias or an attribute.
+            error: Skipped tokens. Expected: Const/Module/Use/FreeFunction/ExternFunction/ExternType/Trait/Impl/Struct/Enum/TypeAlias/InlineMacro.
              --> lib.cairo:1:1
             not_a_keyword
             ^***********^
@@ -102,7 +102,7 @@ fn compile_with_syntax_error_json() {
         .code(1)
         .stdout_matches(indoc! {r#"
             {"status":"compiling","message":"hello v0.1.0 ([..]Scarb.toml)"}
-            {"type":"diagnostic","message":"error: Skipped tokens. Expected: Const/Module/Use/FreeFunction/ExternFunction/ExternType/Trait/Impl/Struct/Enum/TypeAlias or an attribute./n --> lib.cairo:1:1/nnot_a_keyword/n^***********^/n/n"}
+            {"type":"diagnostic","message":"error: Skipped tokens. Expected: Const/Module/Use/FreeFunction/ExternFunction/ExternType/Trait/Impl/Struct/Enum/TypeAlias/InlineMacro./n --> lib.cairo:1:1/nnot_a_keyword/n^***********^/n/n"}
             {"type":"error","message":"could not compile `hello` due to previous error"}
         "#});
 }

--- a/website/docs/guides/formatting.md
+++ b/website/docs/guides/formatting.md
@@ -13,6 +13,32 @@ properly formatted:
 scarb fmt --check
 ```
 
+## Formatting options
+
+You can add `[tool.fmt]` section inside `Scarb.toml` to override the default formatter configuration.
+
+```toml
+[tool.fmt]
+sort-module-level-items = true
+```
+
+### Available configuration option
+
+- `sort_module_level_items`
+
+  Reorder import statements alphabetically in groups (a group is separated by a newline).\
+  **Default:** `false`
+
+- `max_line_length`
+
+  Maximum width of each line.\
+  **Default:** `100`
+
+- `tab_size`
+
+  Number of spaces per tab.\
+  **Default:** `4`
+
 ## Ignoring files
 
 By default, Scarb will format all files with a `.cairo` extension from the directory containing the manifest file


### PR DESCRIPTION
Resolves #609

Introduces `[tool.fmt]` section to `Scarb.toml` with `sort-imports` boolean flag