### PR TITLE
DepBuilder DSL

### DIFF
--- a/scarb/tests/build.rs
+++ b/scarb/tests/build.rs
@@ -8,7 +8,7 @@ use predicates::prelude::*;
 use scarb_build_metadata::CAIRO_VERSION;
 use scarb_test_support::command::Scarb;
 use scarb_test_support::fsx::ChildPathEx;
-use scarb_test_support::project_builder::ProjectBuilder;
+use scarb_test_support::project_builder::{Dep, DepBuilder, ProjectBuilder};
 use scarb_test_support::workspace_builder::WorkspaceBuilder;
 
 #[test]
@@ -550,7 +550,7 @@ fn workspace_as_dep() {
     let pkg2 = first_t.child("second");
     ProjectBuilder::start()
         .name("second")
-        .dep("first", r#"path = "../first""#)
+        .dep("first", Dep.path("../first"))
         .lib_cairo(indoc! {r#"
         fn fib(a: felt252, b: felt252, n: felt252) -> felt252 {
             match n {
@@ -580,8 +580,8 @@ fn workspace_as_dep() {
     let pkg1 = second_t.child("third");
     ProjectBuilder::start()
         .name("third")
-        .dep("first", r#"path = "../../first_workspace""#)
-        .dep("second", r#"path = "../../first_workspace""#)
+        .dep("first", Dep.path("../../first_workspace"))
+        .dep("second", Dep.path("../../first_workspace"))
         .lib_cairo(indoc! {r#"
             use second::fib;
             fn example() -> felt252 { 42 }
@@ -594,7 +594,7 @@ fn workspace_as_dep() {
     let pkg2 = second_t.child("fourth");
     ProjectBuilder::start()
         .name("fourth")
-        .dep("third", r#"path = "../third""#)
+        .dep("third", Dep.path("../third"))
         .build(&pkg2);
     WorkspaceBuilder::start()
         .add_member("third")

--- a/scarb/tests/build_starknet_contract.rs
+++ b/scarb/tests/build_starknet_contract.rs
@@ -26,7 +26,7 @@ fn compile_dep_test_case(hello: &ChildPath, world: &ChildPath, target_extra: &st
     ProjectBuilder::start()
         .name("world")
         .version("0.1.0")
-        .dep("hello", r#" path = "../hello" "#)
+        .dep("hello", hello)
         .manifest_extra(formatdoc! {r#"
             [[target.starknet-contract]]
             {target_extra}

--- a/scarb/tests/build_starknet_external_contracts.rs
+++ b/scarb/tests/build_starknet_external_contracts.rs
@@ -27,7 +27,7 @@ fn compile_dep_test_case(hello: &ChildPath, world: &ChildPath, target_extra: &st
     ProjectBuilder::start()
         .name("world")
         .version("0.1.0")
-        .dep("hello", r#" path = "../hello" "#)
+        .dep("hello", hello)
         .manifest_extra(formatdoc! {r#"
             [[target.starknet-contract]]
             {target_extra}
@@ -203,7 +203,7 @@ fn build_external_full_path() {
     ProjectBuilder::start()
         .name("world")
         .version("0.1.0")
-        .dep("hello", r#" path = "../hello" "#)
+        .dep("hello", &hello)
         .manifest_extra(indoc! {r#"
             [[target.starknet-contract]]
             build-external-contracts = [
@@ -410,7 +410,7 @@ fn compile_with_bad_glob_path() {
     ProjectBuilder::start()
         .name("world")
         .version("0.1.0")
-        .dep("hello", r#" path = "../hello" "#)
+        .dep("hello", &hello)
         .manifest_extra(formatdoc! {r#"
             [[target.starknet-contract]]
             build-external-contracts = ["hello::**",]

--- a/scarb/tests/fmt.rs
+++ b/scarb/tests/fmt.rs
@@ -231,13 +231,13 @@ fn workspace_with_root() {
     ProjectBuilder::start()
         .name("second")
         .lib_cairo(SIMPLE_ORIGINAL)
-        .dep("first", r#"path = "../first""#)
+        .dep("first", &pkg1)
         .build(&pkg2);
     let root = ProjectBuilder::start()
         .name("some_root")
         .lib_cairo(SIMPLE_ORIGINAL)
-        .dep("first", r#"path = "./first""#)
-        .dep("second", r#"path = "./second""#);
+        .dep("first", &pkg1)
+        .dep("second", &pkg2);
     WorkspaceBuilder::start()
         .add_member("first")
         .add_member("second")

--- a/scarb/tests/git_source.rs
+++ b/scarb/tests/git_source.rs
@@ -4,13 +4,13 @@ use std::fs;
 use assert_fs::prelude::*;
 use assert_fs::TempDir;
 use gix::refs::transaction::PreviousValue;
-use indoc::{formatdoc, indoc};
+use indoc::indoc;
 use scarb_metadata::Metadata;
 
 use scarb_test_support::command::{CommandExt, Scarb};
 use scarb_test_support::fsx::ChildPathEx;
 use scarb_test_support::gitx;
-use scarb_test_support::project_builder::ProjectBuilder;
+use scarb_test_support::project_builder::{Dep, DepBuilder, ProjectBuilder};
 
 #[test]
 fn compile_simple_git_dep() {
@@ -59,13 +59,7 @@ fn fetch_git_dep_branch() {
     ProjectBuilder::start()
         .name("hello")
         .version("1.0.0")
-        .dep(
-            "dep1",
-            formatdoc! {r#"
-                git = "{git_dep}"
-                branch = "foo"
-            "#},
-        )
+        .dep("dep1", git_dep.with("branch", "foo"))
         .lib_cairo("fn world() -> felt252 { dep1::branched() }")
         .build(&t);
 
@@ -95,13 +89,7 @@ fn fetch_git_dep_tag() {
     ProjectBuilder::start()
         .name("hello")
         .version("1.0.0")
-        .dep(
-            "dep1",
-            formatdoc! {r#"
-                git = "{git_dep}"
-                tag = "v1.4.0"
-            "#},
-        )
+        .dep("dep1", git_dep.with("tag", "v1.4.0"))
         .lib_cairo("fn world() -> felt252 { dep1::tagged() }")
         .build(&t);
 
@@ -137,13 +125,7 @@ fn fetch_git_dep_pull_request() {
     ProjectBuilder::start()
         .name("hello")
         .version("1.0.0")
-        .dep(
-            "dep1",
-            formatdoc! {r#"
-                git = "{git_dep}"
-                rev = "refs/pull/330/head"
-            "#},
-        )
+        .dep("dep1", git_dep.with("rev", "refs/pull/330/head"))
         .lib_cairo("fn world() -> felt252 { dep1::hello() }")
         .build(&t);
 
@@ -163,7 +145,7 @@ fn fetch_with_nested_paths() {
         ProjectBuilder::start()
             .name("dep1")
             .lib_cairo("fn hello() -> felt252 { dep2::hello() }")
-            .dep("dep2", r#" path = "vendor/dep2" "#)
+            .dep("dep2", Dep.path("vendor/dep2"))
             .build(&t);
 
         ProjectBuilder::start()
@@ -195,7 +177,7 @@ fn fetch_with_short_ssh_git() {
     ProjectBuilder::start()
         .name("hello")
         .version("1.0.0")
-        .dep("dep", r#" git = "git@github.com:a/dep" "#)
+        .dep("dep", Dep.with("git", "git@github.com:a/dep"))
         .lib_cairo("fn world() -> felt252 { dep1::hello() }")
         .build(&t);
 
@@ -379,7 +361,7 @@ fn transitive_path_dep() {
         ProjectBuilder::start()
             .name("dep1")
             .lib_cairo("fn hello() -> felt252 { dep0::hello() }")
-            .dep("dep0", r#" path = "../zero" "#)
+            .dep("dep0", Dep.path("../zero"))
             .build(&t.child("one"));
     });
 

--- a/scarb/tests/git_source_network.rs
+++ b/scarb/tests/git_source_network.rs
@@ -3,10 +3,10 @@ use std::net::TcpListener;
 use std::thread;
 
 use assert_fs::TempDir;
-use indoc::{formatdoc, indoc};
+use indoc::indoc;
 
 use scarb_test_support::command::Scarb;
-use scarb_test_support::project_builder::ProjectBuilder;
+use scarb_test_support::project_builder::{Dep, DepBuilder, ProjectBuilder};
 
 #[test]
 fn https_something_happens() {
@@ -27,9 +27,7 @@ fn https_something_happens() {
             .version("1.0.0")
             .dep(
                 "dep",
-                formatdoc! {r#"
-                    git = "https://127.0.0.1:{port}/foo/bar"
-                "#},
+                Dep.with("git", format!("https://127.0.0.1:{port}/foo/bar")),
             )
             .build(&t);
 
@@ -64,9 +62,7 @@ fn ssh_something_happens() {
             .version("1.0.0")
             .dep(
                 "dep",
-                formatdoc! {r#"
-                    git = "ssh://127.0.0.1:{port}/foo/bar"
-                "#},
+                Dep.with("git", format!("ssh://127.0.0.1:{port}/foo/bar")),
             )
             .build(&t);
 

--- a/scarb/tests/metadata.rs
+++ b/scarb/tests/metadata.rs
@@ -7,7 +7,7 @@ use serde_json::json;
 use scarb_metadata::{Cfg, ManifestMetadataBuilder, Metadata, PackageMetadata};
 use scarb_test_support::command::{CommandExt, Scarb};
 use scarb_test_support::fsx;
-use scarb_test_support::project_builder::ProjectBuilder;
+use scarb_test_support::project_builder::{Dep, DepBuilder, ProjectBuilder};
 use scarb_test_support::workspace_builder::WorkspaceBuilder;
 
 fn packages_by_name(meta: Metadata) -> BTreeMap<String, PackageMetadata> {
@@ -407,7 +407,8 @@ fn workspace_simple() {
     ProjectBuilder::start()
         .name("second")
         .manifest_extra("[[test]]")
-        .dep("first", r#"path = "../first""#)
+        // Check paths are relative to manifest file.
+        .dep("first", Dep.path("../first"))
         .build(&pkg2);
     WorkspaceBuilder::start()
         .add_member("first")
@@ -448,12 +449,12 @@ fn workspace_with_root() {
     let pkg2 = t.child("second");
     ProjectBuilder::start()
         .name("second")
-        .dep("first", r#"path = "../first""#)
+        .dep("first", Dep.path("../first"))
         .build(&pkg2);
     let root = ProjectBuilder::start()
         .name("some_root")
-        .dep("first", r#"path = "./first""#)
-        .dep("second", r#"path = "./second""#);
+        .dep("first", Dep.path("./first"))
+        .dep("second", Dep.path("./second"));
     WorkspaceBuilder::start()
         .add_member("first")
         .add_member("second")
@@ -508,7 +509,7 @@ fn workspace_as_dep() {
     ProjectBuilder::start()
         .name("second")
         .manifest_extra("[[test]]")
-        .dep("first", r#"path = "../first""#)
+        .dep("first", Dep.path("../first"))
         .build(&pkg2);
     WorkspaceBuilder::start()
         .add_member("first")
@@ -545,14 +546,14 @@ fn workspace_as_dep() {
     ProjectBuilder::start()
         .name("third")
         .manifest_extra("[[test]]")
-        .dep("first", r#"path = "../../first_workspace""#)
-        .dep("second", r#"path = "../../first_workspace""#)
+        .dep("first", Dep.path("../../first_workspace"))
+        .dep("second", Dep.path("../../first_workspace"))
         .build(&pkg1);
     let pkg2 = second_t.child("fourth");
     ProjectBuilder::start()
         .name("fourth")
         .manifest_extra("[[test]]")
-        .dep("third", r#"path = "../third""#)
+        .dep("third", Dep.path("../third"))
         .build(&pkg2);
     WorkspaceBuilder::start()
         .add_member("third")
@@ -618,17 +619,17 @@ fn workspace_package_key_inheritance() {
     ProjectBuilder::start()
         .name("first")
         .manifest_extra("[[test]]")
-        .workspace_dep("some_dep")
+        .dep("some_dep", Dep.workspace())
         .build(&pkg1);
     let pkg2 = some_workspace.child("second");
     ProjectBuilder::start()
         .name("second")
         .manifest_extra("[[test]]")
-        .dep("first", r#"path = "../first""#)
+        .dep("first", Dep.path("../first"))
         .build(&pkg2);
 
     WorkspaceBuilder::start()
-        .dep("some_dep", r#"path = "../some_dep""#)
+        .dep("some_dep", Dep.path("../some_dep"))
         .add_member("first")
         .add_member("second")
         .build(&some_workspace);

--- a/scarb/tests/resolver_with_git.rs
+++ b/scarb/tests/resolver_with_git.rs
@@ -1,10 +1,10 @@
 use assert_fs::prelude::*;
 use assert_fs::TempDir;
-use indoc::{formatdoc, indoc};
+use indoc::indoc;
 
 use scarb_test_support::command::Scarb;
 use scarb_test_support::gitx;
-use scarb_test_support::project_builder::ProjectBuilder;
+use scarb_test_support::project_builder::{DepBuilder, ProjectBuilder};
 
 #[test]
 fn valid_triangle() {
@@ -62,13 +62,7 @@ fn two_revs_of_same_dep() {
     ProjectBuilder::start()
         .name("proxy")
         .lib_cairo("fn p() -> felt252 { culprit::f2() }")
-        .dep(
-            "culprit",
-            formatdoc! {r#"
-                git = "{culprit}"
-                branch = "branchy"
-            "#},
-        )
+        .dep("culprit", culprit.with("branch", "branchy"))
         .build(&proxy);
 
     ProjectBuilder::start()
@@ -119,13 +113,7 @@ fn two_revs_of_same_dep_diamond() {
         ProjectBuilder::start()
             .name("dep2")
             .lib_cairo("fn p() -> felt252 { culprit::f2() }")
-            .dep(
-                "culprit",
-                formatdoc! {r#"
-                    git = "{culprit}"
-                    branch = "branchy"
-                "#},
-            )
+            .dep("culprit", culprit.with("branch", "branchy"))
             .build(&t);
     });
 

--- a/utils/scarb-test-support/src/workspace_builder.rs
+++ b/utils/scarb-test-support/src/workspace_builder.rs
@@ -1,4 +1,4 @@
-use crate::project_builder::{ProjectBuilder, ToDep};
+use crate::project_builder::{DepBuilder, ProjectBuilder};
 use assert_fs::prelude::*;
 use scarb::MANIFEST_FILE_NAME;
 use toml_edit::{Array, Document, Item, Value};
@@ -31,8 +31,8 @@ impl WorkspaceBuilder {
         self
     }
 
-    pub fn dep(mut self, name: impl Into<String>, dep: impl ToDep) -> Self {
-        self.deps.push((name.into(), dep.to_dep()));
+    pub fn dep(mut self, name: impl Into<String>, dep: impl DepBuilder) -> Self {
+        self.deps.push((name.into(), dep.build()));
         self
     }
 


### PR DESCRIPTION
This PR adds a new DSL for specifying dependencies in `ProjectBuilder` and `WorkspaceBuilder`. It is capable of expressing all cases for which we have been falling back to strings currently, and also it can now do things like amending auto-generated deps for e.g. paths.

This PR updates all string- and TOML table-based usages of old API. It does not migrate explicit paths usage to auto-generation for `ChildPaths` whereverr we want to ensure paths are properly treated as relative.

---

**Stack**:
- #697
- #710
- #726 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*