### PR TITLE
fix: mistaken error message

### DIFF
--- a/scarb/src/ops/resolve.rs
+++ b/scarb/src/ops/resolve.rs
@@ -364,7 +364,7 @@ fn check_cairo_version_compatibility(packages: &[Package], ws: &Workspace<'_>) -
             Some(package_version) if !package_version.matches(&current_version) => {
                 ws.config().ui().error(format!(
                     "Package {}. Required Cairo version isn't compatible with current version. Should be: {} is: {}",
-                    pkg.id.name, package_version, current_version
+                    pkg.id.name, current_version, package_version
                 ));
                 false
             }


### PR DESCRIPTION
When `Scarb.toml` file is like below:
```toml
[package]
name = "token"
version = "0.1.0"
cairo-version = "4.3.5"
```

`scarb build` command prints the message below:
```
error: Package token. Required Cairo version isn't compatible with current version. Should be: ^4.3.5 is: 2.4.0
error: For each package, the required Cairo version must match the current Cairo version.
```

This part is mistaken: *"... Should be: ^4.3.5 is: 2.4.0"*

The reason is that `package_version` and `current_version` is in wrong order.
```rs
ws.config().ui().error(format!(
    "Package {}. Required Cairo version isn't compatible with current version. Should be: {} is: {}",
    pkg.id.name, package_version, current_version
));
```

This will fix it by changing the code to:
```rs
ws.config().ui().error(format!(
    "Package {}. Required Cairo version isn't compatible with current version. Should be: {} is: {}",
    pkg.id.name, current_version, package_version
));
```