### PR TITLE
Fix: unify path_in_vcs format accross target os

### DIFF
--- a/scarb/src/ops/package.rs
+++ b/scarb/src/ops/package.rs
@@ -119,7 +119,7 @@ fn extract_vcs_info(repo: PackageRepository, opts: &PackageOpts) -> Result<Optio
     );
 
     Ok(Some(VcsInfo {
-        path_in_vcs: repo.path_in_vcs()?.to_string(),
+        path_in_vcs: repo.path_in_vcs()?,
         git: GitVcsInfo {
             sha1: repo.head_rev_hash()?,
         },

--- a/scarb/src/sources/git/client.rs
+++ b/scarb/src/sources/git/client.rs
@@ -369,13 +369,16 @@ impl PackageRepository {
     }
 
     /// Calculate relative path from the repository root to the package root.
-    pub fn path_in_vcs(&self) -> Result<Utf8PathBuf> {
+    pub fn path_in_vcs(&self) -> Result<String> {
         Ok(self
             .pkg
             .root()
             .to_path_buf()
             .strip_prefix(self.work_dir()?)?
-            .to_path_buf())
+            .to_path_buf()
+            .to_string()
+            // Unify paths on windows and unix based systems
+            .replace('\\', "/"))
     }
 }
 


### PR DESCRIPTION
**Stack**:
- #875
- #874
- #873 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*