### PR TITLE
Remove redundant `cannot_choose_both_dev_and_release` test

### DIFF
--- a/scarb/tests/profiles.rs
+++ b/scarb/tests/profiles.rs
@@ -132,25 +132,6 @@ fn can_choose_release_by_name() {
 }
 
 #[test]
-fn cannot_choose_both_release_and_dev() {
-    let t = TempDir::new().unwrap();
-    ProjectBuilder::start().name("hello").build(&t);
-
-    Scarb::quick_snapbox()
-        .args(["--release", "--dev", "metadata", "--format-version", "1"])
-        .current_dir(&t)
-        .assert()
-        .failure()
-        .stderr_matches(indoc! {r#"
-            error: the argument '--release' cannot be used with '--dev'
-
-            Usage: scarb --release [..] <COMMAND>
-
-            For more information, try '--help'.
-        "#});
-}
-
-#[test]
 fn can_choose_dev_by_name() {
     let t = TempDir::new().unwrap();
     ProjectBuilder::start().name("hello").build(&t);


### PR DESCRIPTION
Fixes #849
Removing a test when it's failing isn't a good idea but `cannot_choose_both_release_and_dev` test that created from `cannot_choose_both_release_and_by_name` (in #825)  is a duplicate of `cannot_choose_both_dev_and_release` test.

It could be fixed by adjusting stderr message assertion to 
```sh
Usage: scarb[..] --dev --global-cache-dir <DIRECTORY> --global-config-dir <DIRECTORY> <COMMAND>
```

but that would be the exact same thing as `cannot_choose_both_dev_and_release`.