### PR TITLE
Remove @mkaput from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @tomek0123456789 @szymmis @maciektr @mkaput
+* @tomek0123456789 @szymmis @maciektr


### PR DESCRIPTION
@mkaput is going to maintain CairoLS and will not attempt to review each PR going into Scarb from now on.