### PR TITLE
chore: minor optimisation

### DIFF
--- a/extensions/scarb-cairo-test/src/main.rs
+++ b/extensions/scarb-cairo-test/src/main.rs
@@ -5,9 +5,7 @@ use cairo_lang_test_plugin::TestCompilation;
 use cairo_lang_test_runner::{CompiledTestRunner, TestRunConfig};
 use clap::Parser;
 
-use scarb_metadata::{
-    Metadata, MetadataCommand, PackageId, PackageMetadata, ScarbCommand, TargetMetadata,
-};
+use scarb_metadata::{Metadata, MetadataCommand, PackageMetadata, ScarbCommand, TargetMetadata};
 use scarb_ui::args::PackagesFilter;
 
 /// Execute all unit tests of a local package.

--- a/extensions/scarb-cairo-test/src/main.rs
+++ b/extensions/scarb-cairo-test/src/main.rs
@@ -5,7 +5,9 @@ use cairo_lang_test_plugin::TestCompilation;
 use cairo_lang_test_runner::{CompiledTestRunner, TestRunConfig};
 use clap::Parser;
 
-use scarb_metadata::{Metadata, MetadataCommand, PackageId, ScarbCommand, TargetMetadata};
+use scarb_metadata::{
+    Metadata, MetadataCommand, PackageId, PackageMetadata, ScarbCommand, TargetMetadata,
+};
 use scarb_ui::args::PackagesFilter;
 
 /// Execute all unit tests of a local package.
@@ -54,7 +56,7 @@ fn main() -> Result<()> {
     for package in matched {
         println!("testing {} ...", package.name);
 
-        for target in find_testable_targets(&metadata, &package.id) {
+        for target in find_testable_targets(&package) {
             let file_path = target_dir.join(format!("{}.test.json", target.name.clone()));
             let test_compilation = serde_json::from_str::<TestCompilation>(
                 &fs::read_to_string(file_path.clone())
@@ -76,12 +78,10 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-fn find_testable_targets(metadata: &Metadata, package_id: &PackageId) -> Vec<TargetMetadata> {
-    metadata
-        .packages
+fn find_testable_targets(package: &PackageMetadata) -> Vec<&TargetMetadata> {
+    package
+        .targets
         .iter()
-        .filter(|package| package.id == *package_id)
-        .flat_map(|package| package.targets.clone())
         .filter(|target| target.kind == "test")
         .collect()
 }


### PR DESCRIPTION
Here's an overview of changes as a diff...

```diff
fn find_testable_targets(...) {
-   Take metadata and of the package id.
+   Take package metadata
-   Loop through packages in metadata
-   Filter packages with ID matching package id.
-   Flat map and clone targets of the matching package(s?)
+   Get targets of the package
    Filter the test kind
-   Return vec of TargetMetadata
+   Return vec of &TargetMetadata
}
```