### PR TITLE
Impl `Clone` for `Filesystem`

### DIFF
--- a/scarb/src/compiler/compilation_unit.rs
+++ b/scarb/src/compiler/compilation_unit.rs
@@ -77,7 +77,7 @@ impl CompilationUnit {
         &self.main_component().target
     }
 
-    pub fn target_dir<'c>(&self, ws: &'c Workspace<'_>) -> Filesystem<'c> {
+    pub fn target_dir(&self, ws: &Workspace<'_>) -> Filesystem {
         ws.target_dir().child(self.profile.as_str())
     }
 

--- a/scarb/src/compiler/helpers.rs
+++ b/scarb/src/compiler/helpers.rs
@@ -46,7 +46,7 @@ pub fn collect_all_crate_ids(unit: &CompilationUnit, db: &RootDatabase) -> Vec<C
 pub fn write_json(
     file_name: &str,
     description: &str,
-    target_dir: &Filesystem<'_>,
+    target_dir: &Filesystem,
     ws: &Workspace<'_>,
     value: impl Serialize,
 ) -> Result<()> {
@@ -60,7 +60,7 @@ pub fn write_json(
 pub fn write_string(
     file_name: &str,
     description: &str,
-    target_dir: &Filesystem<'_>,
+    target_dir: &Filesystem,
     ws: &Workspace<'_>,
     value: impl ToString,
 ) -> Result<()> {

--- a/scarb/src/core/dirs.rs
+++ b/scarb/src/core/dirs.rs
@@ -7,13 +7,13 @@ use anyhow::{anyhow, Result};
 use camino::Utf8PathBuf;
 use directories::ProjectDirs;
 
-use crate::flock::{Filesystem, RootFilesystem};
+use crate::flock::Filesystem;
 use crate::internal::fsx::PathUtf8Ext;
 
 #[derive(Debug)]
 pub struct AppDirs {
-    pub cache_dir: RootFilesystem,
-    pub config_dir: RootFilesystem,
+    pub cache_dir: Filesystem,
+    pub config_dir: Filesystem,
     pub path_dirs: Vec<PathBuf>,
 }
 
@@ -57,8 +57,8 @@ impl AppDirs {
         };
 
         Ok(Self {
-            cache_dir: RootFilesystem::new_output_dir(cache_dir),
-            config_dir: RootFilesystem::new(config_dir),
+            cache_dir: Filesystem::new_output_dir(cache_dir),
+            config_dir: Filesystem::new(config_dir),
             path_dirs,
         })
     }
@@ -67,7 +67,7 @@ impl AppDirs {
         env::join_paths(self.path_dirs.iter()).unwrap()
     }
 
-    pub fn registry_dir(&self) -> Filesystem<'_> {
+    pub fn registry_dir(&self) -> Filesystem {
         self.cache_dir.child("registry")
     }
 }

--- a/scarb/src/core/registry/client/http.rs
+++ b/scarb/src/core/registry/client/http.rs
@@ -29,7 +29,7 @@ pub struct HttpRegistryClient<'c> {
     source_id: SourceId,
     config: &'c Config,
     cached_index_config: OnceCell<IndexConfig>,
-    dl_fs: Filesystem<'c>,
+    dl_fs: Filesystem,
 }
 
 enum HttpCacheKey {

--- a/scarb/src/core/registry/package_source_store.rs
+++ b/scarb/src/core/registry/package_source_store.rs
@@ -11,7 +11,7 @@ use crate::internal::fsx::PathUtf8Ext;
 use crate::internal::restricted_names::is_windows_restricted_path;
 
 pub struct PackageSourceStore<'a> {
-    fs: Filesystem<'a>,
+    fs: Filesystem,
     config: &'a Config,
 }
 

--- a/scarb/src/core/workspace.rs
+++ b/scarb/src/core/workspace.rs
@@ -10,7 +10,7 @@ use crate::compiler::Profile;
 use crate::core::config::Config;
 use crate::core::package::Package;
 use crate::core::{PackageId, Target};
-use crate::flock::RootFilesystem;
+use crate::flock::Filesystem;
 use crate::{DEFAULT_TARGET_DIR_NAME, LOCK_FILE_NAME, MANIFEST_FILE_NAME};
 
 /// The core abstraction for working with a workspace of packages.
@@ -23,7 +23,7 @@ pub struct Workspace<'c> {
     manifest_path: Utf8PathBuf,
     profiles: Vec<Profile>,
     root_package: Option<PackageId>,
-    target_dir: RootFilesystem,
+    target_dir: Filesystem,
 }
 
 impl<'c> Workspace<'c> {
@@ -50,7 +50,7 @@ impl<'c> Workspace<'c> {
                 .expect("parent of manifest path must always exist")
                 .join(DEFAULT_TARGET_DIR_NAME)
         });
-        let target_dir = RootFilesystem::new_output_dir(target_dir);
+        let target_dir = Filesystem::new_output_dir(target_dir);
         Ok(Self {
             config,
             manifest_path,
@@ -97,7 +97,7 @@ impl<'c> Workspace<'c> {
         self.root().join(LOCK_FILE_NAME)
     }
 
-    pub fn target_dir(&self) -> &RootFilesystem {
+    pub fn target_dir(&self) -> &Filesystem {
         &self.target_dir
     }
 

--- a/scarb/src/sources/git/client.rs
+++ b/scarb/src/sources/git/client.rs
@@ -110,7 +110,7 @@ impl GitRemote {
     #[tracing::instrument(level = "trace", skip(config))]
     pub fn checkout(
         &self,
-        fs: &Filesystem<'_>,
+        fs: &Filesystem,
         db: Option<GitDatabase>,
         reference: &GitReference,
         locked_rev: Option<Rev>,
@@ -155,7 +155,7 @@ impl GitRemote {
 
 impl GitDatabase {
     #[tracing::instrument(level = "trace")]
-    pub fn open(remote: &GitRemote, fs: &Filesystem<'_>) -> Result<Self> {
+    pub fn open(remote: &GitRemote, fs: &Filesystem) -> Result<Self> {
         let path = fs.path_existent()?;
         let opts = gix::open::Options::default().open_path_as_is(true);
         let repo = gix::open_opts(path, opts)?;
@@ -167,7 +167,7 @@ impl GitDatabase {
     }
 
     #[tracing::instrument(level = "trace")]
-    pub fn init_bare(remote: &GitRemote, fs: &Filesystem<'_>) -> Result<Self> {
+    pub fn init_bare(remote: &GitRemote, fs: &Filesystem) -> Result<Self> {
         let path = fs.path_existent()?;
         let repo = gix::init_bare(path)?;
         Ok(Self {
@@ -201,12 +201,7 @@ impl GitDatabase {
         exec(&mut cmd, config)
     }
 
-    pub fn copy_to(
-        &self,
-        fs: &Filesystem<'_>,
-        rev: Rev,
-        config: &Config,
-    ) -> Result<GitCheckout<'_>> {
+    pub fn copy_to(&self, fs: &Filesystem, rev: Rev, config: &Config) -> Result<GitCheckout<'_>> {
         let checkout = GitCheckout::clone(self, fs, rev, config)?;
         checkout.reset(config)?;
         Ok(checkout)
@@ -264,7 +259,7 @@ impl GitDatabase {
 
 impl<'d> GitCheckout<'d> {
     #[tracing::instrument(level = "trace", skip(config))]
-    fn clone(db: &'d GitDatabase, fs: &Filesystem<'_>, rev: Rev, config: &Config) -> Result<Self> {
+    fn clone(db: &'d GitDatabase, fs: &Filesystem, rev: Rev, config: &Config) -> Result<Self> {
         unsafe {
             fs.recreate()?;
         }

--- a/scarb/src/sources/git/mod.rs
+++ b/scarb/src/sources/git/mod.rs
@@ -99,9 +99,7 @@ impl<'c> GitSource<'c> {
 
             let git_fs = config.dirs().registry_dir().into_child("git");
 
-            let db_fs = git_fs
-                .child("db")
-                .into_child(&format!("{remote_ident}.git"));
+            let db_fs = git_fs.child("db").into_child(format!("{remote_ident}.git"));
 
             let db = GitDatabase::open(&remote, &db_fs).ok();
             let (db, actual_rev) = match (db, locked_rev) {


### PR DESCRIPTION
This surprisingly small addition required some bigger changes. Filesystems are now lifetime-unbound, and rely on internal `Arc`s instead of references. Technically this means higher heap pressure and slower code due to increased use of atomics, but `Filesystem`s are by nature not part of hot paths, so this is fine.

Signed-off-by: Marek Kaput <marek.kaput@swmansion.com>

---

**Stack**:
- #909
- #906
- #892
- #846
- #845 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*