### PR TITLE
Fix nightlies pipeline after rust package id spec update

### DIFF
--- a/xtask/src/nightly_release_notes.rs
+++ b/xtask/src/nightly_release_notes.rs
@@ -28,11 +28,14 @@ pub fn main(_: Args) -> Result<()> {
         .unwrap()
         .iter()
         .find(|node| {
-            node.get("id")
+            let repr = node.get("id")
                 .unwrap()
                 .as_str()
-                .unwrap()
-                .starts_with("scarb ")
+                .unwrap();
+            // The first condition for Rust >= 1.77
+            // (After the PackageId spec stabilization)
+            // The second condition for Rust < 1.77
+            repr.contains("scarb#") || repr.starts_with("scarb ")
         })
         .unwrap()
         .get("deps")


### PR DESCRIPTION
commit-id:006f3571

---

**Stack**:
- #1220
- #1219
- #1218
- #1217
- #1216
- #1215
- #1214
- #1221
- #1222 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*