### PR TITLE
Consider a case when the test fn return types are actually an empty vec

### DIFF
--- a/extensions/scarb-snforge-test-collector/src/compilation/test_collector.rs
+++ b/extensions/scarb-snforge-test-collector/src/compilation/test_collector.rs
@@ -243,6 +243,12 @@ fn validate_tests(
         let func = function_finder.find_function(&test.name)?;
         let signature = &func.signature;
         let ret_types = &signature.ret_types;
+        if ret_types.is_empty() {
+            bail!(
+                "The test function {} always succeeds and cannot be used as a test. Make sure to include panickable statements such as `assert` in your test",
+                test.name
+            );
+        }
         let tp = &ret_types[ret_types.len() - 1];
         let info = function_finder.get_info(tp);
         let mut maybe_return_type_name = None;

--- a/extensions/scarb-snforge-test-collector/tests/test.rs
+++ b/extensions/scarb-snforge-test-collector/tests/test.rs
@@ -107,14 +107,16 @@ fn forge_empty_test() {
         .build(&pkg1);
     let output = Scarb::quick_snapbox()
         .arg("snforge-test-collector")
-        .current_dir(&pkg1).output().unwrap();
+        .current_dir(&pkg1)
+        .output()
+        .unwrap();
 
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr).to_string();
     assert!(stderr.contains(
-    "Error: The test function forge_test::tests::test always succeeds and cannot be used as a test"));
+    "Error: The test function forge_test::tests::test always succeeds and cannot be used as a test")
+    );
 }
-
 
 const WITH_MANY_ATTRIBUTES_TEST: &str = indoc! {r#"
     #[cfg(test)]

--- a/extensions/scarb-snforge-test-collector/tests/test.rs
+++ b/extensions/scarb-snforge-test-collector/tests/test.rs
@@ -87,6 +87,35 @@ fn forge_test_wrong_location() {
     assert_eq!(&json[0]["test_cases"][0], &Value::Null);
 }
 
+const EMPTY_TEST: &str = indoc! {r#"
+    #[cfg(test)]
+    mod tests {
+        #[test]
+        fn test() {}
+    }
+    "#
+};
+
+#[test]
+fn forge_empty_test() {
+    let t = TempDir::new().unwrap();
+    let pkg1 = t.child("forge");
+
+    ProjectBuilder::start()
+        .name("forge_test")
+        .lib_cairo(EMPTY_TEST)
+        .build(&pkg1);
+    let output = Scarb::quick_snapbox()
+        .arg("snforge-test-collector")
+        .current_dir(&pkg1).output().unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    assert!(stderr.contains(
+    "Error: The test function forge_test::tests::test always succeeds and cannot be used as a test"));
+}
+
+
 const WITH_MANY_ATTRIBUTES_TEST: &str = indoc! {r#"
     #[cfg(test)]
     mod tests {


### PR DESCRIPTION
Closes https://github.com/foundry-rs/starknet-foundry/issues/1934