### PR TITLE
Add derives for `Severity` and `Diagnostics`

### DIFF
--- a/plugins/cairo-lang-macro/src/types/mod.rs
+++ b/plugins/cairo-lang-macro/src/types/mod.rs
@@ -5,7 +5,7 @@ mod conversion;
 mod expansions;
 
 pub use expansions::*;
-use std::ops::Deref;
+use std::ops::{Deref, DerefMut};
 
 /// Result of procedural macro code generation.
 #[derive(Debug)]
@@ -198,6 +198,12 @@ impl Deref for Diagnostics {
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+impl DerefMut for Diagnostics {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
     }
 }
 

--- a/plugins/cairo-lang-macro/src/types/mod.rs
+++ b/plugins/cairo-lang-macro/src/types/mod.rs
@@ -161,15 +161,15 @@ impl From<AuxData> for Vec<u8> {
 /// Diagnostic returned by the procedural macro.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Diagnostic {
+    /// The severity of the [`Diagnostic`].
+    ///
+    /// Defines how this diagnostic should influence the compilation.
+    pub severity: Severity,
     /// A human addressed message associated with the [`Diagnostic`].
     ///
     /// This message will not be parsed by the compiler,
     /// but rather shown to the user as an explanation.
     pub message: String,
-    /// The severity of the [`Diagnostic`].
-    ///
-    /// Defines how this diagnostic should influence the compilation.
-    pub severity: Severity,
 }
 
 /// The severity of a diagnostic.
@@ -179,14 +179,14 @@ pub struct Diagnostic {
 /// The appropriate action for each diagnostic kind will be taken by `Scarb`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Severity {
-    /// An error has occurred.
-    ///
-    /// Emitting diagnostic with [`Severity::Error`] severity will fail the source code compilation.
-    Error = 1,
     /// A warning suggestion will be shown to the user.
     ///
     /// Emitting diagnostic with [`Severity::Warning`] severity does not stop the compilation.
-    Warning = 2,
+    Warning = 1,
+    /// An error has occurred.
+    ///
+    /// Emitting diagnostic with [`Severity::Error`] severity will fail the source code compilation.
+    Error = 2,
 }
 
 /// A set of diagnostics that arose during the computation.

--- a/plugins/cairo-lang-macro/src/types/mod.rs
+++ b/plugins/cairo-lang-macro/src/types/mod.rs
@@ -5,6 +5,7 @@ mod conversion;
 mod expansions;
 
 pub use expansions::*;
+use std::ops::Deref;
 
 /// Result of procedural macro code generation.
 #[derive(Debug)]
@@ -158,7 +159,7 @@ impl From<AuxData> for Vec<u8> {
 }
 
 /// Diagnostic returned by the procedural macro.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Diagnostic {
     /// A human addressed message associated with the [`Diagnostic`].
     ///
@@ -176,7 +177,7 @@ pub struct Diagnostic {
 /// This should be roughly equivalent to the severity of Cairo diagnostics.
 ///
 /// The appropriate action for each diagnostic kind will be taken by `Scarb`.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Severity {
     /// An error has occurred.
     ///
@@ -189,8 +190,16 @@ pub enum Severity {
 }
 
 /// A set of diagnostics that arose during the computation.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Diagnostics(Vec<Diagnostic>);
+
+impl Deref for Diagnostics {
+    type Target = Vec<Diagnostic>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 impl Diagnostic {
     /// Create new diagnostic with severity [`Severity::Error`].

--- a/plugins/cairo-lang-macro/src/types/mod.rs
+++ b/plugins/cairo-lang-macro/src/types/mod.rs
@@ -5,7 +5,6 @@ mod conversion;
 mod expansions;
 
 pub use expansions::*;
-use std::ops::{Deref, DerefMut};
 
 /// Result of procedural macro code generation.
 #[derive(Debug)]
@@ -193,20 +192,6 @@ pub enum Severity {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Diagnostics(Vec<Diagnostic>);
 
-impl Deref for Diagnostics {
-    type Target = Vec<Diagnostic>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl DerefMut for Diagnostics {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
 impl Diagnostic {
     /// Create new diagnostic with severity [`Severity::Error`].
     pub fn error(message: impl ToString) -> Self {
@@ -264,6 +249,18 @@ impl IntoIterator for Diagnostics {
 
     fn into_iter(self) -> IntoIter<Diagnostic> {
         self.0.into_iter()
+    }
+}
+
+impl FromIterator<Diagnostic> for Diagnostics {
+    fn from_iter<T: IntoIterator<Item = Diagnostic>>(iter: T) -> Self {
+        Self(iter.into_iter().collect())
+    }
+}
+
+impl Extend<Diagnostic> for Diagnostics {
+    fn extend<T: IntoIterator<Item = Diagnostic>>(&mut self, iter: T) {
+        self.0.extend(iter.into_iter());
     }
 }
 

--- a/plugins/cairo-lang-macro/src/types/mod.rs
+++ b/plugins/cairo-lang-macro/src/types/mod.rs
@@ -159,17 +159,17 @@ impl From<AuxData> for Vec<u8> {
 }
 
 /// Diagnostic returned by the procedural macro.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Diagnostic {
-    /// The severity of the [`Diagnostic`].
-    ///
-    /// Defines how this diagnostic should influence the compilation.
-    pub severity: Severity,
     /// A human addressed message associated with the [`Diagnostic`].
     ///
     /// This message will not be parsed by the compiler,
     /// but rather shown to the user as an explanation.
     pub message: String,
+    /// The severity of the [`Diagnostic`].
+    ///
+    /// Defines how this diagnostic should influence the compilation.
+    pub severity: Severity,
 }
 
 /// The severity of a diagnostic.
@@ -177,20 +177,20 @@ pub struct Diagnostic {
 /// This should be roughly equivalent to the severity of Cairo diagnostics.
 ///
 /// The appropriate action for each diagnostic kind will be taken by `Scarb`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Severity {
-    /// A warning suggestion will be shown to the user.
-    ///
-    /// Emitting diagnostic with [`Severity::Warning`] severity does not stop the compilation.
-    Warning = 1,
     /// An error has occurred.
     ///
     /// Emitting diagnostic with [`Severity::Error`] severity will fail the source code compilation.
-    Error = 2,
+    Error = 1,
+    /// A warning suggestion will be shown to the user.
+    ///
+    /// Emitting diagnostic with [`Severity::Warning`] severity does not stop the compilation.
+    Warning = 2,
 }
 
 /// A set of diagnostics that arose during the computation.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Diagnostics(Vec<Diagnostic>);
 
 impl Deref for Diagnostics {

--- a/plugins/cairo-lang-macro/src/types/mod.rs
+++ b/plugins/cairo-lang-macro/src/types/mod.rs
@@ -260,7 +260,7 @@ impl FromIterator<Diagnostic> for Diagnostics {
 
 impl Extend<Diagnostic> for Diagnostics {
     fn extend<T: IntoIterator<Item = Diagnostic>>(&mut self, iter: T) {
-        self.0.extend(iter.into_iter());
+        self.0.extend(iter);
     }
 }
 


### PR DESCRIPTION
Add derives for `Diagnostic`, `Severity` and `Diagnostics`, also `Deref` for `Diagnostics`. In current shape these are very hard to work with, which is caused by lack of basic functionalities (like `Eq`), also `Diagnostics` can't be merged or extended with ready `Diagnostic` (only by matching on it's `Severity` and then choosing correct method to reconstruct in again)