### PR TITLE
Fix nightly builds: install pre-build openssl for cross compilation

### DIFF
--- a/.github/workflows/_build-release.yml
+++ b/.github/workflows/_build-release.yml
@@ -28,9 +28,9 @@ jobs:
             # Use cross to link oldest GLIBC possible.
             cross: true
 
-          - target: x86_64-unknown-linux-musl
-            os: ubuntu-latest
-            cross: true
+          # - target: x86_64-unknown-linux-musl
+          #   os: ubuntu-latest
+          #   cross: true
 
           #- target: armv7-unknown-linux-gnueabihf
           #  os: ubuntu-latest
@@ -40,9 +40,9 @@ jobs:
             os: ubuntu-latest
             cross: true
 
-          - target: aarch64-unknown-linux-musl
-            os: ubuntu-latest
-            cross: true
+          # - target: aarch64-unknown-linux-musl
+          #   os: ubuntu-latest
+          #   cross: true
 
           - target: x86_64-apple-darwin
             os: macos-latest

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,11 @@
+[target.x86_64-unknown-linux-gnu]
+pre-build = [
+    "dpkg --add-architecture $CROSS_DEB_ARCH",
+    "apt-get update && apt-get install --assume-yes libssl-dev:$CROSS_DEB_ARCH"
+]
+
+[target.aarch64-unknown-linux-gnu]
+pre-build = [
+    "dpkg --add-architecture $CROSS_DEB_ARCH",
+    "apt-get update && apt-get install --assume-yes libssl-dev:$CROSS_DEB_ARCH"
+]


### PR DESCRIPTION
When building in release pipeline, we use `cross` for cross-compilation. This renders the `openssl-sys` dependency of `reqwest` unable to find the appropriate openssl installation in the system - as the host system has different architecture from the target one.  

Instead of relying on available openssl, this PR makes `reqwest` use vendored openssl, i.e. one build during the compilation, so it does not search the host during cross-compilation. 

See: https://github.com/cross-rs/cross/wiki/Recipes#openssl