### PR TITLE
Fix link in `Testing Scarb projects` docs section

### DIFF
--- a/website/docs/extensions/testing.md
+++ b/website/docs/extensions/testing.md
@@ -10,7 +10,7 @@ using the [test targets](../reference/targets#test-targets) mechanism.
 The extension itself only relies on produced artifacts to actually run the tests.
 
 As for how to write Cairo tests, we recommend reading the "Testing Cairo Programs" chapter in the
-[Cairo Programming Language](https://cairo-book.github.io/) book.
+[Cairo Programming Language](https://book.cairo-lang.org/) book.
 
 ## Testing Starknet contracts
 


### PR DESCRIPTION
Wrong link [here](https://github.com/software-mansion/scarb/blob/main/website/docs/extensions/testing.md?plain=1#L13)