### PR TITLE
Remove example dependency comment from the template

### DIFF
--- a/examples/hello_world/Scarb.toml
+++ b/examples/hello_world/Scarb.toml
@@ -5,4 +5,3 @@ version = "0.1.0"
 # See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
 
 [dependencies]
-# foo = { path = "vendor/foo" }

--- a/scarb/src/ops/new.rs
+++ b/scarb/src/ops/new.rs
@@ -127,7 +127,6 @@ fn mk(
             # See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
 
             [dependencies]
-            # foo = {{ path = "vendor/foo" }}
         "#},
     )?;
 


### PR DESCRIPTION
External template scripts want to use `scarb add` to auto-add necessary dependencies, and this comment makes the outcome ugly. We also don't really need it, so let's just remove it for simplicity.