### PR TITLE
Remove `indoc` dependency from `scarb-ui`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4137,7 +4137,6 @@ dependencies = [
  "clap",
  "console",
  "indicatif",
- "indoc",
  "scarb-metadata 1.8.0",
  "serde",
  "serde_json",

--- a/utils/scarb-ui/Cargo.toml
+++ b/utils/scarb-ui/Cargo.toml
@@ -10,7 +10,6 @@ camino.workspace = true
 clap.workspace = true
 console.workspace = true
 indicatif.workspace = true
-indoc.workspace = true
 scarb-metadata = { version = "*", path = "../../scarb-metadata" }
 serde.workspace = true
 serde_json.workspace = true

--- a/utils/scarb-ui/src/args/packages_filter.rs
+++ b/utils/scarb-ui/src/args/packages_filter.rs
@@ -4,7 +4,6 @@ use std::fmt;
 
 use anyhow::{bail, ensure, Result};
 use camino::{Utf8Path, Utf8PathBuf};
-use indoc::{formatdoc, indoc};
 
 use scarb_metadata::{Metadata, PackageMetadata};
 
@@ -60,10 +59,10 @@ impl PackagesFilter {
         if (self.workspace || specs.iter().any(|spec| matches!(spec, Spec::All)))
             && members.len() > 1
         {
-            bail!(indoc! {r#"
-                could not determine which package to work on
-                help: use the `--package` option to specify the package
-            "#});
+            bail!(
+                "could not determine which package to work on\n\
+                help: use the `--package` option to specify the package"
+            );
         }
 
         let specs_filter: String = specs
@@ -75,10 +74,8 @@ impl PackagesFilter {
 
         ensure!(
             found.len() <= 1,
-            formatdoc! {r#"
-                workspace has multiple members matching `{specs_filter}`
-                help: use the `--package` option to specify single package
-            "#}
+            "workspace has multiple members matching `{specs_filter}`\n\
+            help: use the `--package` option to specify single package"
         );
 
         Ok(found.into_iter().next().unwrap())
@@ -314,9 +311,11 @@ impl PackagesSource for Metadata {
 
 #[cfg(test)]
 mod tests {
-    use crate::args::{PackagesFilter, PackagesSource, WithManifestPath};
-    use camino::{Utf8Path, Utf8PathBuf};
     use std::collections::HashSet;
+
+    use camino::{Utf8Path, Utf8PathBuf};
+
+    use crate::args::{PackagesFilter, PackagesSource, WithManifestPath};
 
     #[derive(Clone)]
     struct MockPackage {


### PR DESCRIPTION
It was barely used.

---

**Stack**:
- #753
- #752
- #751
- #750
- #749 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*