### PR TITLE
Revert matching parsing errors in git db client contains method

### DIFF
--- a/scarb/src/sources/git/client.rs
+++ b/scarb/src/sources/git/client.rs
@@ -212,14 +212,9 @@ impl GitDatabase {
     }
 
     pub fn contains(&self, rev: Rev) -> bool {
-        use gix::revision::spec::parse::single::Error;
         let rev = rev.to_string();
         let rev = rev.as_bytes();
-        match self.repo.rev_parse_single(rev) {
-            Ok(_) => true,
-            Err(Error::RangedRev { .. }) => false,
-            Err(err) => unreachable!("{err:?}"),
-        }
+        self.repo.rev_parse_single(rev).is_ok()
     }
 
     #[tracing::instrument(level = "trace")]


### PR DESCRIPTION
commit-id:9f949bd5

---

**Stack**:
- #778
- #777
- #775
- #774 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*