### PR TITLE
Cross init templates off the roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Scarb is under active development! Expect a lot of new features to appear soon! 
 - [x] Workspaces
 - [x] Nightlies
 - [ ] Standardized `test` target
-- [ ] `scarb init` templates or `scarb create-starknet-contract` command
+- [ ] ~`scarb init` templates or `scarb create-starknet-contract` command~ ➡️ Use `snforge init`
 - [ ] `Scarb.lock`
 - [ ] Package registry
 - [ ] PubGrub implementation for version resolution


### PR DESCRIPTION
As Foundry [is working on their init template](https://github.com/foundry-rs/starknet-foundry/pull/565), which will cover our mostly requested use-case, we do not see the need to invest into generic init templates idea anymore.