### PR TITLE
Add forge template to `scarb new` and `scarb init` under separate flag

### DIFF
--- a/scarb/src/bin/scarb/args.rs
+++ b/scarb/src/bin/scarb/args.rs
@@ -241,6 +241,10 @@ pub struct InitArgs {
     /// Do not initialize a new Git repository.
     #[arg(long)]
     pub no_vcs: bool,
+
+    /// Initialize snforge setup.
+    #[arg(long)]
+    pub snforge: bool,
 }
 
 /// Arguments accepted by the `metadata` command.

--- a/scarb/src/bin/scarb/args.rs
+++ b/scarb/src/bin/scarb/args.rs
@@ -242,7 +242,7 @@ pub struct InitArgs {
     #[arg(long)]
     pub no_vcs: bool,
 
-    /// Initialize snforge setup.
+    /// Use a Starknet Foundry Forge template.
     #[arg(long)]
     pub snforge: bool,
 }

--- a/scarb/src/bin/scarb/commands/init.rs
+++ b/scarb/src/bin/scarb/commands/init.rs
@@ -24,6 +24,7 @@ pub fn run(args: InitArgs, config: &Config) -> Result<()> {
             } else {
                 VersionControl::Git
             },
+            snforge: args.snforge,
         },
         config,
     )?;

--- a/scarb/src/bin/scarb/commands/new.rs
+++ b/scarb/src/bin/scarb/commands/new.rs
@@ -18,6 +18,7 @@ pub fn run(args: NewArgs, config: &Config) -> Result<()> {
             } else {
                 VersionControl::Git
             },
+            snforge: args.init.snforge,
         },
         config,
     )?;

--- a/scarb/src/ops/new.rs
+++ b/scarb/src/ops/new.rs
@@ -211,7 +211,7 @@ fn init_snforge(name: PackageName, target_dir: Utf8PathBuf, config: &Config) -> 
     let mut process = Command::new("snforge")
         .arg("init")
         .arg(name.as_str())
-        .current_dir(target_dir.canonicalize_utf8()?)
+        .current_dir(fsx::canonicalize_utf8(&target_dir)?)
         .envs(get_env_vars(config, Some(target_dir))?)
         .stderr(Stdio::inherit())
         .stdout(Stdio::inherit())

--- a/scarb/src/ops/new.rs
+++ b/scarb/src/ops/new.rs
@@ -208,13 +208,16 @@ fn mk(
 }
 
 fn init_snforge(name: PackageName, target_dir: Utf8PathBuf, config: &Config) -> Result<()> {
-    Command::new("snforge")
+    let mut process = Command::new("snforge")
         .arg("init")
         .arg(name.as_str())
+        .current_dir(target_dir.canonicalize_utf8()?)
         .envs(get_env_vars(config, Some(target_dir))?)
         .stderr(Stdio::inherit())
         .stdout(Stdio::inherit())
-        .status()?;
+        .spawn()?;
+
+    process.wait()?;
 
     Ok(())
 }

--- a/scarb/src/ops/new.rs
+++ b/scarb/src/ops/new.rs
@@ -8,6 +8,7 @@ use crate::core::{edition_variant, Config, PackageName};
 use crate::internal::fsx;
 use crate::internal::restricted_names;
 use crate::{ops, DEFAULT_SOURCE_PATH, DEFAULT_TARGET_DIR_NAME, MANIFEST_FILE_NAME};
+use std::process::Command;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum VersionControl {
@@ -20,6 +21,7 @@ pub struct InitOptions {
     pub path: Utf8PathBuf,
     pub name: Option<PackageName>,
     pub vcs: VersionControl,
+    pub snforge: bool,
 }
 
 #[derive(Debug)]
@@ -46,6 +48,7 @@ pub fn new_package(opts: InitOptions, config: &Config) -> Result<NewResult> {
             path: opts.path.clone(),
             name: name.clone(),
             version_control: opts.vcs,
+            snforge: opts.snforge,
         },
         config,
     )
@@ -67,6 +70,7 @@ pub fn init_package(opts: InitOptions, config: &Config) -> Result<NewResult> {
             path: opts.path,
             name: name.clone(),
             version_control: opts.vcs,
+            snforge: opts.snforge,
         },
         config,
     )
@@ -113,6 +117,7 @@ struct MkOpts {
     path: Utf8PathBuf,
     name: PackageName,
     version_control: VersionControl,
+    snforge: bool,
 }
 
 fn mk(
@@ -120,6 +125,7 @@ fn mk(
         path,
         name,
         version_control,
+        snforge,
     }: MkOpts,
     config: &Config,
 ) -> Result<()> {
@@ -192,6 +198,19 @@ fn mk(
             {err:?}
         "#})
     }
+
+    if snforge {
+        init_snforge(name)?;
+    }
+
+    Ok(())
+}
+
+fn init_snforge(name: PackageName) -> Result<()> {
+    Command::new("snforge")
+        .arg("init")
+        .arg(name.as_str())
+        .status()?;
 
     Ok(())
 }


### PR DESCRIPTION
Closes  #1208

- Added `--snforge` flag that enables forge template for
   - `new` command
   - `init` command
   
  On forge side https://github.com/foundry-rs/starknet-foundry/pull/2113