### PR TITLE
Bring back `block_on` helper function

### DIFF
--- a/scarb/src/core/config.rs
+++ b/scarb/src/core/config.rs
@@ -338,3 +338,21 @@ impl ConfigBuilder {
         self
     }
 }
+
+pub trait GetConfig {
+    // Hide this method, so that IDEs will not be tempted to auto suggest it.
+    #[doc(hidden)]
+    fn config(&self) -> &Config;
+}
+
+impl GetConfig for Config {
+    fn config(&self) -> &Config {
+        self
+    }
+}
+
+impl<T: GetConfig> GetConfig for &T {
+    fn config(&self) -> &Config {
+        (*self).config()
+    }
+}

--- a/scarb/src/core/workspace.rs
+++ b/scarb/src/core/workspace.rs
@@ -6,7 +6,7 @@ use camino::{Utf8Path, Utf8PathBuf};
 use scarb_ui::args::PackagesSource;
 
 use crate::compiler::Profile;
-use crate::core::config::Config;
+use crate::core::config::{Config, GetConfig};
 use crate::core::package::Package;
 use crate::core::PackageId;
 use crate::flock::RootFilesystem;
@@ -207,5 +207,11 @@ impl<'c> PackagesSource for Workspace<'c> {
 
     fn runtime_manifest(&self) -> Utf8PathBuf {
         self.config.manifest_path().to_path_buf()
+    }
+}
+
+impl<'c> GetConfig for Workspace<'c> {
+    fn config(&self) -> &Config {
+        self.config()
     }
 }

--- a/scarb/src/internal/asyncx.rs
+++ b/scarb/src/internal/asyncx.rs
@@ -1,0 +1,7 @@
+use std::future::Future;
+
+use crate::core::config::GetConfig;
+
+pub fn block_on<F: Future>(config: impl GetConfig, future: F) -> F::Output {
+    config.config().tokio_handle().block_on(future)
+}

--- a/scarb/src/internal/mod.rs
+++ b/scarb/src/internal/mod.rs
@@ -1,4 +1,5 @@
 pub mod async_cache;
+pub mod asyncx;
 pub mod cloneable_error;
 pub mod fsx;
 pub mod lazy_directory_creator;

--- a/scarb/src/ops/cache.rs
+++ b/scarb/src/ops/cache.rs
@@ -1,15 +1,14 @@
 use anyhow::{Context, Result};
 
 use crate::core::Config;
+use crate::internal::asyncx::block_on;
 use crate::internal::fsx;
 
 #[tracing::instrument(skip_all, level = "debug")]
 pub fn cache_clean(config: &Config) -> Result<()> {
     let path = config.dirs().cache_dir.path_unchecked();
     if path.exists() {
-        let _lock = config
-            .tokio_handle()
-            .block_on(config.package_cache_lock().acquire_async())?;
+        let _lock = block_on(config, config.package_cache_lock().acquire_async())?;
         fsx::remove_dir_all(path).context("failed to clean cache")?;
     }
     Ok(())

--- a/scarb/src/ops/resolve.rs
+++ b/scarb/src/ops/resolve.rs
@@ -18,6 +18,7 @@ use crate::core::{
     DepKind, DependencyVersionReq, ManifestDependency, PackageName, SourceId, Target, TargetKind,
     TestTargetProps, TestTargetType,
 };
+use crate::internal::asyncx::block_on;
 use crate::internal::to_version::ToVersion;
 use crate::{resolver, DEFAULT_SOURCE_PATH};
 
@@ -52,7 +53,8 @@ impl WorkspaceResolve {
     fields(root = ws.root().to_string())
 )]
 pub fn resolve_workspace(ws: &Workspace<'_>) -> Result<WorkspaceResolve> {
-    ws.config().tokio_handle().block_on(
+    block_on(
+        ws,
         async {
             let mut patch_map = PatchMap::new();
 

--- a/scarb/src/ops/scripts.rs
+++ b/scarb/src/ops/scripts.rs
@@ -10,6 +10,7 @@ use deno_task_shell::{parser, ExecutableCommand, ShellCommand};
 use crate::core::errors::ScriptExecutionError;
 use crate::core::manifest::ScriptDefinition;
 use crate::core::Workspace;
+use crate::internal::asyncx::block_on;
 use crate::subcommands::get_env_vars;
 
 /// Execute user defined script.
@@ -62,13 +63,10 @@ pub fn execute_script(
         );
     }
 
-    let runtime = ws.config().tokio_handle();
-    let exit_code = runtime.block_on(deno_task_shell::execute(
-        list,
-        env_vars,
-        (&cwd).as_ref(),
-        custom_commands,
-    ));
+    let exit_code = block_on(
+        ws,
+        deno_task_shell::execute(list, env_vars, (&cwd).as_ref(), custom_commands),
+    );
 
     if exit_code != 0 {
         Err(ScriptExecutionError::new(exit_code).into())


### PR DESCRIPTION
The frequency of `ws.config().tokio_handle().block_on()` spell has increased significantly a lot, thus it makes sense to bring back this helper after months of being buried.

---

**Stack**:
- #794 ⬅
- #793
- #790
- #792
- #783
- #767


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*