### PR TITLE
Remove `update_read_async` method and use `update_read` instead

### DIFF
--- a/scarb/src/core/registry/client/cache.rs
+++ b/scarb/src/core/registry/client/cache.rs
@@ -1,12 +1,11 @@
-use std::io::SeekFrom;
+use std::io::{Seek, SeekFrom};
 
 use anyhow::{anyhow, bail, ensure, Context, Result};
 use camino::Utf8Path;
 use redb::{MultimapTableDefinition, ReadableMultimapTable, ReadableTable, TableDefinition};
 use semver::Version;
-use tokio::io::AsyncSeekExt;
 use tokio::sync::OnceCell;
-use tokio::task::block_in_place;
+use tokio::task::{block_in_place, spawn_blocking};
 use tracing::trace;
 
 use scarb_ui::Ui;
@@ -214,25 +213,25 @@ impl<'c> RegistryClientCache<'c> {
         &self,
         package: PackageId,
         checksum: &Checksum,
-        file: FileLockGuard,
+        mut file: FileLockGuard,
     ) -> Result<FileLockGuard> {
-        let mut file = file.into_async();
+        let checksum = checksum.clone();
+        spawn_blocking(move || -> Result<_> {
+            file.seek(SeekFrom::Start(0))?;
+            let actual = checksum
+                .digest()
+                .update_read(&mut *file)
+                .with_context(|| format!("failed to calculate checksum of: {package}"))?
+                .finish();
 
-        file.seek(SeekFrom::Start(0)).await?;
-        let actual = checksum
-            .digest()
-            .update_read_async(&mut *file)
-            .await
-            .with_context(|| format!("failed to calculate checksum of: {package}"))?
-            .finish();
+            ensure!(
+                actual == checksum,
+                "failed to verify the checksum of downloaded archive"
+            );
 
-        ensure!(
-            actual == *checksum,
-            "failed to verify the checksum of downloaded archive"
-        );
-
-        let file = file.into_sync().await;
-        Ok(file)
+            Ok(file)
+        })
+        .await?
     }
 
     async fn get_record_maybe_uncached(&self, package: PackageId) -> Result<IndexRecord> {


### PR DESCRIPTION
The implementation of `update_read_async` caused stack overflows on Windows only, with exact details being quite a mystery. We did not really need a super performant async version of this code, as we are just using it to compute checksums of files residing in well known local filesystems, and thus the plain old `spawn_blocking` call should do as fine job as the removed code was expected to.