### PR TITLE
Handle case when packaged repo does not have any commits

### DIFF
--- a/scarb/src/ops/package.rs
+++ b/scarb/src/ops/package.rs
@@ -123,12 +123,16 @@ fn extract_vcs_info(repo: PackageRepository, opts: &PackageOpts) -> Result<Optio
         "#}
     );
 
-    Ok(Some(VcsInfo {
-        path_in_vcs: repo.path_in_vcs()?,
-        git: GitVcsInfo {
-            sha1: repo.head_rev_hash()?,
-        },
-    }))
+    // If the HEAD commit has cannot be determined, we assume the repository is empty.
+    // In that case there is no VCS info to return.
+    if let Ok(sha1) = repo.head_rev_hash() {
+        Ok(Some(VcsInfo {
+            path_in_vcs: repo.path_in_vcs()?,
+            git: GitVcsInfo { sha1 },
+        }))
+    } else {
+        Ok(None)
+    }
 }
 
 #[tracing::instrument(level = "trace", skip(opts, ws))]
@@ -261,16 +265,14 @@ fn prepare_archive_recipe(pkg: &Package, opts: &PackageOpts) -> Result<ArchiveRe
 
     // Add VCS info file.
     if let Ok(repo) = PackageRepository::open(pkg) {
-        recipe.push(ArchiveFile {
-            path: VCS_INFO_FILE_NAME.into(),
-            contents: ArchiveFileContents::Generated({
-                let opts = opts.clone();
-                Box::new(move || {
-                    let vcs_info = extract_vcs_info(repo, &opts)?;
-                    Ok(serde_json::to_string(&vcs_info)?.into_bytes())
-                })
-            }),
-        });
+        if let Some(vcs_info) = extract_vcs_info(repo, opts)? {
+            recipe.push(ArchiveFile {
+                path: VCS_INFO_FILE_NAME.into(),
+                contents: ArchiveFileContents::Generated({
+                    Box::new(move || Ok(serde_json::to_string(&vcs_info)?.into_bytes()))
+                }),
+            });
+        }
     };
 
     // Put generated files in right order within the recipe.

--- a/scarb/src/ops/package.rs
+++ b/scarb/src/ops/package.rs
@@ -123,7 +123,7 @@ fn extract_vcs_info(repo: PackageRepository, opts: &PackageOpts) -> Result<Optio
         "#}
     );
 
-    // If the HEAD commit has cannot be determined, we assume the repository is empty.
+    // If the HEAD commit cannot be determined, we assume the repository is empty.
     // In that case there is no VCS info to return.
     if let Ok(sha1) = repo.head_rev_hash() {
         Ok(Some(VcsInfo {

--- a/scarb/tests/package.rs
+++ b/scarb/tests/package.rs
@@ -574,6 +574,34 @@ fn dirty_repo_allow_dirty() {
 }
 
 #[test]
+fn repo_without_commits() {
+    let t = TempDir::new().unwrap();
+
+    simple_project().build(&t);
+    gitx::init(&t);
+
+    t.child("src/bar.cairo").write_str("fn bar() {}").unwrap();
+
+    Scarb::quick_snapbox()
+        .arg("package")
+        .arg("--allow-dirty")
+        .current_dir(&t)
+        .assert()
+        .success();
+
+    PackageChecker::assert(&t.child("target/package/foo-1.0.0.tar.zst"))
+        .name_and_version("foo", "1.0.0")
+        .contents(&[
+            "VERSION",
+            "Scarb.orig.toml",
+            "Scarb.toml",
+            "src/lib.cairo",
+            "src/foo.cairo",
+            "src/bar.cairo",
+        ]);
+}
+
+#[test]
 fn list_clean_repo() {
     let t = TempDir::new().unwrap();
 


### PR DESCRIPTION
Resolves #869.

Unlike cargo which completely ignores VCS when using `--allow-dirty`, we still want to package the info because that seems reasonably. 

There is an edge case when `--allow-dirty` flag which reads a hash of HEAD commit fails due to repository not having any commits. In that case we want to treat it like there was no VCS information to include at all and just ignore it.