### PR TITLE
Fix `TomlTargetKind` parsing rules

### DIFF
--- a/scarb/src/bin/scarb/commands/build.rs
+++ b/scarb/src/bin/scarb/commands/build.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 
 use crate::args::BuildArgs;
-use scarb::core::{Config, Target, TargetKind};
+use scarb::core::{Config, TargetKind};
 use scarb::ops;
 use scarb::ops::CompileOpts;
 
@@ -17,7 +17,7 @@ pub fn run(args: BuildArgs, config: &Config) -> Result<()> {
     let exclude_targets: Vec<TargetKind> = if args.test {
         Vec::new()
     } else {
-        vec![Target::TEST.into()]
+        vec![TargetKind::TEST.clone()]
     };
     let opts = CompileOpts { exclude_targets };
     ops::compile(packages, opts, &ws)

--- a/scarb/src/compiler/compilation_unit.rs
+++ b/scarb/src/compiler/compilation_unit.rs
@@ -93,7 +93,7 @@ impl CompilationUnit {
     }
 
     pub fn has_custom_name(&self) -> bool {
-        self.main_component().target.kind != self.main_package_id.name.as_str()
+        self.main_component().target.kind.as_str() != self.main_package_id.name.as_str()
     }
 
     pub fn id(&self) -> String {

--- a/scarb/src/compiler/compilers/lib.rs
+++ b/scarb/src/compiler/compilers/lib.rs
@@ -9,7 +9,7 @@ use tracing::trace_span;
 
 use crate::compiler::helpers::{build_compiler_config, collect_main_crate_ids};
 use crate::compiler::{CompilationUnit, Compiler};
-use crate::core::{Target, Workspace};
+use crate::core::{TargetKind, Workspace};
 
 pub struct LibCompiler;
 
@@ -32,8 +32,8 @@ impl Default for Props {
 }
 
 impl Compiler for LibCompiler {
-    fn target_kind(&self) -> &str {
-        Target::LIB
+    fn target_kind(&self) -> TargetKind {
+        TargetKind::LIB.clone()
     }
 
     fn compile(

--- a/scarb/src/compiler/compilers/starknet_contract.rs
+++ b/scarb/src/compiler/compilers/starknet_contract.rs
@@ -22,7 +22,7 @@ use tracing::{debug, trace, trace_span};
 
 use crate::compiler::helpers::{build_compiler_config, collect_main_crate_ids, write_json};
 use crate::compiler::{CompilationUnit, Compiler};
-use crate::core::{PackageName, Utf8PathWorkspaceExt, Workspace};
+use crate::core::{PackageName, TargetKind, Utf8PathWorkspaceExt, Workspace};
 use crate::internal::serdex::RelativeUtf8PathBuf;
 use crate::internal::stable_hash::short_hash;
 
@@ -185,8 +185,8 @@ struct ContractArtifact {
 }
 
 impl Compiler for StarknetContractCompiler {
-    fn target_kind(&self) -> &str {
-        "starknet-contract"
+    fn target_kind(&self) -> TargetKind {
+        TargetKind::STARKNET_CONTRACT.clone()
     }
 
     fn compile(

--- a/scarb/src/compiler/compilers/test.rs
+++ b/scarb/src/compiler/compilers/test.rs
@@ -2,17 +2,18 @@ use anyhow::Result;
 use cairo_lang_compiler::db::RootDatabase;
 use cairo_lang_compiler::diagnostics::DiagnosticsReporter;
 use cairo_lang_test_plugin::compile_test_prepared_db;
+
 use scarb_ui::components::TypedMessage;
 
 use crate::compiler::helpers::{collect_all_crate_ids, collect_main_crate_ids, write_json};
 use crate::compiler::{CompilationUnit, Compiler};
-use crate::core::{PackageName, SourceId, Target, Workspace};
+use crate::core::{PackageName, SourceId, TargetKind, Workspace};
 
 pub struct TestCompiler;
 
 impl Compiler for TestCompiler {
-    fn target_kind(&self) -> &str {
-        Target::TEST
+    fn target_kind(&self) -> TargetKind {
+        TargetKind::TEST.clone()
     }
 
     fn compile(

--- a/scarb/src/compiler/mod.rs
+++ b/scarb/src/compiler/mod.rs
@@ -5,7 +5,7 @@ pub use compilation_unit::*;
 pub use profile::*;
 pub use repository::*;
 
-use crate::core::Workspace;
+use crate::core::{TargetKind, Workspace};
 
 mod compilation_unit;
 mod compilers;
@@ -16,7 +16,7 @@ mod profile;
 mod repository;
 
 pub trait Compiler: Sync {
-    fn target_kind(&self) -> &str;
+    fn target_kind(&self) -> TargetKind;
 
     fn compile(
         &self,

--- a/scarb/src/compiler/repository.rs
+++ b/scarb/src/compiler/repository.rs
@@ -48,7 +48,7 @@ impl CompilerRepository {
         ws: &Workspace<'_>,
     ) -> Result<()> {
         let target_kind = &unit.target().kind;
-        let Some(compiler) = self.compilers.get(target_kind) else {
+        let Some(compiler) = self.compilers.get(target_kind.as_str()) else {
             bail!("unknown compiler for target `{target_kind}`");
         };
         compiler.compile(unit, db, ws)

--- a/scarb/src/core/manifest/mod.rs
+++ b/scarb/src/core/manifest/mod.rs
@@ -13,6 +13,7 @@ pub use dependency::*;
 pub use scripts::*;
 pub use summary::*;
 pub use target::*;
+pub use target_kind::*;
 pub use toml_manifest::*;
 pub use version_req::*;
 
@@ -25,6 +26,7 @@ mod maybe_workspace;
 mod scripts;
 mod summary;
 mod target;
+mod target_kind;
 mod toml_manifest;
 mod version_req;
 
@@ -79,7 +81,7 @@ impl ManifestBuilder {
             ensure!(
                 targets.len() == 1,
                 "target `{}` cannot be mixed with other targets",
-                Target::CAIRO_PLUGIN,
+                TargetKind::CAIRO_PLUGIN,
             );
         }
         Ok(())

--- a/scarb/src/core/manifest/summary.rs
+++ b/scarb/src/core/manifest/summary.rs
@@ -8,8 +8,7 @@ use typed_builder::TypedBuilder;
 #[cfg(doc)]
 use crate::core::Manifest;
 use crate::core::{
-    DepKind, DependencyVersionReq, ManifestDependency, PackageId, PackageName, SourceId, Target,
-    TargetKind,
+    DepKind, DependencyVersionReq, ManifestDependency, PackageId, PackageName, SourceId, TargetKind,
 };
 
 /// Subset of a [`Manifest`] that contains only the most important information about a package.
@@ -70,7 +69,7 @@ impl Summary {
             // NOTE: Pin test plugin to exact version, because we know that's the only one we have.
             let cairo_version = crate::version::get().cairo.version.parse().unwrap();
             ManifestDependency::builder()
-                .kind(DepKind::Target(Target::TEST.into()))
+                .kind(DepKind::Target(TargetKind::TEST))
                 .name(PackageName::TEST_PLUGIN)
                 .source_id(SourceId::default())
                 .version_req(DependencyVersionReq::exact(&cairo_version))
@@ -81,7 +80,7 @@ impl Summary {
 
         if !self.no_core {
             deps.push(&CORE_DEPENDENCY);
-            if self.target_kinds.contains(&TargetKind::from(Target::TEST)) {
+            if self.target_kinds.contains(&TargetKind::TEST) {
                 deps.push(&TEST_PLUGIN_DEPENDENCY);
             }
         }

--- a/scarb/src/core/manifest/target_kind.rs
+++ b/scarb/src/core/manifest/target_kind.rs
@@ -1,0 +1,189 @@
+use std::borrow::Borrow;
+use std::fmt;
+use std::str::FromStr;
+
+use anyhow::{bail, Result};
+use serde::{Deserialize, Serialize};
+use smol_str::SmolStr;
+
+#[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[serde(into = "SmolStr", try_from = "SmolStr")]
+pub struct TargetKind(SmolStr);
+
+impl TargetKind {
+    pub const CAIRO_PLUGIN: Self = TargetKind(SmolStr::new_inline("cairo-plugin"));
+    pub const LIB: Self = TargetKind(SmolStr::new_inline("lib"));
+    pub const TEST: Self = TargetKind(SmolStr::new_inline("test"));
+    pub const STARKNET_CONTRACT: Self = TargetKind(SmolStr::new_inline("starknet-contract"));
+
+    /// Constructs and validates new [`TargetKind`].
+    ///
+    /// Panics if name does not conform to package naming rules.
+    pub fn new(name: impl AsRef<str>) -> Self {
+        Self::try_new(name).unwrap()
+    }
+
+    /// Constructs and validates new [`TargetKind`].
+    pub fn try_new(name: impl AsRef<str>) -> Result<Self> {
+        Self::try_new_impl(name.as_ref().into())
+    }
+
+    fn try_new_impl(name: SmolStr) -> Result<Self> {
+        if name.is_empty() {
+            bail!("empty string cannot be used as target kind");
+        }
+
+        if name == "_" {
+            bail!("underscore cannot be used as target kind");
+        }
+
+        if name == "-" {
+            bail!("dash cannot be used as target kind");
+        }
+
+        if name != name.to_ascii_lowercase() {
+            bail!(
+                "invalid target kind: `{name}`\n\
+                note: usage of ASCII uppercase letters in the target kind has been disallowed\n\
+                help: change target kind to: {}",
+                name.to_ascii_lowercase()
+            )
+        }
+
+        let mut chars = name.chars();
+
+        // Validate first letter.
+        if let Some(ch) = chars.next() {
+            // A specific error for a potentially common case.
+            if ch.is_ascii_digit() {
+                bail!(
+                    "the name `{name}` cannot be used as a target kind, \
+                    names cannot start with a digit"
+                );
+            }
+
+            if !(ch.is_ascii_alphabetic() || ch == '-') {
+                bail!(
+                    "invalid character `{ch}` in target kind: `{name}`, \
+                    the first character must be an ASCII lowercase letter or dash"
+                )
+            }
+        }
+
+        // Validate rest.
+        for ch in chars {
+            if !(ch.is_ascii_alphanumeric() || ch == '-') {
+                bail!(
+                    "invalid character `{ch}` in target kind: `{name}`, \
+                    characters must be ASCII lowercase letters, ASCII numbers or dash"
+                )
+            }
+        }
+
+        Ok(Self(name))
+    }
+
+    #[inline(always)]
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+
+    #[inline(always)]
+    pub fn to_smol_str(&self) -> SmolStr {
+        self.0.clone()
+    }
+}
+
+impl AsRef<str> for TargetKind {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl From<TargetKind> for SmolStr {
+    fn from(value: TargetKind) -> Self {
+        value.0
+    }
+}
+
+impl TryFrom<&str> for TargetKind {
+    type Error = anyhow::Error;
+
+    fn try_from(value: &str) -> Result<Self> {
+        TargetKind::try_new(value)
+    }
+}
+
+impl TryFrom<String> for TargetKind {
+    type Error = anyhow::Error;
+
+    fn try_from(value: String) -> Result<Self> {
+        TargetKind::try_new(value)
+    }
+}
+
+impl TryFrom<SmolStr> for TargetKind {
+    type Error = anyhow::Error;
+
+    fn try_from(value: SmolStr) -> Result<Self> {
+        TargetKind::try_new(value.as_str())
+    }
+}
+
+impl FromStr for TargetKind {
+    type Err = anyhow::Error;
+
+    fn from_str(name: &str) -> Result<Self> {
+        TargetKind::try_new(name)
+    }
+}
+
+impl Borrow<str> for TargetKind {
+    fn borrow(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl From<TargetKind> for String {
+    fn from(value: TargetKind) -> Self {
+        value.to_string()
+    }
+}
+
+impl fmt::Display for TargetKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl fmt::Debug for TargetKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "TargetKind({self})")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use test_case::test_case;
+
+    use super::TargetKind;
+
+    #[test_case("foo")]
+    #[test_case("b-ar")]
+    #[test_case("loop")]
+    fn validate_correct_target_kind(name: &str) {
+        assert!(TargetKind::try_new(name).is_ok())
+    }
+
+    #[test_case("" => "empty string cannot be used as target kind"; "empty string")]
+    #[test_case("_" => "underscore cannot be used as target kind"; "underscore")]
+    #[test_case("-" => "dash cannot be used as target kind"; "dash")]
+    #[test_case("1" => "the name `1` cannot be used as a target kind, names cannot start with a digit")]
+    #[test_case("123" => "the name `123` cannot be used as a target kind, names cannot start with a digit")]
+    #[test_case("0foo" => "the name `0foo` cannot be used as a target kind, names cannot start with a digit")]
+    #[test_case("fo_o" => "invalid character `_` in target kind: `fo_o`, characters must be ASCII lowercase letters, ASCII numbers or dash")]
+    #[test_case("baR" => "invalid target kind: `baR`\nnote: usage of ASCII uppercase letters in the target kind has been disallowed\nhelp: change target kind to: bar")]
+    fn validate_incorrect_target_kind(name: &str) -> String {
+        TargetKind::try_new(name).unwrap_err().to_string()
+    }
+}

--- a/scarb/src/core/package/mod.rs
+++ b/scarb/src/core/package/mod.rs
@@ -11,7 +11,7 @@ pub use name::*;
 use scarb_ui::args::WithManifestPath;
 
 use crate::core::manifest::Manifest;
-use crate::core::Target;
+use crate::core::{Target, TargetKind};
 
 mod id;
 mod name;
@@ -80,11 +80,11 @@ impl Package {
         }
     }
 
-    pub fn target(&self, kind: &str) -> Option<&Target> {
-        self.manifest.targets.iter().find(|t| t.kind == kind)
+    pub fn target(&self, kind: &TargetKind) -> Option<&Target> {
+        self.manifest.targets.iter().find(|t| t.kind == *kind)
     }
 
-    pub fn fetch_target(&self, kind: &str) -> Result<&Target> {
+    pub fn fetch_target(&self, kind: &TargetKind) -> Result<&Target> {
         self.target(kind)
             .ok_or_else(|| anyhow!("package `{self}` has no target `{kind}`"))
     }

--- a/scarb/src/core/registry/mod.rs
+++ b/scarb/src/core/registry/mod.rs
@@ -30,7 +30,7 @@ pub(crate) mod mock {
     use crate::core::package::PackageName;
     use crate::core::registry::Registry;
     use crate::core::{
-        ManifestBuilder, ManifestDependency, Package, PackageId, SourceId, Summary, Target,
+        ManifestBuilder, ManifestDependency, Package, PackageId, SourceId, Summary, TargetKind,
     };
 
     #[derive(Debug, Default)]
@@ -106,7 +106,7 @@ pub(crate) mod mock {
 
         fn build_package(package_id: PackageId, dependencies: Vec<ManifestDependency>) -> Package {
             let summary = Summary::builder()
-                .target_kinds(HashSet::from_iter(vec![Target::LIB.into()]))
+                .target_kinds(HashSet::from_iter(vec![TargetKind::LIB]))
                 .package_id(package_id)
                 .dependencies(dependencies)
                 .no_core(package_id.is_core())
@@ -204,7 +204,7 @@ pub(crate) mod mock {
                 .name($crate::core::PackageName::new($n))
                 .version_req(::semver::VersionReq::parse($v).unwrap().into())
                 .source_id($crate::core::SourceId::default_registry())
-                .kind($crate::core::DepKind::Target($t.into()))
+                .kind($crate::core::DepKind::Target($t.parse().unwrap()))
                 .build()
         };
 
@@ -213,7 +213,7 @@ pub(crate) mod mock {
                 .name($crate::core::PackageName::new($n))
                 .version_req(::semver::VersionReq::parse($v).unwrap().into())
                 .source_id($crate::core::SourceId::from_display_str($s).unwrap())
-                .kind($crate::core::DepKind::Target($t.into()))
+                .kind($crate::core::DepKind::Target($t.parse().unwrap()))
                 .build()
         };
     }

--- a/scarb/src/core/resolver.rs
+++ b/scarb/src/core/resolver.rs
@@ -33,7 +33,7 @@ impl Resolve {
     ///
     /// # Safety
     /// * Asserts that `root_package` is a node in this graph.
-    pub fn solution_of(&self, root_package: PackageId, target_kind: TargetKind) -> Vec<PackageId> {
+    pub fn solution_of(&self, root_package: PackageId, target_kind: &TargetKind) -> Vec<PackageId> {
         assert!(&self.graph.contains_node(root_package));
         let filtered_graph = EdgeFiltered::from_fn(&self.graph, move |(_node_a, _node_b, edge)| {
             edge.accepts_target(target_kind.clone())

--- a/scarb/src/ops/compile.rs
+++ b/scarb/src/ops/compile.rs
@@ -67,7 +67,7 @@ fn compile_unit(unit: CompilationUnit, ws: &Workspace<'_>) -> Result<()> {
     //   `starknet` dependency will error in 99% real-world Starknet contract projects.
     //   I think we can get away with emitting false positives for users who write raw contracts
     //   without using Starknet code generators. Such people shouldn't do what they do 😁
-    if unit.target().kind == "starknet-contract" && !has_starknet_plugin(&db) {
+    if unit.target().kind == TargetKind::STARKNET_CONTRACT && !has_starknet_plugin(&db) {
         ws.config().ui().warn(formatdoc! {
             r#"
             package `{package_name}` declares `starknet-contract` target, but does not depend on `starknet` package

--- a/scarb/src/resolver/mod.rs
+++ b/scarb/src/resolver/mod.rs
@@ -7,7 +7,7 @@ use scarb_ui::Ui;
 
 use crate::core::registry::Registry;
 use crate::core::resolver::{DependencyEdge, Resolve};
-use crate::core::{DepKind, ManifestDependency, PackageId, Summary, Target, TargetKind};
+use crate::core::{DepKind, ManifestDependency, PackageId, Summary, TargetKind};
 
 /// Builds the list of all packages required to build the first argument.
 ///
@@ -60,8 +60,8 @@ pub async fn resolve(summaries: &[Summary], registry: &dyn Registry, ui: &Ui) ->
                 };
                 let dep = dep_summary.package_id;
 
-                if !(dep_summary.target_kinds.contains(Target::CAIRO_PLUGIN)
-                    || dep_summary.target_kinds.contains(Target::LIB))
+                if !(dep_summary.target_kinds.contains(&TargetKind::CAIRO_PLUGIN)
+                    || dep_summary.target_kinds.contains(&TargetKind::LIB))
                 {
                     ui.warn(format!(
                         "{} ignoring invalid dependency `{}` which is missing a lib or cairo-plugin target",
@@ -176,7 +176,7 @@ mod tests {
 
     use crate::core::package::PackageName;
     use crate::core::registry::mock::{deps, pkgs, registry, MockRegistry};
-    use crate::core::{ManifestDependency, PackageId, Resolve, SourceId};
+    use crate::core::{ManifestDependency, PackageId, Resolve, SourceId, TargetKind};
 
     fn check(
         registry: MockRegistry,
@@ -573,7 +573,7 @@ mod tests {
         )
         .unwrap();
 
-        let mut test_solution = resolve.solution_of(root, "test".into());
+        let mut test_solution = resolve.solution_of(root, &TargetKind::TEST);
         test_solution.sort();
         assert_eq!(test_solution.len(), 4);
         assert_eq!(
@@ -584,7 +584,7 @@ mod tests {
             vec!["bar", "boo", "core", "foo"],
         );
 
-        let mut lib_solution = resolve.solution_of(root, "lib".into());
+        let mut lib_solution = resolve.solution_of(root, &TargetKind::LIB);
         lib_solution.sort();
         assert_eq!(lib_solution.len(), 3);
         assert_eq!(

--- a/scarb/tests/build_targets.rs
+++ b/scarb/tests/build_targets.rs
@@ -163,6 +163,40 @@ fn compile_with_named_default_lib_target() {
 }
 
 #[test]
+fn compile_with_lib_target_in_target_array() {
+    let t = TempDir::new().unwrap();
+    t.child("Scarb.toml")
+        .write_str(
+            r#"
+            [package]
+            name = "hello"
+            version = "0.1.0"
+
+            [[target.lib]]
+            name = "not_hello"
+            sierra = true
+            "#,
+        )
+        .unwrap();
+    t.child("src/lib.cairo")
+        .write_str(r#"fn f() -> felt252 { 42 }"#)
+        .unwrap();
+
+    Scarb::quick_snapbox()
+        .arg("build")
+        .current_dir(&t)
+        .assert()
+        .success()
+        .stdout_matches(indoc! {r#"
+        [..] Compiling hello v0.1.0 ([..])
+        [..]  Finished release target(s) in [..]
+        "#});
+
+    t.child("target/dev/not_hello.sierra.json")
+        .assert(predicates::str::is_empty().not());
+}
+
+#[test]
 fn compile_dep_not_a_lib() {
     let t = TempDir::new().unwrap();
 


### PR DESCRIPTION
1. There were no reasons to disallow `[[target.lib]]`.
2. On the other hand, it would be cool to expect target names to have package-name-style validation.

---

**Stack**:
- #697
- #710
- #675
- #657
- #646
- #712 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*