### PR TITLE
Introduce `RegistryClientCache` stub

### DIFF
--- a/scarb/src/core/registry/client/cache.rs
+++ b/scarb/src/core/registry/client/cache.rs
@@ -1,0 +1,66 @@
+use std::path::PathBuf;
+
+use anyhow::{bail, Result};
+use tracing::trace;
+
+use crate::core::registry::client::{RegistryClient, RegistryResource};
+use crate::core::registry::index::IndexRecords;
+use crate::core::{Config, ManifestDependency, PackageId};
+
+pub struct RegistryClientCache<'c> {
+    client: Box<dyn RegistryClient + 'c>,
+    _config: &'c Config,
+}
+
+impl<'c> RegistryClientCache<'c> {
+    pub fn new(client: Box<dyn RegistryClient + 'c>, config: &'c Config) -> Result<Self> {
+        Ok(Self {
+            client,
+            _config: config,
+        })
+    }
+
+    /// Layer over [`RegistryClient::get_records`] that caches the result.
+    ///
+    /// It takes [`ManifestDependency`] instead of [`PackageName`] to allow performing some
+    /// optimizations by pre-filtering index records on cache-level.
+    #[tracing::instrument(level = "trace", skip_all)]
+    pub async fn get_records_with_cache(
+        &self,
+        dependency: &ManifestDependency,
+    ) -> Result<IndexRecords> {
+        match self.client.get_records(dependency.name.clone()).await? {
+            RegistryResource::NotFound => {
+                trace!("package not found in registry, pruning cache");
+                bail!("package not found in registry: {dependency}")
+            }
+            RegistryResource::InCache => {
+                trace!("getting records from cache");
+                todo!()
+            }
+            RegistryResource::Download { resource, .. } => {
+                trace!("got new records, invalidating cache");
+                Ok(resource)
+            }
+        }
+    }
+
+    /// Layer over [`RegistryClient::download`] that caches the result.
+    #[tracing::instrument(level = "trace", skip_all)]
+    pub async fn download_with_cache(&self, package: PackageId) -> Result<PathBuf> {
+        match self.client.download(package).await? {
+            RegistryResource::NotFound => {
+                trace!("archive not found in registry, pruning cache");
+                bail!("could not find downloadable archive for package indexed in registry: {package}")
+            }
+            RegistryResource::InCache => {
+                trace!("using cached archive");
+                todo!()
+            }
+            RegistryResource::Download { resource, .. } => {
+                trace!("got new archive, invalidating cache");
+                Ok(resource)
+            }
+        }
+    }
+}

--- a/scarb/src/core/registry/client/mod.rs
+++ b/scarb/src/core/registry/client/mod.rs
@@ -1,5 +1,4 @@
 use std::path::PathBuf;
-use std::sync::Arc;
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -8,17 +7,29 @@ use crate::core::registry::index::IndexRecords;
 use crate::core::{Package, PackageId, PackageName};
 use crate::flock::FileLockGuard;
 
+pub mod cache;
 pub mod http;
 pub mod local;
 
+/// Result from loading data from a registry.
+pub enum RegistryResource<T> {
+    /// The requested resource was not found.
+    NotFound,
+    /// The cache is valid and the cached data should be used.
+    #[allow(dead_code)]
+    InCache,
+    /// The cache is out of date, new data was downloaded and should be used from now on.
+    Download {
+        resource: T,
+        /// Client-dependent opaque value used to determine whether resource is out of date.
+        ///
+        /// Returning `None` means that this client/resource is not cacheable.
+        cache_key: Option<String>,
+    },
+}
+
 #[async_trait]
 pub trait RegistryClient: Send + Sync {
-    /// State whether this registry works in offline mode.
-    ///
-    /// Local registries are expected to perform immediate file operations, while remote registries
-    /// can take some IO-bound time. This flag also influences appearance of various UI elements.
-    fn is_offline(&self) -> bool;
-
     /// Get the index record for a specific named package from this index.
     ///
     /// Returns `None` if the package is not present in the index.
@@ -27,13 +38,7 @@ pub trait RegistryClient: Send + Sync {
     ///
     /// This method is not expected to internally cache the result, but it is not prohibited either.
     /// Scarb applies specialized caching layers on top of clients.
-    async fn get_records(&self, package: PackageName) -> Result<Option<Arc<IndexRecords>>>;
-
-    /// Check if the package `.tar.zst` file has already been downloaded and is stored on disk.
-    ///
-    /// On internal errors, this method should return `false`. This method must not perform any
-    /// network operations (it can be called before offline mode check).
-    async fn is_downloaded(&self, package: PackageId) -> bool;
+    async fn get_records(&self, package: PackageName) -> Result<RegistryResource<IndexRecords>>;
 
     /// Download the package `.tar.zst` file.
     ///
@@ -41,10 +46,9 @@ pub trait RegistryClient: Send + Sync {
     ///
     /// ## Caching
     ///
-    /// If the registry is remote, i.e. actually downloads files and writes them to disk,
-    /// it should write downloaded files to Scarb cache directory. If the file has already been
-    /// downloaded, it should avoid downloading it again, and read it from this cache instead.
-    async fn download(&self, package: PackageId) -> Result<PathBuf>;
+    /// This method is not expected to internally cache the result, but it is not prohibited either.
+    /// Scarb applies specialized caching layers on top of clients.
+    async fn download(&self, package: PackageId) -> Result<RegistryResource<PathBuf>>;
 
     /// State whether packages can be published to this registry.
     ///

--- a/scarb/src/sources/registry.rs
+++ b/scarb/src/sources/registry.rs
@@ -2,12 +2,13 @@ use std::collections::HashSet;
 use std::fmt;
 use std::path::PathBuf;
 
-use anyhow::{anyhow, bail, ensure, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use async_trait::async_trait;
 use tracing::trace;
 
 use scarb_ui::components::Status;
 
+use crate::core::registry::client::cache::RegistryClientCache;
 use crate::core::registry::client::http::HttpRegistryClient;
 use crate::core::registry::client::local::LocalRegistryClient;
 use crate::core::registry::client::RegistryClient;
@@ -23,16 +24,14 @@ use crate::sources::PathSource;
 pub struct RegistrySource<'c> {
     source_id: SourceId,
     config: &'c Config,
-    client: Box<dyn RegistryClient + 'c>,
+    client: RegistryClientCache<'c>,
     package_sources: PackageSourceStore<'c>,
 }
 
 impl<'c> RegistrySource<'c> {
     pub fn new(source_id: SourceId, config: &'c Config) -> Result<Self> {
         let client = Self::create_client(source_id, config)?;
-
-        // TODO(mkaput): Wrap remote clients in a disk caching layer.
-        // TODO(mkaput): Wrap all clients in an in-memory caching layer.
+        let client = RegistryClientCache::new(client, config)?;
 
         let package_sources = PackageSourceStore::new(source_id, config);
 
@@ -73,19 +72,16 @@ impl<'c> RegistrySource<'c> {
 impl<'c> Source for RegistrySource<'c> {
     #[tracing::instrument(level = "trace", skip(self))]
     async fn query(&self, dependency: &ManifestDependency) -> Result<Vec<Summary>> {
-        let Some(records) = self
+        let records = self
             .client
-            .get_records(dependency.name.clone())
+            .get_records_with_cache(dependency)
             .await
             .with_context(|| {
                 format!(
                     "failed to lookup for `{dependency}` in registry: {}",
                     self.source_id
                 )
-            })?
-        else {
-            bail!("package not found in registry: {dependency}");
-        };
+            })?;
 
         let build_summary_from_index_record = |record: &IndexRecord| {
             let package_id = PackageId::new(
@@ -120,6 +116,8 @@ impl<'c> Source for RegistrySource<'c> {
             .iter()
             // NOTE: We filter based on IndexRecords here, to avoid unnecessarily allocating
             //   PackageIds just to abandon them soon after.
+            // NOTE: Technically, RegistryClientCache may already have filtered the records,
+            //   but it is not required to do so, so we do it here again as a safety measure.
             .filter(|record| dependency.version_req.matches(&record.version))
             .map(build_summary_from_index_record)
             .collect())
@@ -127,21 +125,11 @@ impl<'c> Source for RegistrySource<'c> {
 
     #[tracing::instrument(level = "trace", skip(self))]
     async fn download(&self, id: PackageId) -> Result<Package> {
-        let is_downloaded = self.client.is_downloaded(id).await;
-
-        ensure!(
-            self.config.network_allowed() || self.client.is_offline() || is_downloaded,
-            "cannot download from `{}` in offline mode",
-            self.source_id
-        );
-
-        if !is_downloaded && !self.client.is_offline() {
-            self.config
-                .ui()
-                .print(Status::new("Downloading", &id.to_string()));
-        }
-
-        let archive = self.client.download(id).await?;
+        let archive = self
+            .client
+            .download_with_cache(id)
+            .await
+            .with_context(|| format!("failed to download package: {id}"))?;
 
         self.verify_checksum(id, archive.clone()).await?;
         self.load_package(id, archive).await
@@ -164,15 +152,9 @@ impl<'c> RegistrySource<'c> {
     /// This method extracts the tarball into cache directory, and then loads it using
     /// suitably configured [`PathSource`].
     async fn load_package(&self, id: PackageId, archive: PathBuf) -> Result<Package> {
-        if self.client.is_offline() {
-            self.config
-                .ui()
-                .print(Status::new("Unpacking", &id.to_string()));
-        } else {
-            self.config
-                .ui()
-                .verbose(Status::new("Unpacking", &id.to_string()));
-        }
+        self.config
+            .ui()
+            .verbose(Status::new("Unpacking", &id.to_string()));
 
         let path = self.package_sources.extract(id, archive).await?;
         let path_source = PathSource::recursive_at(&path, self.source_id, self.config);

--- a/scarb/tests/http_registry.rs
+++ b/scarb/tests/http_registry.rs
@@ -66,7 +66,10 @@ fn not_found() {
         .assert()
         .failure()
         .stdout_matches(indoc! {r#"
-        error: package not found in registry: baz ^1 (registry+http://[..])
+        error: failed to lookup for `baz ^1 (registry+http://[..])` in registry: registry+http://[..]
+
+        Caused by:
+            package not found in registry: baz ^1 (registry+http://[..])
         "#});
 }
 

--- a/scarb/tests/local_registry.rs
+++ b/scarb/tests/local_registry.rs
@@ -34,9 +34,7 @@ fn usage() {
         .current_dir(&t)
         .assert()
         .success()
-        .stdout_matches(indoc! {r#"
-        [..] Unpacking bar v1.0.0 ([..])
-        "#});
+        .stdout_eq("");
 }
 
 #[test]
@@ -65,7 +63,10 @@ fn not_found() {
         .assert()
         .failure()
         .stdout_matches(indoc! {r#"
-        error: package not found in registry: baz ^1 (registry+file://[..])
+        error: failed to lookup for `baz ^1 (registry+file://[..])` in registry: registry+file://[..]
+
+        Caused by:
+            package not found in registry: baz ^1 (registry+file://[..])
         "#});
 }
 
@@ -89,7 +90,10 @@ fn empty_registry() {
         .assert()
         .failure()
         .stdout_matches(indoc! {r#"
-        error: package not found in registry: baz ^1 (registry+file://[..])
+        error: failed to lookup for `baz ^1 (registry+file://[..])` in registry: registry+file://[..]
+
+        Caused by:
+            package not found in registry: baz ^1 (registry+file://[..])
         "#});
 }
 


### PR DESCRIPTION
This PR lays groundwork for implementing caching of `RegistryClient` instances.
It just sets up all the types and refactors, no caching is done yet.

There is also a small functional change: local registry client does not print
`Unpacking` status in normal mode. This wasn't a big deal, and it allowed removing
the `is_offline` method from `RegistryClient`.

---

**Stack**:
- #892
- #846
- #845
- #844
- #819
- #818
- #809
- #808 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*