### PR TITLE
feat: add emit option

### DIFF
--- a/scarb/src/bin/scarb/args.rs
+++ b/scarb/src/bin/scarb/args.rs
@@ -8,6 +8,7 @@ use std::ffi::OsString;
 use anyhow::Result;
 use camino::Utf8PathBuf;
 use clap::{CommandFactory, Parser, Subcommand};
+use scarb::ops::EmitTarget;
 use smol_str::SmolStr;
 use tracing::level_filters::LevelFilter;
 use tracing_log::AsTrace;
@@ -244,6 +245,9 @@ pub struct FmtArgs {
     /// Only check if files are formatted, do not write the changes to disk.
     #[arg(short, long, default_value_t = false)]
     pub check: bool,
+    /// Emit the formatted file to stdout
+    #[arg(short, long)]
+    pub emit: Option<EmitTarget>,
     /// Do not color output.
     #[arg(long, default_value_t = false)]
     pub no_color: bool,

--- a/scarb/src/bin/scarb/args.rs
+++ b/scarb/src/bin/scarb/args.rs
@@ -243,7 +243,7 @@ pub struct NewArgs {
 #[derive(Parser, Clone, Debug)]
 pub struct FmtArgs {
     /// Only check if files are formatted, do not write the changes to disk.
-    #[arg(short, long, default_value_t = false)]
+    #[arg(short, long, default_value_t = false, conflicts_with = "emit")]
     pub check: bool,
     /// Emit the formatted file to stdout
     #[arg(short, long)]

--- a/scarb/src/bin/scarb/commands/fmt.rs
+++ b/scarb/src/bin/scarb/commands/fmt.rs
@@ -10,7 +10,6 @@ pub fn run(args: FmtArgs, config: &Config) -> Result<()> {
     // The action the formatted should perform,
     // e.g. check formatting, format in place, or emit formatted file to stdout.
     let action = if args.check {
-        // adding the `--check` flag will shortcircuit the ability to emit the formatted file
         FmtAction::Check
     } else if let Some(emit_target) = args.emit {
         FmtAction::Emit(emit_target)

--- a/scarb/src/ops/fmt.rs
+++ b/scarb/src/ops/fmt.rs
@@ -144,13 +144,16 @@ fn check_file_formatting(
 }
 
 pub trait Emittable {
-    fn emit(&self, ws: &Workspace<'_>, formatted: &str);
+    fn emit(&self, ws: &Workspace<'_>, path: &Path, formatted: &str);
 }
 
 impl Emittable for EmitTarget {
-    fn emit(&self, ws: &Workspace<'_>, formatted: &str) {
+    fn emit(&self, ws: &Workspace<'_>, path: &Path, formatted: &str) {
         match self {
-            Self::Stdout => ws.config().ui().print(formatted),
+            Self::Stdout => ws
+                .config()
+                .ui()
+                .print(format!("{}:\n{}", path.display(), formatted)),
         }
     }
 }
@@ -164,7 +167,7 @@ fn emit_formatted_file(
     match fmt.format_to_string(&path) {
         Ok(FormatOutcome::Identical(_)) => true,
         Ok(FormatOutcome::DiffFound(diff)) => {
-            target.emit(ws, &diff.formatted);
+            target.emit(ws, path, &diff.formatted);
             false
         }
         Err(parsing_error) => {

--- a/scarb/tests/fmt.rs
+++ b/scarb/tests/fmt.rs
@@ -69,12 +69,13 @@ fn simple_emit_invalid() {
         .current_dir(&t)
         .assert()
         .failure()
-        .stdout_matches(indoc! {"\
-            fn main() -> felt252 {
-                42
-            }
-
-        "});
+        .stdout_matches(format!(
+            "{}:\n{}\n",
+            fs::canonicalize(t.child("src/lib.cairo"))
+                .unwrap()
+                .display(),
+            SIMPLE_FORMATTED
+        ));
     let content = fs::read_to_string(t.child("src/lib.cairo")).unwrap();
     assert_eq!(content, SIMPLE_ORIGINAL);
 }
@@ -336,12 +337,13 @@ fn workspace_emit_with_root() {
         .current_dir(&t)
         .assert()
         .failure()
-        .stdout_matches(indoc! {"\
-            fn main() -> felt252 {
-                42
-            }
-
-        "});
+        .stdout_matches(format!(
+            "{}:\n{}\n",
+            fs::canonicalize(t.child("src/lib.cairo"))
+                .unwrap()
+                .display(),
+            SIMPLE_FORMATTED
+        ));
 
     let content = fs::read_to_string(t.child("src/lib.cairo")).unwrap();
     assert_eq!(content, SIMPLE_ORIGINAL);
@@ -355,20 +357,21 @@ fn workspace_emit_with_root() {
         .current_dir(&t)
         .assert()
         .failure()
-        .stdout_matches(indoc! {"\
-            fn main() -> felt252 {
-                42
-            }
-
-            fn main() -> felt252 {
-                42
-            }
-
-            fn main() -> felt252 {
-                42
-            }
-
-        "});
+        .stdout_matches(format!(
+            "{}:\n{}\n{}:\n{}\n{}:\n{}\n",
+            fs::canonicalize(t.child("first/src/lib.cairo"))
+                .unwrap()
+                .display(),
+            SIMPLE_FORMATTED,
+            fs::canonicalize(t.child("second/src/lib.cairo"))
+                .unwrap()
+                .display(),
+            SIMPLE_FORMATTED,
+            fs::canonicalize(t.child("src/lib.cairo"))
+                .unwrap()
+                .display(),
+            SIMPLE_FORMATTED,
+        ));
 
     let content = fs::read_to_string(t.child("src/lib.cairo")).unwrap();
     assert_eq!(content, SIMPLE_ORIGINAL);

--- a/scarb/tests/fmt.rs
+++ b/scarb/tests/fmt.rs
@@ -5,6 +5,7 @@ use assert_fs::TempDir;
 use indoc::indoc;
 
 use scarb_test_support::command::Scarb;
+use scarb_test_support::fsx;
 use scarb_test_support::project_builder::ProjectBuilder;
 use scarb_test_support::workspace_builder::WorkspaceBuilder;
 
@@ -71,7 +72,7 @@ fn simple_emit_invalid() {
         .failure()
         .stdout_matches(format!(
             "{}:\n{}\n",
-            fs::canonicalize(t.child("src/lib.cairo"))
+            fsx::canonicalize(t.child("src/lib.cairo"))
                 .unwrap()
                 .display(),
             SIMPLE_FORMATTED
@@ -339,7 +340,7 @@ fn workspace_emit_with_root() {
         .failure()
         .stdout_matches(format!(
             "{}:\n{}\n",
-            fs::canonicalize(t.child("src/lib.cairo"))
+            fsx::canonicalize(t.child("src/lib.cairo"))
                 .unwrap()
                 .display(),
             SIMPLE_FORMATTED
@@ -359,15 +360,15 @@ fn workspace_emit_with_root() {
         .failure()
         .stdout_matches(format!(
             "{}:\n{}\n{}:\n{}\n{}:\n{}\n",
-            fs::canonicalize(t.child("first/src/lib.cairo"))
+            fsx::canonicalize(t.child("first/src/lib.cairo"))
                 .unwrap()
                 .display(),
             SIMPLE_FORMATTED,
-            fs::canonicalize(t.child("second/src/lib.cairo"))
+            fsx::canonicalize(t.child("second/src/lib.cairo"))
                 .unwrap()
                 .display(),
             SIMPLE_FORMATTED,
-            fs::canonicalize(t.child("src/lib.cairo"))
+            fsx::canonicalize(t.child("src/lib.cairo"))
                 .unwrap()
                 .display(),
             SIMPLE_FORMATTED,


### PR DESCRIPTION
- add an emit option to stdout to match some linter specs
- modify FmtAction to have an exclusive option to: fix, check or emit formatted file.
- not modify the existing flag --check for clarity, though --check and --emit flags are mutually exclusive (--check overrides --emit)


Requesting help for: getting familiar with the repository: 
- what should the clap argument for emit be? is this fine?
```rust
#[derive(Parser, Clone, Debug)]
pub struct FmtArgs {
    // ...
    #[arg(short, long)]
    pub emit: Option<EmitTarget>,
    // ...
}
```
- How should the `emit_formatted_file` function behave? Should it output a specific per-path message like the diff printing function, i.e.: `ws.config().ui().print(format!("{file}"))` versus `ws.config().ui().print(format!("Diff in file {}:\n {}", path.display(), diff))`

- How should I test the feature?