### PR TITLE
Add basic tests for local registry

### DIFF
--- a/utils/scarb-test-support/src/lib.rs
+++ b/utils/scarb-test-support/src/lib.rs
@@ -6,4 +6,5 @@ pub mod fsx;
 pub mod gitx;
 pub mod manifest_edit;
 pub mod project_builder;
+pub mod registry;
 pub mod workspace_builder;

--- a/utils/scarb-test-support/src/registry/local.rs
+++ b/utils/scarb-test-support/src/registry/local.rs
@@ -1,0 +1,38 @@
+use std::fmt;
+
+use assert_fs::TempDir;
+use url::Url;
+
+use crate::command::Scarb;
+
+pub struct LocalRegistry {
+    pub t: TempDir,
+    pub url: String,
+}
+
+impl LocalRegistry {
+    pub fn create() -> Self {
+        let t = TempDir::new().unwrap();
+        let url = Url::from_directory_path(&t).unwrap().to_string();
+        Self { t, url }
+    }
+
+    pub fn publish(&mut self, f: impl FnOnce(&TempDir)) -> &mut Self {
+        let t = TempDir::new().unwrap();
+        f(&t);
+        Scarb::quick_snapbox()
+            .arg("publish")
+            .arg("--index")
+            .arg(&self.url)
+            .current_dir(&t)
+            .assert()
+            .success();
+        self
+    }
+}
+
+impl fmt::Display for LocalRegistry {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.url, f)
+    }
+}

--- a/utils/scarb-test-support/src/registry/mod.rs
+++ b/utils/scarb-test-support/src/registry/mod.rs
@@ -1,0 +1,1 @@
+pub mod local;


### PR DESCRIPTION
These tests depend on both #790 and #793, hence they come in separate PR.

---

**Stack**:
- #819
- #818
- #809
- #808
- #807
- #806
- #805
- #803
- #802
- #799
- #798 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*