### PR TITLE
Move large struct `DetailedTomlDependency` into a `Box` and use `Cow` to avoid cloning it

### DIFF
--- a/scarb/src/core/manifest/toml_manifest.rs
+++ b/scarb/src/core/manifest/toml_manifest.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::default::Default;
 use std::fs;
@@ -245,7 +246,7 @@ pub enum TomlDependency {
     /// [`VersionReq`] specified as a string, e.g. `package = "<version>"`.
     Simple(VersionReq),
     /// Detailed specification as a table, e.g. `package = { version = "<version>" }`.
-    Detailed(DetailedTomlDependency),
+    Detailed(Box<DetailedTomlDependency>),
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
@@ -331,13 +332,13 @@ impl TomlManifest {
 }
 
 impl TomlDependency {
-    fn resolve(&self) -> DetailedTomlDependency {
+    fn resolve(&self) -> Cow<'_, DetailedTomlDependency> {
         match self {
-            TomlDependency::Simple(version) => DetailedTomlDependency {
+            TomlDependency::Simple(version) => Cow::Owned(DetailedTomlDependency {
                 version: Some(version.clone()),
                 ..Default::default()
-            },
-            TomlDependency::Detailed(detailed) => detailed.clone(),
+            }),
+            TomlDependency::Detailed(detailed) => Cow::Borrowed(detailed),
         }
     }
 }

--- a/scarb/src/core/publishing/manifest_normalization.rs
+++ b/scarb/src/core/publishing/manifest_normalization.rs
@@ -110,14 +110,14 @@ fn generate_dependency(dep: &ManifestDependency) -> Result<TomlDependency> {
         }
     });
 
-    Ok(TomlDependency::Detailed(DetailedTomlDependency {
+    Ok(TomlDependency::Detailed(Box::new(DetailedTomlDependency {
         version,
         path: None,
         git: None,
         branch: None,
         tag: None,
         rev: None,
-    }))
+    })))
 }
 
 fn map_metadata_file_path<T>(


### PR DESCRIPTION
**Stack**:
- #758
- #757
- #748 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*