### PR TITLE
Allow ignoring example project by name in test_for_each_example macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1352,8 +1352,18 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.14.4",
+ "darling_macro 0.14.4",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
+dependencies = [
+ "darling_core 0.20.3",
+ "darling_macro 0.20.3",
 ]
 
 [[package]]
@@ -1371,14 +1381,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.38",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
- "darling_core",
+ "darling_core 0.14.4",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
+dependencies = [
+ "darling_core 0.20.3",
+ "quote",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -1451,7 +1486,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
 dependencies = [
- "darling",
+ "darling 0.14.4",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -4633,6 +4668,7 @@ name = "test-for-each-example"
 version = "1.0.0"
 dependencies = [
  "camino",
+ "darling 0.20.3",
  "proc-macro2",
  "quote",
  "syn 2.0.38",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ cargo_metadata = "0.18"
 clap = { version = "4", features = ["derive", "env", "string"] }
 clap-verbosity-flag = "2"
 console = "0.15"
+darling = "0.20.3"
 data-encoding = "2"
 deno_task_shell = "0.13"
 derive_builder = "0.12"

--- a/extensions/scarb-cairo-test/tests/examples.rs
+++ b/extensions/scarb-cairo-test/tests/examples.rs
@@ -4,7 +4,8 @@ use snapbox::cmd::{cargo_bin, Command};
 
 use test_for_each_example::test_for_each_example;
 
-#[test_for_each_example]
+// TODO(maciektr): Revert ignoring the dependencies test case.
+#[test_for_each_example(ignore = "dependencies")]
 fn cairo_test(example: &Path) {
     Command::new(cargo_bin("scarb"))
         .arg("cairo-test")

--- a/utils/test-for-each-example/Cargo.toml
+++ b/utils/test-for-each-example/Cargo.toml
@@ -9,6 +9,7 @@ proc-macro = true
 
 [dependencies]
 camino.workspace = true
+darling.workspace = true
 proc-macro2.workspace = true
 quote.workspace = true
 syn = { workspace = true, features = ["full", "extra-traits"] }

--- a/utils/test-for-each-example/src/lib.rs
+++ b/utils/test-for-each-example/src/lib.rs
@@ -2,13 +2,46 @@ use proc_macro::TokenStream;
 use std::path::Path;
 
 use camino::Utf8PathBuf;
+use darling::ast::NestedMeta;
+use darling::{Error, FromMeta};
 use proc_macro2::{Ident, Span};
 use quote::quote;
 use syn::{parse_macro_input, parse_quote, ItemFn};
 
+#[derive(Debug, FromMeta)]
+struct TestForEachArgs {
+    #[darling(default)]
+    /// Comma-separated list of example project dir names to ignore.
+    ignore: Option<String>,
+}
+
 #[proc_macro_attribute]
-pub fn test_for_each_example(_args: TokenStream, input: TokenStream) -> TokenStream {
+pub fn test_for_each_example(args: TokenStream, input: TokenStream) -> TokenStream {
     let mut item: ItemFn = parse_macro_input!(input as ItemFn);
+
+    let attr_args = match NestedMeta::parse_meta_list(args.into()) {
+        Ok(v) => v,
+        Err(e) => {
+            return TokenStream::from(Error::from(e).write_errors());
+        }
+    };
+
+    let args = match TestForEachArgs::from_list(&attr_args) {
+        Ok(v) => v,
+        Err(e) => {
+            return TokenStream::from(e.write_errors());
+        }
+    };
+
+    let ignored = args
+        .ignore
+        .map(|ignore| {
+            ignore
+                .split(',')
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or(vec![]);
 
     let examples_dir_path = Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()
@@ -35,9 +68,16 @@ pub fn test_for_each_example(_args: TokenStream, input: TokenStream) -> TokenStr
 
             let example_name = Ident::new(example_path.file_name().unwrap(), Span::call_site());
 
+            let ignore_attr = if ignored.contains(&example_name.to_string()) {
+                quote!(#[ignore = "test ignored by example name"])
+            } else {
+                quote!()
+            };
+
             let example_path = example_path.as_str();
 
             let test = quote! {
+                #ignore_attr
                 #[::core::prelude::v1::test]
                 fn #example_name() {
                     let example_path = ::std::path::Path::new(#example_path);

--- a/utils/test-for-each-example/src/lib.rs
+++ b/utils/test-for-each-example/src/lib.rs
@@ -10,8 +10,8 @@ use syn::{parse_macro_input, parse_quote, ItemFn};
 
 #[derive(Debug, FromMeta)]
 struct TestForEachArgs {
-    #[darling(default)]
     /// Comma-separated list of example project dir names to ignore.
+    #[darling(default)]
     ignore: Option<String>,
 }
 


### PR DESCRIPTION
We fail to run cairo-test on alexandria with cairo main. This results in failed tests on https://github.com/software-mansion/scarb/pull/821

This PR adds an ignore argument on  test_for_each_example, so we can skip running cairo-test on dependencies example.