### PR TITLE
Support `.scarbignore` files when packaging

### DIFF
--- a/scarb/src/core/publishing/source.rs
+++ b/scarb/src/core/publishing/source.rs
@@ -4,14 +4,14 @@ use ignore::{DirEntry, WalkBuilder};
 
 use crate::core::Package;
 use crate::internal::fsx::PathBufUtf8Ext;
-use crate::{DEFAULT_TARGET_DIR_NAME, LOCK_FILE_NAME, MANIFEST_FILE_NAME};
+use crate::{DEFAULT_TARGET_DIR_NAME, LOCK_FILE_NAME, MANIFEST_FILE_NAME, SCARB_IGNORE_FILE_NAME};
 
 /// List all files relevant to building this package inside this source.
 ///
 /// The basic assumption is that all files in the package directory are relevant for building this
 /// package, provided that they potentially can be committed to the source directory. The following
 /// rules hold:
-/// * Look for any `.gitignore` or `.ignore`-like files, using the [`ignore`] crate.
+/// * Look for any `.scarbignore`, `.gitignore` or `.ignore`-like files, using the [`ignore`] crate.
 /// * Skip `.git` directory.
 /// * Skip any subdirectories containing `Scarb.toml`.
 /// * Skip `<root>/target` directory.
@@ -63,6 +63,7 @@ fn push_worktree_files(pkg: &Package, ret: &mut Vec<Utf8PathBuf>) -> Result<()> 
         .parents(false)
         .require_git(true)
         .same_file_system(true)
+        .add_custom_ignore_filename(SCARB_IGNORE_FILE_NAME)
         .filter_entry(filter)
         .build()
         .try_for_each(|entry| {

--- a/scarb/src/lib.rs
+++ b/scarb/src/lib.rs
@@ -29,3 +29,4 @@ pub const DEFAULT_SOURCE_PATH: &str = "src/lib.cairo";
 pub const DEFAULT_MODULE_MAIN_FILE: &str = "lib.cairo";
 pub const DEFAULT_TESTS_PATH: &str = "tests";
 pub const DEFAULT_TARGET_DIR_NAME: &str = "target";
+pub const SCARB_IGNORE_FILE_NAME: &str = ".scarbignore";


### PR DESCRIPTION
This PR makes `scarb package` check for `.scarbignore` files when determining package source files set. This is a trivial addition thanks to features of the `ignore` crate.

Supporting this file is effectively a similar feature to the include/exclude fields of Cargo (https://doc.rust-lang.org/cargo/reference/manifest.html#the-exclude-and-include-fields). This PR fixes #644 then, as we do not want to create multiple ways of achieving the same thing.

---

**Stack**:
- #758
- #757
- #748
- #746 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*