### PR TITLE
Update deno_task_shell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1495,9 +1495,9 @@ checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
 
 [[package]]
 name = "deno_task_shell"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4721cc23c43e05a8dce807ed322320b3538ce9a60d131c50b2301b14c984a9d4"
+checksum = "6b44af10161906e1bccc1fc966f074bec0148997bb7e2221ecd29416dcad90b3"
 dependencies = [
  "anyhow",
  "futures",
@@ -1505,6 +1505,7 @@ dependencies = [
  "monch",
  "os_pipe",
  "path-dedot",
+ "thiserror",
  "tokio",
  "tokio-util",
 ]

--- a/scarb/src/ops/scripts.rs
+++ b/scarb/src/ops/scripts.rs
@@ -25,7 +25,8 @@ pub fn execute_script(
         (
             "scarb".to_string(),
             Rc::new(ExecutableCommand::new(
-                ws.config().app_exe()?.display().to_string(),
+                "scarb".to_string(),
+                ws.config().app_exe()?.to_path_buf(),
             )) as Rc<dyn ShellCommand>,
         ),
     ]);


### PR DESCRIPTION
Replaces https://github.com/software-mansion/scarb/pull/1239
- **Bump deno_task_shell from 0.15.0 to 0.16.0**
- **Fix build after deno update**
