### PR TITLE
fix: scarb new edition

### DIFF
--- a/scarb/src/ops/new.rs
+++ b/scarb/src/ops/new.rs
@@ -133,7 +133,7 @@ fn mk(
 
     // Create the `Scarb.toml` file.
     let manifest_path = canonical_path.join(MANIFEST_FILE_NAME);
-    let edition = edition_variant(Edition::latest());
+    let edition = edition_variant(Edition::V2023_10);
     fsx::write(
         &manifest_path,
         formatdoc! {r#"


### PR DESCRIPTION
Fixed the prelude edition used to `2023_10` - as `2023_11` is not a valid edition (maybe a bug in the compiler itself, but I figured out they might have reasons to use it internally and not have it released).