### PR TITLE
Exclude cairo-felt from dependabot patterns

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,7 @@ updates:
           - "*"
         exclude-patterns:
           - "cairo-lang-*"
+          - "cairo-felt"
           - "deno_task_shell"
           - "gix"
           - "semver"


### PR DESCRIPTION
Motivation: should match the compiler used