### PR TITLE
Fix `TomlTargetKind` parsing rules

### DIFF
--- a/scarb/src/core/manifest/toml_manifest.rs
+++ b/scarb/src/core/manifest/toml_manifest.rs
@@ -256,7 +256,9 @@ pub struct TomlTargetKind(SmolStr);
 
 impl TomlTargetKind {
     pub fn try_new(name: SmolStr) -> Result<Self> {
-        ensure!(name != Target::LIB, "target kind `{name}` is reserved");
+        PackageName::try_new(&name).with_context(|| {
+            format!("invalid target name `{name}`, because it cannot be used as a package name")
+        })?;
         Ok(Self(name))
     }
 

--- a/scarb/tests/build_targets.rs
+++ b/scarb/tests/build_targets.rs
@@ -163,6 +163,40 @@ fn compile_with_named_default_lib_target() {
 }
 
 #[test]
+fn compile_with_lib_target_in_target_array() {
+    let t = TempDir::new().unwrap();
+    t.child("Scarb.toml")
+        .write_str(
+            r#"
+            [package]
+            name = "hello"
+            version = "0.1.0"
+
+            [[target.lib]]
+            name = "not_hello"
+            sierra = true
+            "#,
+        )
+        .unwrap();
+    t.child("src/lib.cairo")
+        .write_str(r#"fn f() -> felt252 { 42 }"#)
+        .unwrap();
+
+    Scarb::quick_snapbox()
+        .arg("build")
+        .current_dir(&t)
+        .assert()
+        .success()
+        .stdout_matches(indoc! {r#"
+        [..] Compiling hello v0.1.0 ([..])
+        [..]  Finished release target(s) in [..]
+        "#});
+
+    t.child("target/dev/not_hello.sierra.json")
+        .assert(predicates::str::is_empty().not());
+}
+
+#[test]
 fn compile_dep_not_a_lib() {
     let t = TempDir::new().unwrap();
 


### PR DESCRIPTION
1. There were no reasons to disallow `[[target.lib]]`.
2. On the other hand, it would be cool to expect target names to be valid package names.

---

**Stack**:
- #709
- #697
- #675
- #657
- #646
- #708 ⬅
- #707


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*