### PR TITLE
Set cairo version to latest main commit explicitly in nightly workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -48,7 +48,7 @@ jobs:
           echo "nightly_branch=$NIGHTLY_BRANCH" >> $GITHUB_OUTPUT
 
       - name: Upgrade Cairo to latest main commit
-        run: cargo xtask set-cairo-version --branch main
+        run: cargo xtask set-cairo-version --rev $(git ls-remote --refs "https://github.com/starkware-libs/cairo" main | awk '{print $1}')
 
       - name: Set Scarb version
         run: cargo xtask set-scarb-version ${{ env.NIGHTLY_VERSION }}


### PR DESCRIPTION
Pinning Cairo version to branch doesn't work when Cargo.toml already specifies that branch, because lockfile locks the branch on some commit in the past. We need to explicitly set the dependency as a commit hash, to override what is in the lockfile. 