### PR TITLE
Cache index configs

### DIFF
--- a/scarb/tests/http_registry.rs
+++ b/scarb/tests/http_registry.rs
@@ -278,21 +278,6 @@ fn caching() {
 
         ###
 
-        GET /config.json
-        accept: */*
-        accept-encoding: gzip, br, deflate
-        host: ...
-        user-agent: ...
-
-        200 OK
-        accept-ranges: bytes
-        content-length: ...
-        content-type: application/json
-        etag: ...
-        last-modified: ...
-
-        ###
-
         GET /index/3/b/bar.json
         accept: */*
         accept-encoding: gzip, br, deflate


### PR DESCRIPTION
This PR implements permanent caching of index configs. These resources are expected to change very rarely, so event the ETag-style approach is expected to be too talkative to the server. I expect registry administrators to publicly announce to their users that they have to clear the cache manually (by calling `scarb cache clean`) if they change their configs.

fix #741

Signed-off-by: Marek Kaput <marek.kaput@swmansion.com>

---

**Stack**:
- #909
- #906
- #892 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*