### PR TITLE
Add snforge test collector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aes"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -70,6 +81,21 @@ name = "allocator-api2"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+
+[[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "anstream"
@@ -404,9 +430,27 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
+
+[[package]]
+name = "bigdecimal"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6773ddc0eafc0e509fb60e48dff7f450f8e674a0686ae8605e8d9901bd5eefa"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits 0.2.17",
+ "serde",
+]
 
 [[package]]
 name = "bincode"
@@ -563,7 +607,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-casm"
 version = "2.3.1"
-source = "git+https://github.com/starkware-libs/cairo?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
 dependencies = [
  "cairo-lang-utils",
  "indoc",
@@ -579,7 +623,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-compiler"
 version = "2.3.1"
-source = "git+https://github.com/starkware-libs/cairo?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
 dependencies = [
  "anyhow",
  "cairo-lang-defs",
@@ -601,7 +645,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-debug"
 version = "2.3.1"
-source = "git+https://github.com/starkware-libs/cairo?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
 dependencies = [
  "cairo-lang-utils",
 ]
@@ -609,7 +653,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-defs"
 version = "2.3.1"
-source = "git+https://github.com/starkware-libs/cairo?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-diagnostics",
@@ -625,7 +669,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-diagnostics"
 version = "2.3.1"
-source = "git+https://github.com/starkware-libs/cairo?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-filesystem",
@@ -636,7 +680,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-eq-solver"
 version = "2.3.1"
-source = "git+https://github.com/starkware-libs/cairo?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
 dependencies = [
  "cairo-lang-utils",
  "good_lp",
@@ -645,7 +689,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-filesystem"
 version = "2.3.1"
-source = "git+https://github.com/starkware-libs/cairo?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-utils",
@@ -658,7 +702,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-formatter"
 version = "2.3.1"
-source = "git+https://github.com/starkware-libs/cairo?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
 dependencies = [
  "anyhow",
  "cairo-lang-diagnostics",
@@ -677,7 +721,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-language-server"
 version = "2.3.1"
-source = "git+https://github.com/starkware-libs/cairo?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
 dependencies = [
  "anyhow",
  "cairo-lang-compiler",
@@ -706,7 +750,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-lowering"
 version = "2.3.1"
-source = "git+https://github.com/starkware-libs/cairo?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -731,7 +775,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-parser"
 version = "2.3.1"
-source = "git+https://github.com/starkware-libs/cairo?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
 dependencies = [
  "cairo-lang-diagnostics",
  "cairo-lang-filesystem",
@@ -750,7 +794,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-plugins"
 version = "2.3.1"
-source = "git+https://github.com/starkware-libs/cairo?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
 dependencies = [
  "cairo-lang-defs",
  "cairo-lang-diagnostics",
@@ -768,7 +812,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-proc-macros"
 version = "2.3.1"
-source = "git+https://github.com/starkware-libs/cairo?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
 dependencies = [
  "cairo-lang-debug",
  "quote",
@@ -778,7 +822,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-project"
 version = "2.3.1"
-source = "git+https://github.com/starkware-libs/cairo?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
 dependencies = [
  "cairo-lang-filesystem",
  "cairo-lang-utils",
@@ -791,7 +835,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-runner"
 version = "2.3.1"
-source = "git+https://github.com/starkware-libs/cairo?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
 dependencies = [
  "ark-ff",
  "ark-secp256k1",
@@ -818,7 +862,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-semantic"
 version = "2.3.1"
-source = "git+https://github.com/starkware-libs/cairo?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -842,7 +886,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-sierra"
 version = "2.3.1"
-source = "git+https://github.com/starkware-libs/cairo?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
 dependencies = [
  "anyhow",
  "cairo-lang-utils",
@@ -866,7 +910,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-sierra-ap-change"
 version = "2.3.1"
-source = "git+https://github.com/starkware-libs/cairo?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
@@ -879,7 +923,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-sierra-gas"
 version = "2.3.1"
-source = "git+https://github.com/starkware-libs/cairo?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
@@ -892,7 +936,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-sierra-generator"
 version = "2.3.1"
-source = "git+https://github.com/starkware-libs/cairo?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -915,7 +959,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-sierra-to-casm"
 version = "2.3.1"
-source = "git+https://github.com/starkware-libs/cairo?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
 dependencies = [
  "assert_matches",
  "cairo-felt",
@@ -935,7 +979,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-sierra-type-size"
 version = "2.3.1"
-source = "git+https://github.com/starkware-libs/cairo?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
 dependencies = [
  "cairo-lang-sierra",
  "cairo-lang-utils",
@@ -944,7 +988,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-starknet"
 version = "2.3.1"
-source = "git+https://github.com/starkware-libs/cairo?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
 dependencies = [
  "anyhow",
  "cairo-felt",
@@ -979,7 +1023,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-syntax"
 version = "2.3.1"
-source = "git+https://github.com/starkware-libs/cairo?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-filesystem",
@@ -994,7 +1038,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-syntax-codegen"
 version = "2.3.1"
-source = "git+https://github.com/starkware-libs/cairo?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
 dependencies = [
  "genco",
  "xshell",
@@ -1003,7 +1047,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-test-plugin"
 version = "2.3.1"
-source = "git+https://github.com/starkware-libs/cairo?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
 dependencies = [
  "anyhow",
  "cairo-felt",
@@ -1029,7 +1073,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-test-runner"
 version = "2.3.1"
-source = "git+https://github.com/starkware-libs/cairo?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
 dependencies = [
  "anyhow",
  "cairo-felt",
@@ -1050,7 +1094,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-utils"
 version = "2.3.1"
-source = "git+https://github.com/starkware-libs/cairo?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=2850a160c348b72d020d1464544323c0a772c6d4#2850a160c348b72d020d1464544323c0a772c6d4"
 dependencies = [
  "env_logger",
  "indexmap 2.1.0",
@@ -1141,6 +1185,29 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "num-traits 0.2.17",
+ "serde",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
 
 [[package]]
 name = "clap"
@@ -1411,6 +1478,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "darling"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1522,6 +1598,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3"
 dependencies = [
  "powerfmt",
+ "serde",
 ]
 
 [[package]]
@@ -1733,6 +1810,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "eth-keystore"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fda3bf123be441da5260717e0661c25a2fd9cb2b2c1d20bf2e05580047158ab"
+dependencies = [
+ "aes",
+ "ctr",
+ "digest",
+ "hex",
+ "hmac",
+ "pbkdf2",
+ "rand",
+ "scrypt",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sha3",
+ "thiserror",
+ "uuid",
+]
+
+[[package]]
+name = "ethbloom"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c22d4b5885b6aa2fe5e8b9329fb8d232bf739e434e6b87347c63bdd00c120f60"
+dependencies = [
+ "crunchy",
+ "fixed-hash",
+ "impl-rlp",
+ "impl-serde",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "ethereum-types"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d215cbf040552efcbe99a38372fe80ab9d00268e20012b79fcd0f073edd8ee"
+dependencies = [
+ "ethbloom",
+ "fixed-hash",
+ "impl-rlp",
+ "impl-serde",
+ "primitive-types",
+ "uint",
+]
+
+[[package]]
 name = "expect-test"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1767,6 +1893,18 @@ dependencies = [
  "libc",
  "redox_syscall 0.3.5",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "fixed-hash"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
+dependencies = [
+ "byteorder",
+ "rand",
+ "rustc-hex",
+ "static_assertions",
 ]
 
 [[package]]
@@ -2988,6 +3126,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8326b86b6cff230b97d0d312a6c40a60726df3332e721f72a1b035f451663b20"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3034,6 +3195,33 @@ checksum = "e98c1d0ad70fc91b8b9654b1f33db55e59579d3b3de2bffdced0fdb810570cb8"
 dependencies = [
  "ahash 0.8.6",
  "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "impl-codec"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
+dependencies = [
+ "parity-scale-codec",
+]
+
+[[package]]
+name = "impl-rlp"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
+dependencies = [
+ "rlp",
+]
+
+[[package]]
+name = "impl-serde"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc88fc67028ae3db0c853baa36269d398d5f45b6982f95549ff5def78c935cd"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -3112,6 +3300,15 @@ name = "indoc"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
+
+[[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "instant"
@@ -3757,6 +3954,7 @@ dependencies = [
  "bitvec",
  "byte-slice-cast",
  "impl-trait-for-tuples",
+ "parity-scale-codec-derive",
  "serde",
 ]
 
@@ -3848,6 +4046,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 dependencies = [
  "camino",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -3972,6 +4179,19 @@ checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
 dependencies = [
  "predicates-core",
  "termtree",
+]
+
+[[package]]
+name = "primitive-types"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
+dependencies = [
+ "fixed-hash",
+ "impl-codec",
+ "impl-rlp",
+ "impl-serde",
+ "uint",
 ]
 
 [[package]]
@@ -4219,7 +4439,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "046cd98826c46c2ac8ddecae268eb5c2e58628688a5fc7a2643704a73faba95b"
 dependencies = [
  "async-compression",
- "base64",
+ "base64 0.21.5",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -4255,6 +4475,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots",
  "winreg",
 ]
 
@@ -4283,6 +4504,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rlp"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
+dependencies = [
+ "bytes",
+ "rustc-hex",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4293,6 +4524,12 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hex"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustc_version"
@@ -4346,7 +4583,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
 dependencies = [
- "base64",
+ "base64 0.21.5",
 ]
 
 [[package]]
@@ -4398,6 +4635,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -4574,6 +4820,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "scarb-snforge-test-collector"
+version = "2.3.1"
+dependencies = [
+ "anyhow",
+ "cairo-felt",
+ "cairo-lang-casm",
+ "cairo-lang-compiler",
+ "cairo-lang-debug",
+ "cairo-lang-defs",
+ "cairo-lang-diagnostics",
+ "cairo-lang-filesystem",
+ "cairo-lang-lowering",
+ "cairo-lang-project",
+ "cairo-lang-semantic",
+ "cairo-lang-sierra",
+ "cairo-lang-sierra-generator",
+ "cairo-lang-starknet",
+ "cairo-lang-syntax",
+ "cairo-lang-test-plugin",
+ "cairo-lang-utils",
+ "camino",
+ "clap",
+ "create-output-dir",
+ "fs4",
+ "itertools 0.11.0",
+ "num-bigint",
+ "num-traits 0.2.17",
+ "rayon",
+ "scarb-metadata 1.9.0",
+ "scarb-ui",
+ "serde",
+ "serde_json",
+ "smol_str",
+ "starknet",
+ "thiserror",
+ "walkdir",
+]
+
+[[package]]
 name = "scarb-test-support"
 version = "1.0.0"
 dependencies = [
@@ -4655,6 +4940,18 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scrypt"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f9e24d2b632954ded8ab2ef9fea0a0c769ea56ea98bddbafbad22caeeadf45d"
+dependencies = [
+ "hmac",
+ "pbkdf2",
+ "salsa20",
+ "sha2",
+]
 
 [[package]]
 name = "sct"
@@ -4761,6 +5058,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json_pythonic"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62212da9872ca2a0cad0093191ee33753eddff9266cbbc1b4a602d13a3a768db"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_path_to_error"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4809,6 +5117,34 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07ff71d2c147a7b57362cead5e22f772cd52f6ab31cfcd9edcd7f6aeb2a0afbe"
+dependencies = [
+ "base64 0.13.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "serde",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
+dependencies = [
+ "darling 0.20.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -4992,6 +5328,87 @@ dependencies = [
 ]
 
 [[package]]
+name = "starknet"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f0623b045f3dc10aef030c9ddd4781cff9cbe1188b71063cc510b75d1f96be6"
+dependencies = [
+ "starknet-accounts",
+ "starknet-contract",
+ "starknet-core 0.6.1",
+ "starknet-crypto 0.6.1",
+ "starknet-ff",
+ "starknet-macros",
+ "starknet-providers",
+ "starknet-signers",
+]
+
+[[package]]
+name = "starknet-accounts"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68e97edc480348dca300e5a8234e6c4e6f2f1ac028f2b16fcce294ebe93d07f4"
+dependencies = [
+ "async-trait",
+ "auto_impl",
+ "starknet-core 0.6.1",
+ "starknet-providers",
+ "starknet-signers",
+ "thiserror",
+]
+
+[[package]]
+name = "starknet-contract"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b86e3f6b3ca9a5c45271ab10871c99f7dc82fee3199d9f8c7baa2a1829947d"
+dependencies = [
+ "serde",
+ "serde_json",
+ "serde_with",
+ "starknet-accounts",
+ "starknet-core 0.6.1",
+ "starknet-providers",
+ "thiserror",
+]
+
+[[package]]
+name = "starknet-core"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14139b1c39bdc2f1e663c12090ff5108fe50ebe62c09e15e32988dfaf445a7e4"
+dependencies = [
+ "base64 0.21.5",
+ "flate2",
+ "hex",
+ "serde",
+ "serde_json",
+ "serde_json_pythonic",
+ "serde_with",
+ "sha3",
+ "starknet-crypto 0.6.1",
+ "starknet-ff",
+]
+
+[[package]]
+name = "starknet-core"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f1683ca7c63f0642310eddedb7d35056d8306084dff323d440711065c63ed87"
+dependencies = [
+ "base64 0.21.5",
+ "flate2",
+ "hex",
+ "serde",
+ "serde_json",
+ "serde_json_pythonic",
+ "serde_with",
+ "sha3",
+ "starknet-crypto 0.6.1",
+ "starknet-ff",
+]
+
+[[package]]
 name = "starknet-crypto"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5067,9 +5484,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7584bc732e4d2a8ccebdd1dda8236f7940a79a339e30ebf338d45c329659e36c"
 dependencies = [
  "ark-ff",
+ "bigdecimal",
  "crypto-bigint",
  "getrandom",
  "hex",
+ "num-bigint",
+ "serde",
+]
+
+[[package]]
+name = "starknet-macros"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f66fe05edab7ee6752a0aff3e14508001191083f3c6d0b6fa14f7008a96839b0"
+dependencies = [
+ "starknet-core 0.7.2",
+ "syn 2.0.39",
+]
+
+[[package]]
+name = "starknet-providers"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b136c26b72ff1756f0844e0aa80bab680ceb99d63921826facbb8e7340ff82"
+dependencies = [
+ "async-trait",
+ "auto_impl",
+ "ethereum-types",
+ "flate2",
+ "log",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "starknet-core 0.6.1",
+ "thiserror",
+ "url",
+]
+
+[[package]]
+name = "starknet-signers"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9386015d2e6dc3df285bfb33a3afd8ad7596c70ed38ab57019de4d2dfc7826f"
+dependencies = [
+ "async-trait",
+ "auto_impl",
+ "crypto-bigint",
+ "eth-keystore",
+ "rand",
+ "starknet-core 0.6.1",
+ "starknet-crypto 0.6.1",
+ "thiserror",
 ]
 
 [[package]]
@@ -5667,6 +6133,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
+name = "uint"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
+
+[[package]]
 name = "uluru"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5761,6 +6239,16 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom",
+ "serde",
+]
 
 [[package]]
 name = "valuable"
@@ -5904,6 +6392,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
+
+[[package]]
 name = "which"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5952,6 +6446,15 @@ name = "windows"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.51.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
 dependencies = [
  "windows-targets 0.48.5",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "extensions/scarb-cairo-language-server",
     "extensions/scarb-cairo-run",
     "extensions/scarb-cairo-test",
+    "extensions/scarb-snforge-test-collector",
     "utils/create-output-dir",
     "utils/scarb-build-metadata",
     "utils/scarb-test-support",
@@ -29,19 +30,27 @@ anyhow = "1"
 assert_fs = "1"
 async-trait = "0.1"
 axum = { version = "0.6", features = ["http2"] }
-cairo-lang-compiler = { git = "https://github.com/starkware-libs/cairo", rev = "2850a160c348b72d020d1464544323c0a772c6d4" }
-cairo-lang-defs = { git = "https://github.com/starkware-libs/cairo", rev = "2850a160c348b72d020d1464544323c0a772c6d4" }
-cairo-lang-filesystem = { git = "https://github.com/starkware-libs/cairo", rev = "2850a160c348b72d020d1464544323c0a772c6d4" }
-cairo-lang-formatter = { git = "https://github.com/starkware-libs/cairo", rev = "2850a160c348b72d020d1464544323c0a772c6d4" }
-cairo-lang-language-server = { git = "https://github.com/starkware-libs/cairo", rev = "2850a160c348b72d020d1464544323c0a772c6d4" }
-cairo-lang-runner = { git = "https://github.com/starkware-libs/cairo", rev = "2850a160c348b72d020d1464544323c0a772c6d4" }
-cairo-lang-semantic = { git = "https://github.com/starkware-libs/cairo", rev = "2850a160c348b72d020d1464544323c0a772c6d4" }
-cairo-lang-sierra = { git = "https://github.com/starkware-libs/cairo", rev = "2850a160c348b72d020d1464544323c0a772c6d4" }
-cairo-lang-sierra-to-casm = { git = "https://github.com/starkware-libs/cairo", rev = "2850a160c348b72d020d1464544323c0a772c6d4" }
-cairo-lang-starknet = { git = "https://github.com/starkware-libs/cairo", rev = "2850a160c348b72d020d1464544323c0a772c6d4" }
-cairo-lang-test-plugin = { git = "https://github.com/starkware-libs/cairo", rev = "2850a160c348b72d020d1464544323c0a772c6d4" }
-cairo-lang-test-runner = { git = "https://github.com/starkware-libs/cairo", rev = "2850a160c348b72d020d1464544323c0a772c6d4" }
-cairo-lang-utils = { git = "https://github.com/starkware-libs/cairo", rev = "2850a160c348b72d020d1464544323c0a772c6d4", features = ["env_logger"] }
+cairo-felt = "0.9"
+cairo-lang-casm = { git = "https://github.com/starkware-libs/cairo.git", rev = "2850a160c348b72d020d1464544323c0a772c6d4" }
+cairo-lang-compiler = { git = "https://github.com/starkware-libs/cairo.git", rev = "2850a160c348b72d020d1464544323c0a772c6d4" }
+cairo-lang-diagnostics = { git = "https://github.com/starkware-libs/cairo.git", rev = "2850a160c348b72d020d1464544323c0a772c6d4" }
+cairo-lang-debug = { git = "https://github.com/starkware-libs/cairo.git", rev = "2850a160c348b72d020d1464544323c0a772c6d4" }
+cairo-lang-defs = { git = "https://github.com/starkware-libs/cairo.git", rev = "2850a160c348b72d020d1464544323c0a772c6d4" }
+cairo-lang-filesystem = { git = "https://github.com/starkware-libs/cairo.git", rev = "2850a160c348b72d020d1464544323c0a772c6d4" }
+cairo-lang-formatter = { git = "https://github.com/starkware-libs/cairo.git", rev = "2850a160c348b72d020d1464544323c0a772c6d4" }
+cairo-lang-language-server = { git = "https://github.com/starkware-libs/cairo.git", rev = "2850a160c348b72d020d1464544323c0a772c6d4" }
+cairo-lang-lowering = { git = "https://github.com/starkware-libs/cairo.git", rev = "2850a160c348b72d020d1464544323c0a772c6d4" }
+cairo-lang-project = { git = "https://github.com/starkware-libs/cairo.git", rev = "2850a160c348b72d020d1464544323c0a772c6d4" }
+cairo-lang-runner = { git = "https://github.com/starkware-libs/cairo.git", rev = "2850a160c348b72d020d1464544323c0a772c6d4" }
+cairo-lang-semantic = { git = "https://github.com/starkware-libs/cairo.git", rev = "2850a160c348b72d020d1464544323c0a772c6d4" }
+cairo-lang-sierra = { git = "https://github.com/starkware-libs/cairo.git", rev = "2850a160c348b72d020d1464544323c0a772c6d4" }
+cairo-lang-sierra-generator = { git = "https://github.com/starkware-libs/cairo.git", rev = "2850a160c348b72d020d1464544323c0a772c6d4" }
+cairo-lang-sierra-to-casm = { git = "https://github.com/starkware-libs/cairo.git", rev = "2850a160c348b72d020d1464544323c0a772c6d4" }
+cairo-lang-starknet = { git = "https://github.com/starkware-libs/cairo.git", rev = "2850a160c348b72d020d1464544323c0a772c6d4" }
+cairo-lang-syntax = { git = "https://github.com/starkware-libs/cairo.git", rev = "2850a160c348b72d020d1464544323c0a772c6d4" }
+cairo-lang-test-plugin = { git = "https://github.com/starkware-libs/cairo.git", rev = "2850a160c348b72d020d1464544323c0a772c6d4" }
+cairo-lang-test-runner = { git = "https://github.com/starkware-libs/cairo.git", rev = "2850a160c348b72d020d1464544323c0a772c6d4" }
+cairo-lang-utils = { git = "https://github.com/starkware-libs/cairo.git", rev = "2850a160c348b72d020d1464544323c0a772c6d4", features = ["env_logger"] }
 camino = { version = "1", features = ["serde1"] }
 cargo_metadata = ">=0.18"
 clap = { version = "4", features = ["derive", "env", "string"] }
@@ -69,6 +78,8 @@ itertools = "0.11"
 libc = "0.2"
 log = "0.4"
 ntest = "0.9"
+num-bigint = { version = "0.4", features = ["rand"] }
+num-traits = "0.2"
 once_cell = "1"
 pathdiff = { version = "0.2", features = ["camino"] }
 petgraph = "0.6"
@@ -76,6 +87,7 @@ predicates = "3"
 proc-macro2 = "1"
 quote = "1"
 redb = "1.3"
+rayon = "1.8"
 reqwest = { version = "0.11", features = ["gzip", "brotli", "deflate", "json", "stream"], default-features = false }
 semver = { version = "1", features = ["serde"] }
 serde = { version = "1", features = ["serde_derive"] }
@@ -89,6 +101,7 @@ similar-asserts = { version = "1", features = ["serde"] }
 smallvec = "1"
 smol_str = { version = "0.2", features = ["serde"] }
 snapbox = { version = "0.4", features = ["cmd", "path"] }
+starknet = "0.6"
 syn = "2"
 tar = "0.4"
 tempfile = "3"

--- a/extensions/scarb-snforge-test-collector/Cargo.toml
+++ b/extensions/scarb-snforge-test-collector/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "scarb-snforge-test-collector"
+version.workspace = true
+edition.workspace = true
+publish = false
+
+authors.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+cairo-felt.workspace = true
+cairo-lang-casm.workspace = true
+cairo-lang-compiler.workspace = true
+cairo-lang-debug.workspace = true
+cairo-lang-defs.workspace = true
+cairo-lang-diagnostics.workspace = true
+cairo-lang-filesystem.workspace = true
+cairo-lang-lowering.workspace = true
+cairo-lang-project.workspace = true
+cairo-lang-semantic.workspace = true
+cairo-lang-sierra.workspace = true
+cairo-lang-sierra-generator.workspace = true
+cairo-lang-starknet.workspace = true
+cairo-lang-syntax.workspace = true
+cairo-lang-test-plugin.workspace = true
+cairo-lang-utils.workspace = true
+camino.workspace = true
+clap.workspace = true
+create-output-dir = { path = "../../utils/create-output-dir" }
+fs4.workspace = true
+itertools.workspace = true
+num-bigint.workspace = true
+num-traits.workspace = true
+rayon.workspace = true
+scarb-metadata = { path = "../../scarb-metadata" }
+scarb-ui = { path = "../../utils/scarb-ui" }
+serde.workspace = true
+serde_json.workspace = true
+smol_str.workspace = true
+starknet.workspace = true
+thiserror.workspace = true
+walkdir.workspace = true

--- a/extensions/scarb-snforge-test-collector/src/compilation.rs
+++ b/extensions/scarb-snforge-test-collector/src/compilation.rs
@@ -1,0 +1,44 @@
+use anyhow::Result;
+use cairo_lang_sierra::program::{ProgramArtifact, VersionedProgram};
+use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
+use serde::Serialize;
+
+use crate::compilation::test_collector::{collect_tests, TestCaseRaw};
+use crate::crate_collection::{CrateLocation, TestCompilationTarget};
+use crate::metadata::CompilationUnit;
+
+pub mod test_collector;
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct CompiledTestCrateRaw {
+    pub sierra_program: VersionedProgram,
+    pub test_cases: Vec<TestCaseRaw>,
+    pub tests_location: CrateLocation,
+}
+
+pub fn compile_tests(
+    targets: &Vec<TestCompilationTarget>,
+    compilation_unit: &CompilationUnit,
+) -> Result<Vec<CompiledTestCrateRaw>> {
+    targets
+        .par_iter()
+        .map(|target| target.compile_tests(compilation_unit))
+        .collect()
+}
+
+impl TestCompilationTarget {
+    fn compile_tests(&self, compilation_unit: &CompilationUnit) -> Result<CompiledTestCrateRaw> {
+        let (sierra_program, test_cases) = collect_tests(
+            &self.crate_name,
+            self.crate_root.as_std_path(),
+            &self.lib_content,
+            compilation_unit,
+        )?;
+
+        Ok(CompiledTestCrateRaw {
+            sierra_program: VersionedProgram::v1(ProgramArtifact::stripped(sierra_program)),
+            test_cases,
+            tests_location: self.crate_location.clone(),
+        })
+    }
+}

--- a/extensions/scarb-snforge-test-collector/src/compilation/test_collector.rs
+++ b/extensions/scarb-snforge-test-collector/src/compilation/test_collector.rs
@@ -1,0 +1,241 @@
+use anyhow::{anyhow, bail, Context, Result};
+use cairo_lang_compiler::db::RootDatabase;
+use cairo_lang_compiler::diagnostics::DiagnosticsReporter;
+use cairo_lang_debug::DebugWithDb;
+use cairo_lang_defs::db::DefsGroup;
+use cairo_lang_defs::ids::{FreeFunctionId, FunctionWithBodyId, ModuleId, ModuleItemId};
+use cairo_lang_diagnostics::ToOption;
+use cairo_lang_filesystem::cfg::{Cfg, CfgSet};
+use cairo_lang_filesystem::db::{AsFilesGroupMut, CrateConfiguration, FilesGroup, FilesGroupEx};
+use cairo_lang_filesystem::ids::{CrateId, CrateLongId, Directory};
+use cairo_lang_lowering::ids::ConcreteFunctionWithBodyId;
+use cairo_lang_project::{ProjectConfig, ProjectConfigContent};
+use cairo_lang_semantic::db::SemanticGroup;
+use cairo_lang_semantic::items::functions::GenericFunctionId;
+use cairo_lang_semantic::{ConcreteFunction, FunctionLongId};
+use cairo_lang_sierra::extensions::enm::EnumType;
+use cairo_lang_sierra::extensions::NamedType;
+use cairo_lang_sierra::program::{GenericArg, Program};
+use cairo_lang_sierra_generator::db::SierraGenGroup;
+use cairo_lang_sierra_generator::replace_ids::replace_sierra_ids_in_program;
+use cairo_lang_starknet::starknet_plugin_suite;
+use cairo_lang_test_plugin::test_plugin_suite;
+use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
+use itertools::Itertools;
+use serde::Serialize;
+use smol_str::SmolStr;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use crate::compilation::test_collector::config::ExpectedTestResult;
+use crate::metadata::CompilationUnit;
+pub use config::RawForkConfig;
+use config::{forge_try_extract_test_config, FuzzerConfig, SingleTestConfig};
+use plugin::snforge_test_plugin_suite;
+use sierra_casm_generator::FunctionFinder;
+
+mod config;
+mod plugin;
+mod sierra_casm_generator;
+
+fn find_all_tests(
+    db: &dyn SemanticGroup,
+    main_crate: CrateId,
+) -> Vec<(FreeFunctionId, SingleTestConfig)> {
+    let mut tests = vec![];
+    let modules = db.crate_modules(main_crate);
+    for module_id in modules.iter() {
+        let Ok(module_items) = db.module_items(*module_id) else {
+            continue;
+        };
+        tests.extend(module_items.iter().filter_map(|item| {
+            let ModuleItemId::FreeFunction(func_id) = item else {
+                return None;
+            };
+            let Ok(attrs) = db.function_with_body_attributes(FunctionWithBodyId::Free(*func_id))
+            else {
+                return None;
+            };
+            Some((
+                *func_id,
+                forge_try_extract_test_config(db.upcast(), &attrs).unwrap()?,
+            ))
+        }));
+    }
+    tests
+}
+
+#[derive(Debug, PartialEq, Clone, Serialize)]
+pub struct TestCaseRaw {
+    pub name: String,
+    pub available_gas: Option<usize>,
+    pub ignored: bool,
+    pub expected_result: ExpectedTestResult,
+    pub fork_config: Option<RawForkConfig>,
+    pub fuzzer_config: Option<FuzzerConfig>,
+}
+
+pub fn collect_tests(
+    crate_name: &str,
+    crate_root: &Path,
+    lib_content: &str,
+    compilation_unit: &CompilationUnit,
+) -> Result<(Program, Vec<TestCaseRaw>)> {
+    let crate_roots: OrderedHashMap<SmolStr, PathBuf> = compilation_unit
+        .dependencies()
+        .iter()
+        .cloned()
+        .map(|source_root| (source_root.name.into(), source_root.path))
+        .collect();
+
+    let project_config = ProjectConfig {
+        base_path: crate_root.into(),
+        corelib: Some(Directory::Real(compilation_unit.corelib_path()?)),
+        content: ProjectConfigContent {
+            crate_roots,
+            crates_config: compilation_unit.crates_config_for_compilation_unit(),
+        },
+    };
+
+    // code taken from crates/cairo-lang-test-runner/src/lib.rs
+    let db = &mut {
+        let mut b = RootDatabase::builder();
+        b.with_cfg(CfgSet::from_iter([Cfg::name("test")]));
+        b.with_plugin_suite(snforge_test_plugin_suite());
+        b.with_plugin_suite(test_plugin_suite());
+        b.with_plugin_suite(starknet_plugin_suite());
+        b.with_project_config(project_config);
+        b.build()?
+    };
+
+    let main_crate_id =
+        insert_lib_entrypoint_content_into_db(db, crate_name, crate_root, lib_content);
+
+    if DiagnosticsReporter::stderr().check(db) {
+        return Err(anyhow!(
+            "Failed to compile test artifact, for detailed information go through the logs above"
+        ));
+    }
+    let all_tests = find_all_tests(db, main_crate_id);
+
+    let z: Vec<ConcreteFunctionWithBodyId> = all_tests
+        .iter()
+        .filter_map(|(func_id, _cfg)| {
+            ConcreteFunctionWithBodyId::from_no_generics_free(db, *func_id)
+        })
+        .collect();
+
+    let sierra_program = db
+        .get_sierra_program_for_functions(z)
+        .to_option()
+        .context("Compilation failed without any diagnostics")
+        .context("Failed to get sierra program")?;
+
+    let collected_tests = all_tests
+        .into_iter()
+        .map(|(func_id, test)| {
+            (
+                format!(
+                    "{:?}",
+                    FunctionLongId {
+                        function: ConcreteFunction {
+                            generic_function: GenericFunctionId::Free(func_id),
+                            generic_args: vec![]
+                        }
+                    }
+                    .debug(db)
+                ),
+                test,
+            )
+        })
+        .collect_vec()
+        .into_iter()
+        .map(|(test_name, config)| TestCaseRaw {
+            name: test_name,
+            available_gas: config.available_gas,
+            ignored: config.ignored,
+            expected_result: config.expected_result,
+            fork_config: config.fork_config,
+            fuzzer_config: config.fuzzer_config,
+        })
+        .collect();
+
+    let sierra_program = replace_sierra_ids_in_program(db, &sierra_program);
+
+    validate_tests(sierra_program.clone(), &collected_tests)?;
+
+    Ok((sierra_program, collected_tests))
+}
+
+// inspired with cairo-lang-compiler/src/project.rs:49 (part of setup_single_project_file)
+fn insert_lib_entrypoint_content_into_db(
+    db: &mut RootDatabase,
+    crate_name: &str,
+    crate_root: &Path,
+    lib_content: &str,
+) -> CrateId {
+    let main_crate_id = db.intern_crate(CrateLongId::Real(SmolStr::from(crate_name)));
+    db.set_crate_config(
+        main_crate_id,
+        Some(CrateConfiguration::default_for_root(Directory::Real(
+            crate_root.to_path_buf(),
+        ))),
+    );
+
+    let module_id = ModuleId::CrateRoot(main_crate_id);
+    let file_id = db.module_main_file(module_id).unwrap();
+    db.as_files_group_mut()
+        .override_file_content(file_id, Some(Arc::new(lib_content.to_string())));
+
+    main_crate_id
+}
+
+fn validate_tests(
+    sierra_program: Program,
+    collected_tests: &Vec<TestCaseRaw>,
+) -> Result<(), anyhow::Error> {
+    let function_finder = match FunctionFinder::new(sierra_program) {
+        Ok(casm_generator) => casm_generator,
+        Err(e) => panic!("{}", e),
+    };
+    for test in collected_tests {
+        let func = function_finder.find_function(&test.name)?;
+        let signature = &func.signature;
+        let ret_types = &signature.ret_types;
+        let tp = &ret_types[ret_types.len() - 1];
+        let info = function_finder.get_info(tp);
+        let mut maybe_return_type_name = None;
+        if info.long_id.generic_id == EnumType::ID {
+            if let GenericArg::UserType(ut) = &info.long_id.generic_args[0] {
+                if let Some(name) = ut.debug_name.as_ref() {
+                    maybe_return_type_name = Some(name.as_str());
+                }
+            }
+        }
+        if let Some(return_type_name) = maybe_return_type_name {
+            if !return_type_name.starts_with("core::panics::PanicResult::") {
+                bail!(
+                    "The test function {} always succeeds and cannot be used as a test. Make sure to include panickable statements such as `assert` in your test",
+                    test.name
+                );
+            }
+            if return_type_name != "core::panics::PanicResult::<((),)>" {
+                bail!(
+                    "Test function {} returns a value {}, it is required that test functions do \
+                     not return values",
+                    test.name,
+                    return_type_name
+                );
+            }
+        } else {
+            bail!(
+                "Couldn't read result type for test function {} possible cause: The test function {} \
+                 always succeeds and cannot be used as a test. Make sure to include panickable statements such as `assert` in your test",
+                test.name,
+                test.name
+            );
+        }
+    }
+
+    Ok(())
+}

--- a/extensions/scarb-snforge-test-collector/src/compilation/test_collector/plugin.rs
+++ b/extensions/scarb-snforge-test-collector/src/compilation/test_collector/plugin.rs
@@ -1,0 +1,45 @@
+use cairo_lang_defs::plugin::{MacroPlugin, PluginResult, PluginSuite};
+use cairo_lang_syntax::attribute::structured::AttributeListStructurize;
+use cairo_lang_syntax::node::ast;
+use cairo_lang_syntax::node::db::SyntaxGroup;
+
+use super::forge_try_extract_test_config;
+
+/// Plugin to create diagnostics for tests attributes.
+#[derive(Debug, Default)]
+#[non_exhaustive]
+#[allow(clippy::module_name_repetitions)]
+struct TestPlugin;
+
+impl MacroPlugin for TestPlugin {
+    fn generate_code(&self, db: &dyn SyntaxGroup, item_ast: ast::Item) -> PluginResult {
+        PluginResult {
+            code: None,
+            diagnostics: if let ast::Item::FreeFunction(free_func_ast) = item_ast {
+                forge_try_extract_test_config(db, &free_func_ast.attributes(db).structurize(db))
+                    .err()
+            } else {
+                None
+            }
+            .unwrap_or_default(),
+            remove_original_item: false,
+        }
+    }
+
+    fn declared_attributes(&self) -> Vec<String> {
+        vec![
+            "test".to_string(),
+            "ignore".to_string(),
+            "available_gas".to_string(),
+            "should_panic".to_string(),
+            "fork".to_string(),
+            "fuzzer".to_string(),
+        ]
+    }
+}
+
+pub fn snforge_test_plugin_suite() -> PluginSuite {
+    let mut suite = PluginSuite::default();
+    suite.add_plugin::<TestPlugin>();
+    suite
+}

--- a/extensions/scarb-snforge-test-collector/src/compilation/test_collector/sierra_casm_generator.rs
+++ b/extensions/scarb-snforge-test-collector/src/compilation/test_collector/sierra_casm_generator.rs
@@ -1,0 +1,60 @@
+//! Basic runner for running a Sierra program on the vm.
+
+use cairo_lang_sierra::extensions::core::{CoreLibfunc, CoreType};
+use cairo_lang_sierra::extensions::ConcreteType;
+use cairo_lang_sierra::program::Function;
+use cairo_lang_sierra::program_registry::{ProgramRegistry, ProgramRegistryError};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum FinderError {
+    #[error("Function with suffix `{suffix}` to run not found.")]
+    MissingFunction { suffix: String },
+    #[error(transparent)]
+    ProgramRegistryError(#[from] Box<ProgramRegistryError>),
+}
+
+pub struct FunctionFinder {
+    /// The sierra program.
+    sierra_program: cairo_lang_sierra::program::Program,
+    /// Program registry for the Sierra program.
+    sierra_program_registry: ProgramRegistry<CoreType, CoreLibfunc>,
+}
+
+#[allow(clippy::result_large_err)]
+impl FunctionFinder {
+    pub fn new(sierra_program: cairo_lang_sierra::program::Program) -> Result<Self, FinderError> {
+        let sierra_program_registry =
+            ProgramRegistry::<CoreType, CoreLibfunc>::new(&sierra_program)?;
+        Ok(Self {
+            sierra_program,
+            sierra_program_registry,
+        })
+    }
+
+    // Copied from crates/cairo-lang-runner/src/lib.rs
+    /// Finds first function ending with `name_suffix`.
+    pub fn find_function(&self, name_suffix: &str) -> Result<&Function, FinderError> {
+        self.sierra_program
+            .funcs
+            .iter()
+            .find(|f| {
+                if let Some(name) = &f.id.debug_name {
+                    name.ends_with(name_suffix)
+                } else {
+                    false
+                }
+            })
+            .ok_or_else(|| FinderError::MissingFunction {
+                suffix: name_suffix.to_owned(),
+            })
+    }
+
+    #[must_use]
+    pub fn get_info(
+        &self,
+        ty: &cairo_lang_sierra::ids::ConcreteTypeId,
+    ) -> &cairo_lang_sierra::extensions::types::TypeInfo {
+        self.sierra_program_registry.get_type(ty).unwrap().info()
+    }
+}

--- a/extensions/scarb-snforge-test-collector/src/crate_collection.rs
+++ b/extensions/scarb-snforge-test-collector/src/crate_collection.rs
@@ -1,0 +1,80 @@
+use crate::metadata::CompilationUnit;
+use anyhow::{anyhow, Context, Result};
+use camino::{Utf8Path, Utf8PathBuf};
+use serde::Serialize;
+use walkdir::WalkDir;
+
+#[derive(Debug, PartialEq, Clone, Serialize)]
+pub enum CrateLocation {
+    /// Main crate in a package
+    Lib,
+    /// Crate in the `tests/` directory
+    Tests,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct TestCompilationTarget {
+    pub crate_root: Utf8PathBuf,
+    pub crate_name: String,
+    pub crate_location: CrateLocation,
+    pub lib_content: String,
+}
+
+pub fn collect_test_compilation_targets(
+    package_name: &str,
+    package_path: &Utf8Path,
+    compilation_unit: &CompilationUnit,
+) -> Result<Vec<TestCompilationTarget>> {
+    let package_source_file_path = compilation_unit.source_file_path();
+    let mut compilation_targets = vec![TestCompilationTarget {
+        crate_root: compilation_unit.source_root(),
+        crate_name: package_name.to_string(),
+        crate_location: CrateLocation::Lib,
+        lib_content: std::fs::read_to_string(package_source_file_path)
+            .with_context(|| format!("failed to read = {package_source_file_path}"))?,
+    }];
+
+    let tests_dir_path = package_path.join("tests");
+    if tests_dir_path.exists() {
+        compilation_targets.push(TestCompilationTarget {
+            crate_name: "tests".to_string(),
+            crate_location: CrateLocation::Tests,
+            lib_content: get_or_create_test_lib_content(tests_dir_path.as_path())?,
+            crate_root: tests_dir_path,
+        });
+    }
+
+    Ok(compilation_targets)
+}
+
+fn get_or_create_test_lib_content(tests_folder_path: &Utf8Path) -> Result<String> {
+    let tests_lib_path = tests_folder_path.join("lib.cairo");
+    if tests_lib_path
+        .try_exists()
+        .with_context(|| format!("Can't check the existence of file = {tests_lib_path}"))?
+    {
+        return std::fs::read_to_string(&tests_lib_path).with_context(|| {
+            format!("Can't read the content of the file = {tests_lib_path} to string")
+        });
+    }
+
+    let mut content = String::new();
+    for entry in WalkDir::new(tests_folder_path)
+        .max_depth(1)
+        .sort_by_file_name()
+    {
+        let entry = entry
+            .with_context(|| format!("Failed to read directory at path = {tests_folder_path}"))?;
+        let path = Utf8Path::from_path(entry.path())
+            .ok_or_else(|| anyhow!("Failed to convert path = {:?} to Utf8Path", entry.path()))?;
+
+        if path.is_file() && path.extension().unwrap_or_default() == "cairo" {
+            let mod_name = path
+                .file_stem()
+                .unwrap_or_else(|| panic!("Path to test = {path} should have .cairo extension"));
+
+            content.push_str(&format!("mod {mod_name};\n"));
+        }
+    }
+    Ok(content)
+}

--- a/extensions/scarb-snforge-test-collector/src/main.rs
+++ b/extensions/scarb-snforge-test-collector/src/main.rs
@@ -1,0 +1,73 @@
+use anyhow::{Context, Result};
+use clap::Parser;
+use fs4::FileExt;
+use std::fs::{create_dir_all, File};
+use std::io::BufWriter;
+
+use scarb_metadata::MetadataCommand;
+use scarb_ui::args::PackagesFilter;
+
+use crate::compilation::compile_tests;
+use crate::crate_collection::collect_test_compilation_targets;
+use crate::metadata::compilation_unit_for_package;
+
+mod compilation;
+mod crate_collection;
+mod metadata;
+
+/// Starknet Foundry private extension for compiling test artifacts.
+/// Users should not call it directly.
+#[derive(Parser)]
+#[command(version)]
+struct Args {
+    #[command(flatten)]
+    packages_filter: PackagesFilter,
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+
+    let metadata = MetadataCommand::new().inherit_stderr().exec()?;
+    let selected_packages_metadata = args.packages_filter.match_many(&metadata)?;
+
+    let target_dir = metadata
+        .target_dir
+        .clone()
+        .unwrap_or_else(|| metadata.workspace.root.join("target"));
+    let snforge_target_dir = target_dir.join(&metadata.current_profile).join("snforge");
+    create_output_dir::create_output_dir(&target_dir.into_std_path_buf())?;
+    create_dir_all(&snforge_target_dir)?;
+
+    for package_metadata in selected_packages_metadata {
+        let compilation_unit = compilation_unit_for_package(&metadata, &package_metadata)?;
+
+        let compilation_targets = collect_test_compilation_targets(
+            &package_metadata.name,
+            &package_metadata.root,
+            &compilation_unit,
+        )?;
+
+        let test_crates = compile_tests(&compilation_targets, &compilation_unit)?;
+
+        // artifact saved to `{target_dir}/{profile_name}/{package_name}.sierra.json`
+        let output_path =
+            snforge_target_dir.join(&format!("{}.snforge_sierra.json", package_metadata.name));
+        let output_file = File::options()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(&output_path)?;
+
+        output_file
+            .lock_exclusive()
+            .with_context(|| format!("Couldn't lock the output file = {output_path}"))?;
+        let file = BufWriter::new(&output_file);
+        serde_json::to_writer(file, &test_crates)
+            .with_context(|| format!("Failed to serialize = {output_path}"))?;
+        output_file
+            .unlock()
+            .with_context(|| format!("Couldn't lock the output file = {output_path}"))?;
+    }
+
+    Ok(())
+}

--- a/extensions/scarb-snforge-test-collector/src/metadata.rs
+++ b/extensions/scarb-snforge-test-collector/src/metadata.rs
@@ -1,0 +1,114 @@
+use anyhow::{anyhow, Context, Result};
+use cairo_lang_filesystem::db::Edition;
+use cairo_lang_project::{AllCratesConfig, SingleCrateConfig};
+use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
+use camino::{Utf8Path, Utf8PathBuf};
+use scarb_metadata::{CompilationUnitMetadata, Metadata, PackageMetadata};
+use smol_str::SmolStr;
+use std::path::PathBuf;
+
+/// Represents a dependency of a Cairo project
+#[derive(Debug, Clone)]
+pub struct LinkedLibrary {
+    pub name: String,
+    pub path: PathBuf,
+}
+
+pub fn compilation_unit_for_package<'a>(
+    metadata: &'a Metadata,
+    package_metadata: &PackageMetadata,
+) -> Result<CompilationUnit<'a>> {
+    let compilation_unit_metadata = metadata
+        .compilation_units
+        .iter()
+        .filter(|unit| unit.package == package_metadata.id)
+        .min_by_key(|unit| match unit.target.kind.as_str() {
+            name @ "starknet-contract" => (0, name),
+            name @ "lib" => (1, name),
+            name => (2, name),
+        })
+        .ok_or_else(|| {
+            anyhow!(
+                "Failed to find compilation unit for package = {}",
+                package_metadata.name
+            )
+        })?;
+    Ok(CompilationUnit {
+        unit_metadata: compilation_unit_metadata,
+        metadata,
+    })
+}
+
+pub struct CompilationUnit<'a> {
+    unit_metadata: &'a CompilationUnitMetadata,
+    metadata: &'a Metadata,
+}
+
+impl CompilationUnit<'_> {
+    pub fn dependencies(&self) -> Vec<LinkedLibrary> {
+        let dependencies = self
+            .unit_metadata
+            .components
+            .iter()
+            .filter(|du| &du.name != "core")
+            .map(|cu| LinkedLibrary {
+                name: cu.name.clone(),
+                path: cu.source_root().to_owned().into_std_path_buf(),
+            })
+            .collect();
+
+        dependencies
+    }
+
+    pub fn corelib_path(&self) -> Result<PathBuf> {
+        let corelib = self
+            .unit_metadata
+            .components
+            .iter()
+            .find(|du| du.name == "core")
+            .context("Corelib could not be found")?;
+        Ok(PathBuf::from(corelib.source_root()))
+    }
+
+    pub fn crates_config_for_compilation_unit(&self) -> AllCratesConfig {
+        let crates_config: OrderedHashMap<SmolStr, SingleCrateConfig> = self
+            .unit_metadata
+            .components
+            .iter()
+            .map(|component| {
+                (
+                    SmolStr::from(&component.name),
+                    SingleCrateConfig {
+                        edition: if let Some(edition) = self
+                            .metadata
+                            .get_package(&component.package)
+                            .unwrap_or_else(|| {
+                                panic!("Failed to find = {} package", component.package)
+                            })
+                            .edition
+                            .clone()
+                        {
+                            let edition_value = serde_json::Value::String(edition);
+                            serde_json::from_value(edition_value).unwrap()
+                        } else {
+                            Edition::default()
+                        },
+                    },
+                )
+            })
+            .collect();
+
+        AllCratesConfig {
+            override_map: crates_config,
+            ..Default::default()
+        }
+    }
+
+    pub fn source_root(&self) -> Utf8PathBuf {
+        self.unit_metadata.target.source_root().to_path_buf()
+    }
+
+    pub fn source_file_path(&self) -> &Utf8Path {
+        &self.unit_metadata.target.source_path
+    }
+}


### PR DESCRIPTION
Tests will be added to ensure bumping cairo versions doesn't break anything. Before introducing it in snforge will be tested on snforge side locally at first, then with the nightly build.

Example usage:
```console
scarb --manifest-path simple_package/Scarb.toml test-collector --output-path simple_package/target/snforge/simple_package_tests.sierra.json
```