### PR TITLE
fix: propose consistent usage of debug from tracing

### DIFF
--- a/scarb/src/sources/git/client.rs
+++ b/scarb/src/sources/git/client.rs
@@ -13,7 +13,7 @@ use std::process::Command;
 
 use anyhow::{anyhow, bail, Context, Result};
 use camino::Utf8PathBuf;
-use tracing::log::debug;
+use tracing::debug;
 
 use scarb_ui::Verbosity;
 


### PR DESCRIPTION
Gm guys,

wondering if this is a typo or an actual fix.

In dojo we're using scarb as a dependency, and when we compile a package of the workspace this error occurs, which prevent us from building a specific package depending on scarb explicitly.

However, when the whole workspace is compiled, it works fine.

Inspecting the scarb code base, everywhere it seems to be `tracing::trace`, `tracing::debug` etc... Is this `tracing::log::debug` forgotten, but not a direct problem as it compiles fine anyway?

Thanks for the feedback!