### PR TITLE
Remove available_gas args in favour of default

### DIFF
--- a/examples/dependencies/src/lib.cairo
+++ b/examples/dependencies/src/lib.cairo
@@ -9,7 +9,6 @@ mod tests {
     use super::double_fib;
 
     #[test]
-    #[available_gas(100000)]
     fn it_works() {
         assert(double_fib(0, 1, 16) == 1974, 'it works!');
     }

--- a/examples/hello_world/src/lib.cairo
+++ b/examples/hello_world/src/lib.cairo
@@ -21,7 +21,6 @@ mod tests {
     use super::fib;
 
     #[test]
-    #[available_gas(100000)]
     fn it_works() {
         assert(fib(16) == 987, 'it works!');
     }

--- a/examples/starknet_hello_world/tests/contract_test.cairo
+++ b/examples/starknet_hello_world/tests/contract_test.cairo
@@ -12,7 +12,6 @@ mod tests {
     use starknet_hello_world::{Balance, IBalance, IBalanceDispatcher, IBalanceDispatcherTrait};
 
     #[test]
-    #[available_gas(30000000)]
     fn test_flow() {
         let calldata = array![100];
         let (address0, _) = deploy_syscall(

--- a/examples/workspaces/crates/addition/src/lib.cairo
+++ b/examples/workspaces/crates/addition/src/lib.cairo
@@ -7,7 +7,6 @@ mod tests {
     use super::add;
 
     #[test]
-    #[available_gas(100000)]
     fn it_works() {
         assert(add(2, 3) == 5, 'it works!');
     }

--- a/examples/workspaces/crates/fibonacci/src/lib.cairo
+++ b/examples/workspaces/crates/fibonacci/src/lib.cairo
@@ -12,7 +12,6 @@ mod tests {
     use super::fib;
 
     #[test]
-    #[available_gas(100000)]
     fn it_works() {
         assert(fib(0, 1, 16) == 987, 'it works!');
     }

--- a/scarb/src/ops/new.rs
+++ b/scarb/src/ops/new.rs
@@ -176,7 +176,6 @@ fn mk(
                     use super::fib;
 
                     #[test]
-                    #[available_gas(100000)]
                     fn it_works() {
                         assert(fib(16) == 987, 'it works!');
                     }

--- a/scarb/tests/build.rs
+++ b/scarb/tests/build.rs
@@ -564,7 +564,6 @@ fn workspace_as_dep() {
             use super::fib;
 
             #[test]
-            #[available_gas(100000)]
             fn it_works() {
                 assert(fib(0, 1, 16) == 987, 'it works!');
             }

--- a/scarb/tests/build_targets.rs
+++ b/scarb/tests/build_targets.rs
@@ -319,7 +319,6 @@ fn compile_test_target() {
         mod tests {
             use hello::f;
             #[test]
-            #[available_gas(100000)]
             fn it_works() {
                 assert(f() == 42, 'it works!');
             }


### PR DESCRIPTION
resolves #730 

We do not need to make any changes to test compilation, as it is handled down the test-plugin which we import.  