### PR TITLE
Fix `snforge-test-collector`'s default `available_gas` value

### DIFF
--- a/extensions/scarb-snforge-test-collector/src/compilation/test_collector/config.rs
+++ b/extensions/scarb-snforge-test-collector/src/compilation/test_collector/config.rs
@@ -147,15 +147,22 @@ pub fn forge_try_extract_test_config(
 
     let result = maybe_test_config.map(
         |TestConfig {
-             available_gas,
+             mut available_gas,
              expectation,
              ignored,
-         }| SingleTestConfig {
-            available_gas,
-            expected_result: expectation.into(),
-            ignored,
-            fork_config,
-            fuzzer_config,
+         }| {
+            // Older versions will crash if the default is passed through
+            if available_gas.is_some_and(|gas_amt| gas_amt == u32::MAX as usize){
+                available_gas = None
+            }
+
+            SingleTestConfig {
+                available_gas,
+                expected_result: expectation.into(),
+                ignored,
+                fork_config,
+                fuzzer_config,
+            }
         },
     );
     Ok(result)

--- a/extensions/scarb-snforge-test-collector/src/compilation/test_collector/config.rs
+++ b/extensions/scarb-snforge-test-collector/src/compilation/test_collector/config.rs
@@ -15,7 +15,7 @@ use serde::Serialize;
 
 const FORK_ATTR: &str = "fork";
 const FUZZER_ATTR: &str = "fuzzer";
-
+const AVAILABLE_GAS_ATTR: &str = "available_gas";
 /// Expectation for a panic case.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub enum ExpectedPanicValue {
@@ -152,7 +152,11 @@ pub fn forge_try_extract_test_config(
              ignored,
          }| {
             // Older versions will crash if the default is passed through
-            if available_gas.is_some_and(|gas_amt| gas_amt == u32::MAX as usize){
+            let available_gas_attr = attrs
+                .iter()
+                .find(|attr| attr.id.as_str() == AVAILABLE_GAS_ATTR);
+
+            if available_gas_attr.is_none() {
                 available_gas = None
             }
 

--- a/extensions/scarb-snforge-test-collector/tests/test.rs
+++ b/extensions/scarb-snforge-test-collector/tests/test.rs
@@ -48,10 +48,7 @@ fn forge_test_locations() {
     assert_eq!(&json[1]["test_cases"][0]["name"], "tests::tests::test");
     assert_eq!(&json[1]["tests_location"], "Tests");
 
-    assert_eq!(
-        &json[0]["test_cases"][0]["available_gas"],
-        &Value::Null
-    );
+    assert_eq!(&json[0]["test_cases"][0]["available_gas"], &Value::Null);
     assert_eq!(&json[0]["test_cases"][0]["expected_result"], "Success");
     assert_eq!(&json[0]["test_cases"][0]["fork_config"], &Value::Null);
     assert_eq!(&json[0]["test_cases"][0]["fuzzer_config"], &Value::Null);

--- a/extensions/scarb-snforge-test-collector/tests/test.rs
+++ b/extensions/scarb-snforge-test-collector/tests/test.rs
@@ -50,7 +50,7 @@ fn forge_test_locations() {
 
     assert_eq!(
         &json[0]["test_cases"][0]["available_gas"],
-        &Value::Number(Number::from(u32::MAX))
+        &Value::Null
     );
     assert_eq!(&json[0]["test_cases"][0]["expected_result"], "Success");
     assert_eq!(&json[0]["test_cases"][0]["fork_config"], &Value::Null);


### PR DESCRIPTION
This needs to be `None` because older versions of snforge would crash on `u32::max` (which seems to be a default value), with an error that the attribute is not supported.