### PR TITLE
Docs: Add starknet section to guide, edition constant and asdf installation note

### DIFF
--- a/website/constants.data.js
+++ b/website/constants.data.js
@@ -1,0 +1,7 @@
+export default {
+  load() {
+    return {
+      edition: "2023_10",
+    };
+  },
+};

--- a/website/docs/guides/creating-a-new-package.md
+++ b/website/docs/guides/creating-a-new-package.md
@@ -1,3 +1,7 @@
+<script setup>
+import {data as constants} from "../../constants.data";
+</script>
+
 # Creating a New Package
 
 To start a new package with Scarb, use `scarb new`:
@@ -18,11 +22,11 @@ As the result of running `scarb new`, Scarb has created two files:
 
 Let's take a closer look at `Scarb.toml`:
 
-```toml
+```toml-vue
 [package]
 name = "hello_world"
 version = "0.1.0"
-edition = "2023_10"
+edition = "{{ constants.edition }}"
 
 [dependencies]
 ```

--- a/website/docs/guides/creating-a-new-package.md
+++ b/website/docs/guides/creating-a-new-package.md
@@ -1,8 +1,14 @@
 <script setup>
+import { data as rel } from "../../github.data";
 import {data as constants} from "../../constants.data";
 </script>
 
 # Creating a New Package
+
+::: info
+At any time, you can review projects hosted in
+[example directory](https://github.com/software-mansion/scarb/tree/main/examples) from Scarb repository.
+:::
 
 To start a new package with Scarb, use `scarb new`:
 
@@ -57,4 +63,35 @@ $ scarb build
     Finished release target(s) in 2 seconds
 ```
 
-This will create a Sierra code of your program in `target/release/hello_world.sierra.json`.
+This will create a Sierra code of your program in `target/dev/hello_world.sierra.json`.
+
+## Creating a Starknet package
+
+To compile Starknet contracts, you need to add `starknet-contract` target and a `starknet` dependency to your manifest:
+
+```toml-vue
+[package]
+name = "hello_world"
+version = "0.1.0"
+edition = "{{ constants.edition }}"
+
+[dependencies]
+starknet = "{{ rel.stable.starknetPackageVersionReq }}"
+
+[[target.starknet-contract]]
+```
+
+The target definition will let Scarb know, that it should produce Starknet contract artifacts.
+The `starknet` dependency tells Scarb to use a Starknet plugin during compilation of your contract.
+
+Then, you can replace the `src/lib.cairo` file with your Starknet contract source code.
+To compile it, simply run the same `build` command as you would for a regular Cairo package:
+
+```shell
+$ scarb build
+   Compiling hello_world v0.1.0 (/path/to/package/hello_world/Scarb.toml)
+    Finished release target(s) in 2 seconds
+```
+
+This will create a Sierra contract class artifact of your program in `target/dev/hello_world.contract_class.json`
+that can be deployed to Starknet network.

--- a/website/docs/reference/manifest.md
+++ b/website/docs/reference/manifest.md
@@ -1,3 +1,7 @@
+<script setup>
+import {data as constants} from "../../constants.data";
+</script>
+
 # The Manifest Format
 
 The `Scarb.toml` file, present in each package, is called its _manifest_.
@@ -57,9 +61,9 @@ The edition key is an optional key that affects which Cairo edition your package
 The editions allow newer Cairo compiler versions to introduce opt-in features that may break existing code.
 Setting the edition key in `[package]` will affect all targets in the package, including test suites etc.
 
-```toml
+```toml-vue
 [package]
-edition = '2023_01'
+edition = "{{ constants.edition }}"
 ```
 
 Most manifests have the edition field filled in automatically by `scarb new` with the latest available edition.

--- a/website/download.md
+++ b/website/download.md
@@ -71,8 +71,10 @@ Mind that asdf works on macOS and Linux only.
 This plugin needs `bash`, `curl`, `tar` and other generic POSIX utilities.
 Everything should be included by default on your system.
 
-When you have asdf already [installed](https://asdf-vm.com/guide/getting-started.html),
-run the following command to add the `scarb` plugin:
+First [install asdf by following the official installation guide](https://asdf-vm.com/guide/getting-started.html).
+Make sure to complete all installation instructions from the guide,
+in particular add asdf to your local shell's configuration.
+Then run the following command to add the `scarb` plugin:
 
 ```shell
 asdf plugin add scarb


### PR DESCRIPTION
- Make ASDF installation guide more noticeable
- Add edition constant in website def
- Add a starknet section to creating package guide
