### PR TITLE
Initial implementation of `RegistrySource`

### DIFF
--- a/scarb/src/core/registry/client/local.rs
+++ b/scarb/src/core/registry/client/local.rs
@@ -1,0 +1,114 @@
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use anyhow::{ensure, Result};
+use async_trait::async_trait;
+use tokio::task::spawn_blocking;
+use url::Url;
+
+use crate::core::registry::client::RegistryClient;
+use crate::core::registry::index::{IndexRecords, TemplateUrl};
+use crate::core::{PackageId, PackageName};
+use crate::internal::fsx;
+
+/// Local registry that lives on the filesystem as a set of `.tar.zst` files with an `index`
+/// directory in the standard registry index format.
+///
+/// ## Filesystem hierarchy
+///
+/// Here is an example layout of a local registry on a local filesystem:
+///
+/// ```text
+/// [registry root]/
+/// ├── index/                              # registry index
+/// │  ├── al/
+/// │  │  └── ex/
+/// │  │     ├── alexandria_ascii.json
+/// │  │     └── alexandria_math.json
+/// │  ├── ca/
+/// │  │  └── ir/
+/// │  │     └── cairo_lib.json
+/// │  └── op/
+/// │     └── en/
+/// │        └── open_zeppelin.json
+/// ├── alexandria_ascii-0.1.0.tar.zst      # pre-downloaded package tarballs
+/// ├── alexandria_math-0.1.0.tar.zst
+/// ├── cairo_lib-0.2.0.tar.zst
+/// └── open_zeppelin-0.7.0.tar.zst
+/// ```
+pub struct LocalRegistryClient {
+    index_template_url: TemplateUrl,
+    dl_template_url: TemplateUrl,
+}
+
+impl LocalRegistryClient {
+    pub fn new(root: &Path) -> Result<Self> {
+        // NOTE: If we'd put this check after canonicalization, the latter would fail with IO error
+        // on Linux, making this logic non-deterministic from tests point of view.
+        ensure!(
+            root.is_dir(),
+            "local registry path is not a directory: {}",
+            root.display()
+        );
+
+        let root = fsx::canonicalize(root)?;
+
+        let root_url = Url::from_directory_path(root)
+            .expect("Canonical path should always be convertible to URL.");
+
+        let index_template_url =
+            TemplateUrl::new(&format!("{root_url}index/{{prefix}}/{{package}}.json"));
+
+        let dl_template_url =
+            TemplateUrl::new(&format!("{root_url}{{package}}-{{version}}.tar.zst"));
+
+        Ok(Self {
+            index_template_url,
+            dl_template_url,
+        })
+    }
+}
+
+#[async_trait]
+impl RegistryClient for LocalRegistryClient {
+    fn is_offline(&self) -> bool {
+        true
+    }
+
+    #[tracing::instrument(level = "trace", skip(self))]
+    async fn get_records(&self, package: PackageName) -> Result<Option<Arc<IndexRecords>>> {
+        let records_path = self
+            .index_template_url
+            .expand(package.into())?
+            .to_file_path()
+            .expect("Local index should always use file:// URLs.");
+
+        spawn_blocking(move || {
+            let records = match fsx::read(records_path) {
+                Err(e)
+                    if e.downcast_ref::<io::Error>()
+                        .map_or(false, |ioe| ioe.kind() == io::ErrorKind::NotFound) =>
+                {
+                    return Ok(None);
+                }
+                r => r?,
+            };
+            let records = serde_json::from_slice(&records)?;
+            Ok(Some(Arc::new(records)))
+        })
+        .await?
+    }
+
+    async fn is_downloaded(&self, _package: PackageId) -> bool {
+        true
+    }
+
+    async fn download(&self, package: PackageId) -> Result<PathBuf> {
+        Ok(self
+            .dl_template_url
+            .expand(package.into())?
+            .to_file_path()
+            .expect("Local index should always use file:// URLs."))
+    }
+}

--- a/scarb/src/core/registry/client/mod.rs
+++ b/scarb/src/core/registry/client/mod.rs
@@ -1,0 +1,46 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+
+use crate::core::registry::index::IndexRecords;
+use crate::core::{PackageId, PackageName};
+
+pub mod local;
+
+#[async_trait]
+pub trait RegistryClient: Send + Sync {
+    /// State whether this registry works in offline mode.
+    ///
+    /// Local registries are expected to perform immediate file operations, while remote registries
+    /// can take some IO-bound time. This flag also influences appearance of various UI elements.
+    fn is_offline(&self) -> bool;
+
+    /// Get the index record for a specific named package from this index.
+    ///
+    /// Returns `None` if the package is not present in the index.
+    ///
+    /// ## Caching
+    ///
+    /// This method is not expected to internally cache the result, but it is not prohibited either.
+    /// Scarb applies specialized caching layers on top of clients.
+    async fn get_records(&self, package: PackageName) -> Result<Option<Arc<IndexRecords>>>;
+
+    /// Check if the package `.tar.zst` file has already been downloaded and is stored on disk.
+    ///
+    /// On internal errors, this method should return `false`. This method must not perform any
+    /// network operations (it can be called before offline mode check).
+    async fn is_downloaded(&self, package: PackageId) -> bool;
+
+    /// Download the package `.tar.zst` file.
+    ///
+    /// Returns a [`PathBuf`] to the downloaded `.tar.zst` file.
+    ///
+    /// ## Caching
+    ///
+    /// If the registry is remote, i.e. actually downloads files and writes them to disk,
+    /// it should write downloaded files to Scarb cache directory. If the file has already been
+    /// downloaded, it should avoid downloading it again, and read it from this cache instead.
+    async fn download(&self, package: PackageId) -> Result<PathBuf>;
+}

--- a/scarb/src/core/registry/index/mod.rs
+++ b/scarb/src/core/registry/index/mod.rs
@@ -1,6 +1,3 @@
-// FIXME(mkaput): Remove this when we will indeed use this.
-#![allow(unused)]
-
 pub use base_url::*;
 pub use config::*;
 pub use record::*;

--- a/scarb/src/core/registry/mod.rs
+++ b/scarb/src/core/registry/mod.rs
@@ -4,7 +4,9 @@ use async_trait::async_trait;
 use crate::core::{ManifestDependency, Package, PackageId, Summary};
 
 pub mod cache;
+pub mod client;
 pub mod index;
+pub mod package_source_store;
 pub mod patch_map;
 pub mod patcher;
 pub mod source_map;

--- a/scarb/src/core/registry/package_source_store.rs
+++ b/scarb/src/core/registry/package_source_store.rs
@@ -1,0 +1,105 @@
+use anyhow::{ensure, Context, Result};
+use camino::Utf8PathBuf;
+use std::path::PathBuf;
+use tokio::task::spawn_blocking;
+use tracing::{debug, trace};
+
+use crate::core::{Config, PackageId, SourceId};
+use crate::flock::{protected_run_if_not_ok, Filesystem, OK_FILE};
+use crate::internal::fsx;
+use crate::internal::fsx::PathUtf8Ext;
+use crate::internal::restricted_names::is_windows_restricted_path;
+
+pub struct PackageSourceStore<'a> {
+    fs: Filesystem<'a>,
+    config: &'a Config,
+}
+
+impl<'a> PackageSourceStore<'a> {
+    pub fn new(source: SourceId, config: &'a Config) -> Self {
+        let fs = config
+            .dirs()
+            .registry_dir()
+            .into_child("src")
+            .into_child(source.ident());
+        Self { fs, config }
+    }
+
+    /// Extract a downloaded package archive into a location where it is ready to be compiled.
+    ///
+    /// No action is taken if the source looks like it's already unpacked.
+    #[tracing::instrument(level = "debug", skip_all)]
+    pub async fn extract(&self, pkg: PackageId, archive: PathBuf) -> Result<Utf8PathBuf> {
+        trace!("attempting to extract `{pkg}`");
+        trace!(archive = ?archive.display());
+        self.extract_impl(pkg, archive)
+            .await
+            .with_context(|| format!("failed to extract: {pkg}"))
+    }
+
+    async fn extract_impl(&self, pkg: PackageId, archive: PathBuf) -> Result<Utf8PathBuf> {
+        let prefix = pkg.tarball_basename();
+        let fs = self.fs.child(&prefix);
+        let parent_path = self.fs.path_existent()?.to_owned();
+        let output_path = fs.path_existent()?.to_owned();
+        trace!(?output_path);
+
+        assert_eq!(parent_path.join(&prefix), output_path);
+
+        protected_run_if_not_ok!(&fs, &self.config.package_cache_lock(), {
+            debug!("starting extraction");
+
+            // Wipe anything already extracted.
+            unsafe {
+                fs.recreate()?;
+            }
+
+            spawn_blocking(move || -> Result<()> {
+                // FIXME(mkaput): Verify VERSION is 1.
+
+                let mut tar = {
+                    let file = fsx::open(archive)?;
+                    let zst = zstd::Decoder::new(file)?;
+                    // FIXME(mkaput): Protect against zip bomb attacks (https://github.com/rust-lang/cargo/pull/11337).
+                    // FIXME(mkaput): Protect against CVE-2023-38497 (https://github.com/rust-lang/cargo/pull/12443).
+                    tar::Archive::new(zst)
+                };
+
+                for entry in tar.entries()? {
+                    let mut entry = entry.with_context(|| "failed to iterate over archive")?;
+                    let entry_path = entry
+                        .path()
+                        .with_context(|| "failed to read entry path")?
+                        .try_to_utf8()?;
+
+                    // Ensure extracting will not accidentally or maliciously overwrite files
+                    // outside extraction directory.
+                    ensure!(
+                        entry_path.starts_with(&prefix),
+                        "invalid package tarball, contains a file {entry_path} \
+                        which is not under {prefix}"
+                    );
+
+                    // Prevent unpacking OK-file.
+                    if entry_path.file_name().unwrap_or_default() == OK_FILE {
+                        continue;
+                    }
+
+                    let mut r = entry.unpack_in(&parent_path).map_err(anyhow::Error::from);
+
+                    if cfg!(windows) && is_windows_restricted_path(entry_path.as_std_path()) {
+                        r = r.context("path contains Windows restricted file name");
+                    }
+
+                    r.with_context(|| format!("failed to extract: {entry_path}"))?;
+                }
+
+                Ok(())
+            })
+            .await??;
+        });
+
+        trace!("extraction succeeded");
+        Ok(output_path)
+    }
+}

--- a/scarb/src/core/registry/source_map.rs
+++ b/scarb/src/core/registry/source_map.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use async_trait::async_trait;
 use itertools::Itertools;
 use tokio::sync::RwLock;
@@ -47,7 +47,9 @@ impl<'c> SourceMap<'c> {
             Ok(source)
         } else {
             trace!("loading source: {source_id}");
-            let source = source_id.load(self.config)?;
+            let source = source_id
+                .load(self.config)
+                .with_context(|| format!("failed to load source: {source_id}"))?;
             self.sources.write().await.insert(source_id, source.clone());
             Ok(source)
         }

--- a/scarb/src/flock.rs
+++ b/scarb/src/flock.rs
@@ -16,7 +16,7 @@ use crate::internal::fsx;
 use crate::internal::fsx::PathUtf8Ext;
 use crate::internal::lazy_directory_creator::LazyDirectoryCreator;
 
-const OK_FILE: &str = ".scarb-ok";
+pub const OK_FILE: &str = ".scarb-ok";
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum FileLockKind {

--- a/scarb/src/internal/fsx.rs
+++ b/scarb/src/internal/fsx.rs
@@ -55,12 +55,30 @@ pub fn write(path: impl AsRef<Path>, contents: impl AsRef<[u8]>) -> Result<()> {
     }
 }
 
+/// Equivalent to [`File::open`] with better error messages.
+pub fn open(path: impl AsRef<Path>) -> Result<File> {
+    return inner(path.as_ref());
+
+    fn inner(path: &Path) -> Result<File> {
+        File::open(path).with_context(|| format!("failed to open `{}`", path.display()))
+    }
+}
+
 /// Equivalent to [`File::create`] with better error messages.
 pub fn create(path: impl AsRef<Path>) -> Result<File> {
     return inner(path.as_ref());
 
     fn inner(path: &Path) -> Result<File> {
         File::create(path).with_context(|| format!("failed to create `{}`", path.display()))
+    }
+}
+
+/// Equivalent to [`fs::read`] with better error messages.
+pub fn read(path: impl AsRef<Path>) -> Result<Vec<u8>> {
+    return inner(path.as_ref());
+
+    fn inner(path: &Path) -> Result<Vec<u8>> {
+        fs::read(path).with_context(|| format!("failed to read `{}`", path.display()))
     }
 }
 

--- a/scarb/src/sources/mod.rs
+++ b/scarb/src/sources/mod.rs
@@ -1,7 +1,9 @@
 pub use git::*;
 pub use path::*;
+pub use registry::*;
 pub use standard_lib::*;
 
 mod git;
 mod path;
+mod registry;
 mod standard_lib;

--- a/scarb/src/sources/registry.rs
+++ b/scarb/src/sources/registry.rs
@@ -1,0 +1,168 @@
+use std::collections::HashSet;
+use std::fmt;
+use std::path::PathBuf;
+
+use anyhow::{bail, ensure, Context, Result};
+use async_trait::async_trait;
+
+use scarb_ui::components::Status;
+
+use crate::core::registry::client::local::LocalRegistryClient;
+use crate::core::registry::client::RegistryClient;
+use crate::core::registry::index::IndexRecord;
+use crate::core::registry::package_source_store::PackageSourceStore;
+use crate::core::source::Source;
+use crate::core::{
+    Config, DependencyVersionReq, ManifestDependency, Package, PackageId, SourceId, Summary,
+    TargetKind,
+};
+use crate::sources::PathSource;
+
+pub struct RegistrySource<'c> {
+    source_id: SourceId,
+    config: &'c Config,
+    client: Box<dyn RegistryClient + 'c>,
+    package_sources: PackageSourceStore<'c>,
+}
+
+impl<'c> RegistrySource<'c> {
+    pub fn new(source_id: SourceId, config: &'c Config) -> Result<Self> {
+        let client = if let Ok(path) = source_id.url.to_file_path() {
+            Box::new(LocalRegistryClient::new(&path)?)
+        } else {
+            // TODO(mkaput): Implement pipelining HTTP client.
+            bail!("unsupported registry protocol: {source_id}")
+        };
+
+        // TODO(mkaput): Wrap remote clients in a disk caching layer.
+        // TODO(mkaput): Wrap all clients in an in-memory caching layer.
+
+        let package_sources = PackageSourceStore::new(source_id, config);
+
+        Ok(Self {
+            source_id,
+            config,
+            client,
+            package_sources,
+        })
+    }
+}
+
+#[async_trait]
+impl<'c> Source for RegistrySource<'c> {
+    #[tracing::instrument(level = "trace", skip(self))]
+    async fn query(&self, dependency: &ManifestDependency) -> Result<Vec<Summary>> {
+        let Some(records) = self
+            .client
+            .get_records(dependency.name.clone())
+            .await
+            .with_context(|| {
+                format!(
+                    "failed to lookup for `{dependency}` in registry: {}",
+                    self.source_id
+                )
+            })?
+        else {
+            bail!("package not found in registry: {dependency}");
+        };
+
+        let build_summary_from_index_record = |record: &IndexRecord| {
+            let package_id = PackageId::new(
+                dependency.name.clone(),
+                record.version.clone(),
+                self.source_id,
+            );
+
+            let dependencies = record
+                .dependencies
+                .iter()
+                .map(|index_dep| {
+                    ManifestDependency::builder()
+                        .name(index_dep.name.clone())
+                        .version_req(DependencyVersionReq::from(index_dep.req.clone()))
+                        .source_id(self.source_id)
+                        .build()
+                })
+                .collect();
+
+            Summary::builder()
+                .package_id(package_id)
+                .dependencies(dependencies)
+                .target_kinds(HashSet::from_iter([TargetKind::LIB]))
+                .no_core(record.no_core)
+                .build()
+        };
+
+        // TODO(mkaput): Save checksums out-of-band for later use.
+
+        Ok(records
+            .iter()
+            // NOTE: We filter based on IndexRecords here, to avoid unnecessarily allocating
+            //   PackageIds just to abandon them soon after.
+            .filter(|record| dependency.version_req.matches(&record.version))
+            .map(build_summary_from_index_record)
+            .collect())
+    }
+
+    #[tracing::instrument(level = "trace", skip(self))]
+    async fn download(&self, id: PackageId) -> Result<Package> {
+        let is_downloaded = self.client.is_downloaded(id).await;
+
+        ensure!(
+            self.config.network_allowed() || self.client.is_offline() || is_downloaded,
+            "cannot download from `{}` in offline mode",
+            self.source_id
+        );
+
+        if !is_downloaded && !self.client.is_offline() {
+            self.config
+                .ui()
+                .print(Status::new("Downloading", &id.to_string()));
+        }
+
+        let archive = self.client.download(id).await?;
+
+        self.verify_checksum(id, archive.clone()).await?;
+        self.load_package(id, archive).await
+    }
+}
+
+impl<'c> RegistrySource<'c> {
+    async fn verify_checksum(&self, id: PackageId, _archive: PathBuf) -> Result<()> {
+        self.config
+            .ui()
+            .verbose(Status::new("Verifying", &id.to_string()));
+
+        // TODO(mkaput): Verify checksum.
+
+        Ok(())
+    }
+
+    /// Turn the downloaded `.tar.zst` tarball into a [`Package`].
+    ///
+    /// This method extracts the tarball into cache directory, and then loads it using
+    /// suitably configured [`PathSource`].
+    async fn load_package(&self, id: PackageId, archive: PathBuf) -> Result<Package> {
+        if self.client.is_offline() {
+            self.config
+                .ui()
+                .print(Status::new("Unpacking", &id.to_string()));
+        } else {
+            self.config
+                .ui()
+                .verbose(Status::new("Unpacking", &id.to_string()));
+        }
+
+        let path = self.package_sources.extract(id, archive).await?;
+        let path_source = PathSource::recursive_at(&path, self.source_id, self.config);
+        path_source.download(id).await
+    }
+}
+
+impl<'c> fmt::Debug for RegistrySource<'c> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RegistrySource")
+            .field("source", &self.source_id.to_string())
+            .finish_non_exhaustive()
+    }
+}

--- a/utils/scarb-test-support/src/project_builder.rs
+++ b/utils/scarb-test-support/src/project_builder.rs
@@ -146,6 +146,10 @@ pub trait DepBuilder {
     fn path(&self, path: impl ToString) -> DepWith<'_, Self> {
         self.with("path", path.to_string())
     }
+
+    fn registry(&self, registry: impl ToString) -> DepWith<'_, Self> {
+        self.with("registry", registry.to_string())
+    }
 }
 
 pub struct Dep;


### PR DESCRIPTION
This implementation focuses solely on local registries, and it has almost no security.

---

**Stack**:
- #819
- #818
- #809
- #808
- #807
- #806
- #805
- #803
- #802
- #799
- #798
- #793
- #790 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*