### PR TITLE
`availabe_gas` support in snfoundry-test-collector

### DIFF
--- a/extensions/scarb-snforge-test-collector/src/compilation/test_collector/config.rs
+++ b/extensions/scarb-snforge-test-collector/src/compilation/test_collector/config.rs
@@ -147,13 +147,13 @@ pub fn forge_try_extract_test_config(
 
     let result = maybe_test_config.map(
         |TestConfig {
+             available_gas,
              expectation,
              ignored,
-             available_gas,
          }| SingleTestConfig {
+            available_gas,
             expected_result: expectation.into(),
             ignored,
-            available_gas,
             fork_config,
             fuzzer_config,
         },

--- a/extensions/scarb-snforge-test-collector/src/compilation/test_collector/config.rs
+++ b/extensions/scarb-snforge-test-collector/src/compilation/test_collector/config.rs
@@ -13,7 +13,6 @@ use num_bigint::BigInt;
 use num_traits::ToPrimitive;
 use serde::Serialize;
 
-const AVAILABLE_GAS_ATTR: &str = "available_gas";
 const FORK_ATTR: &str = "fork";
 const FUZZER_ATTR: &str = "fuzzer";
 
@@ -96,9 +95,6 @@ pub fn forge_try_extract_test_config(
     attrs: &[Attribute],
 ) -> Result<Option<SingleTestConfig>, Vec<PluginDiagnostic>> {
     let maybe_test_config = try_extract_test_config(db, attrs.to_vec())?;
-    let available_gas_attr = attrs
-        .iter()
-        .find(|attr| attr.id.as_str() == AVAILABLE_GAS_ATTR);
     let fork_attr = attrs.iter().find(|attr| attr.id.as_str() == FORK_ATTR);
     let fuzzer_attr = attrs.iter().find(|attr| attr.id.as_str() == FUZZER_ATTR);
 
@@ -113,14 +109,6 @@ pub fn forge_try_extract_test_config(
             });
         }
     }
-
-    let available_gas = if available_gas_attr.is_some() {
-        // we do not support it so we can write anything here,
-        // any errors in syntax will be caught by `try_extract_test_config` anyways
-        Some(0)
-    } else {
-        None
-    };
 
     let fork_config = if let Some(attr) = fork_attr {
         if attr.args.is_empty() {
@@ -161,11 +149,11 @@ pub fn forge_try_extract_test_config(
         |TestConfig {
              expectation,
              ignored,
-             ..
+             available_gas,
          }| SingleTestConfig {
-            available_gas,
             expected_result: expectation.into(),
             ignored,
+            available_gas,
             fork_config,
             fuzzer_config,
         },

--- a/extensions/scarb-snforge-test-collector/tests/test.rs
+++ b/extensions/scarb-snforge-test-collector/tests/test.rs
@@ -8,7 +8,7 @@ use indoc::indoc;
 use scarb_test_support::command::Scarb;
 
 use scarb_test_support::project_builder::ProjectBuilder;
-use serde_json::Value;
+use serde_json::{Number, Value};
 
 const SIMPLE_TEST: &str = indoc! {r#"
     #[cfg(test)]
@@ -48,7 +48,7 @@ fn forge_test_locations() {
     assert_eq!(&json[1]["test_cases"][0]["name"], "tests::tests::test");
     assert_eq!(&json[1]["tests_location"], "Tests");
 
-    assert_eq!(&json[0]["test_cases"][0]["available_gas"], &Value::Null);
+    assert_eq!(&json[0]["test_cases"][0]["available_gas"], &Value::Number(Number::from(u32::MAX)));
     assert_eq!(&json[0]["test_cases"][0]["expected_result"], "Success");
     assert_eq!(&json[0]["test_cases"][0]["fork_config"], &Value::Null);
     assert_eq!(&json[0]["test_cases"][0]["fuzzer_config"], &Value::Null);
@@ -85,6 +85,7 @@ const WITH_MANY_ATTRIBUTES_TEST: &str = indoc! {r#"
         #[fork(url: "http://your.rpc.url", block_id: BlockId::Number(123))]
         #[should_panic]
         #[fuzzer(runs: 22, seed: 38)]
+        #[available_gas(100)]
         #[test]
         fn test(a: felt252) {
             assert(true == true, 'it works!')
@@ -114,7 +115,7 @@ fn forge_test_with_attributes() {
 
     let json: Value = serde_json::from_str(&snforge_sierra).unwrap();
 
-    assert_eq!(&json[0]["test_cases"][0]["available_gas"], &Value::Null);
+    assert_eq!(&json[0]["test_cases"][0]["available_gas"], &Value::Number(Number::from(100)));
     assert_eq!(
         &json[0]["test_cases"][0]["expected_result"]["Panics"],
         "Any"

--- a/extensions/scarb-snforge-test-collector/tests/test.rs
+++ b/extensions/scarb-snforge-test-collector/tests/test.rs
@@ -48,7 +48,10 @@ fn forge_test_locations() {
     assert_eq!(&json[1]["test_cases"][0]["name"], "tests::tests::test");
     assert_eq!(&json[1]["tests_location"], "Tests");
 
-    assert_eq!(&json[0]["test_cases"][0]["available_gas"], &Value::Number(Number::from(u32::MAX)));
+    assert_eq!(
+        &json[0]["test_cases"][0]["available_gas"],
+        &Value::Number(Number::from(u32::MAX))
+    );
     assert_eq!(&json[0]["test_cases"][0]["expected_result"], "Success");
     assert_eq!(&json[0]["test_cases"][0]["fork_config"], &Value::Null);
     assert_eq!(&json[0]["test_cases"][0]["fuzzer_config"], &Value::Null);
@@ -115,7 +118,10 @@ fn forge_test_with_attributes() {
 
     let json: Value = serde_json::from_str(&snforge_sierra).unwrap();
 
-    assert_eq!(&json[0]["test_cases"][0]["available_gas"], &Value::Number(Number::from(100)));
+    assert_eq!(
+        &json[0]["test_cases"][0]["available_gas"],
+        &Value::Number(Number::from(100))
+    );
     assert_eq!(
         &json[0]["test_cases"][0]["expected_result"]["Panics"],
         "Any"


### PR DESCRIPTION
This PR is connected to the [issue](https://github.com/foundry-rs/starknet-foundry/issues/618) from the Starknet-Foundry repo. It adds support for the `available_gas` attribute in the `test-collector`