### PR TITLE
CI: Use M1 runners wherever possible

### DIFF
--- a/.github/workflows/_build-release.yml
+++ b/.github/workflows/_build-release.yml
@@ -45,10 +45,10 @@ jobs:
             cross: true
 
           - target: x86_64-apple-darwin
-            os: macos-latest
+            os: macos-13
 
           - target: aarch64-apple-darwin
-            os: macos-latest
+            os: macos-14
 
           - target: x86_64-pc-windows-msvc
             os: windows-latest
@@ -104,8 +104,8 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-22.04
 
-          - target: x86_64-apple-darwin
-            os: macos-12
+          - target: aarch64-apple-darwin
+            os: macos-14
 
           - target: x86_64-pc-windows-msvc
             os: windows-2019

--- a/.github/workflows/_check-release.yml
+++ b/.github/workflows/_check-release.yml
@@ -30,7 +30,7 @@ jobs:
         include:
           - name: linux x86-64
             os: ubuntu-latest
-          - name: macos x86-64
+          - name: macos aarch64
             os: macos-14
           - name: windows x86-64
             os: windows-latest

--- a/.github/workflows/_check-release.yml
+++ b/.github/workflows/_check-release.yml
@@ -31,7 +31,7 @@ jobs:
           - name: linux x86-64
             os: ubuntu-latest
           - name: macos x86-64
-            os: macos-latest
+            os: macos-14
           - name: windows x86-64
             os: windows-latest
     steps:


### PR DESCRIPTION
https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/