### PR TITLE
Add dep_kind to dependency metadata

### DIFF
--- a/scarb-metadata/src/lib.rs
+++ b/scarb-metadata/src/lib.rs
@@ -237,6 +237,14 @@ pub struct PackageMetadata {
     pub extra: HashMap<String, serde_json::Value>,
 }
 
+/// Dependency kind.
+#[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub enum DepKind {
+    /// Development dependency.
+    Dev,
+}
+
 /// Scarb package dependency specification.
 ///
 /// Only the `name` field is strictly sourced from `Scarb.toml`, the rest is processed by Scarb
@@ -252,6 +260,8 @@ pub struct DependencyMetadata {
     pub version_req: VersionReq,
     /// Package source.
     pub source: SourceId,
+    /// Dependency kind. None denotes normal dependency.
+    pub kind: Option<DepKind>,
 
     /// Additional data not captured by deserializer.
     #[cfg_attr(feature = "builder", builder(default))]

--- a/scarb/src/core/manifest/target_kind.rs
+++ b/scarb/src/core/manifest/target_kind.rs
@@ -83,6 +83,10 @@ impl TargetKind {
         Ok(Self(name))
     }
 
+    pub fn is_test(&self) -> bool {
+        self == &Self::TEST
+    }
+
     #[inline(always)]
     pub fn as_str(&self) -> &str {
         self.0.as_str()

--- a/scarb/src/ops/metadata.rs
+++ b/scarb/src/ops/metadata.rs
@@ -10,8 +10,8 @@ use scarb_ui::args::PackagesSource;
 
 use crate::compiler::CompilationUnit;
 use crate::core::{
-    edition_variant, DependencyVersionReq, ManifestDependency, Package, PackageId, SourceId,
-    Target, Workspace,
+    edition_variant, DepKind, DependencyVersionReq, ManifestDependency, Package, PackageId,
+    SourceId, Target, Workspace,
 };
 use crate::ops;
 use crate::version::CommitInfo;
@@ -161,8 +161,22 @@ fn collect_dependency_metadata(dependency: &ManifestDependency) -> m::Dependency
         .name(dependency.name.to_string())
         .version_req(version_req)
         .source(wrap_source_id(dependency.source_id))
+        .kind(collect_dependency_kind(&dependency.kind))
         .build()
         .unwrap()
+}
+
+fn collect_dependency_kind(kind: &DepKind) -> Option<m::DepKind> {
+    match kind {
+        DepKind::Normal => None,
+        DepKind::Target(kind) => {
+            if kind.is_test() {
+                Some(m::DepKind::Dev)
+            } else {
+                unreachable!("only test target is supported for dep kinds")
+            }
+        }
+    }
 }
 
 fn collect_target_metadata(target: &Target) -> m::TargetMetadata {


### PR DESCRIPTION
Just like in Cargo (https://doc.rust-lang.org/cargo/commands/cargo-metadata.html), expose dependency kind in Scarb metadata
