### PR TITLE
fix: derive Clone and Debug for CompilationUnit enum

### DIFF
--- a/scarb/src/compiler/compilation_unit.rs
+++ b/scarb/src/compiler/compilation_unit.rs
@@ -11,6 +11,7 @@ use crate::flock::Filesystem;
 use scarb_stable_hash::StableHasher;
 
 /// An object that has enough information so that Scarb knows how to build it.
+#[derive(Clone, Debug)]
 pub enum CompilationUnit {
     Cairo(CairoCompilationUnit),
     ProcMacro(ProcMacroCompilationUnit),


### PR DESCRIPTION
Currently, all the variant of the enum derive `Clone` and `Debug`. Could be helpful to clone regardless of the variant if it's ok for you. :+1: 