### PR TITLE
Make Scarb smarter when searching for Cargo binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4173,6 +4173,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ra_ap_toolchain"
+version = "0.0.218"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53393fc4d85057bcca4dd2d7fa24929a094bb94712980814695f56cb9aa0b1e2"
+dependencies = [
+ "camino",
+ "home",
+]
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4578,6 +4588,7 @@ dependencies = [
  "pathdiff",
  "petgraph",
  "predicates",
+ "ra_ap_toolchain",
  "redb",
  "reqwest",
  "scarb-build-metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ petgraph = "0.6"
 predicates = "3"
 proc-macro2 = "1"
 quote = "1"
+ra_ap_toolchain = "0.0.218"
 rayon = "1.10"
 redb = "2.1.0"
 reqwest = { version = "0.11", features = ["gzip", "brotli", "deflate", "json", "stream"], default-features = false }

--- a/scarb/Cargo.toml
+++ b/scarb/Cargo.toml
@@ -24,8 +24,8 @@ cairo-lang-formatter.workspace = true
 cairo-lang-macro = { path = "../plugins/cairo-lang-macro" }
 cairo-lang-macro-stable = { path = "../plugins/cairo-lang-macro-stable" }
 cairo-lang-semantic.workspace = true
-cairo-lang-sierra.workspace = true
 cairo-lang-sierra-to-casm.workspace = true
+cairo-lang-sierra.workspace = true
 cairo-lang-starknet-classes.workspace = true
 cairo-lang-starknet.workspace = true
 cairo-lang-syntax.workspace = true
@@ -51,6 +51,7 @@ libloading.workspace = true
 once_cell.workspace = true
 pathdiff.workspace = true
 petgraph.workspace = true
+ra_ap_toolchain.workspace = true
 redb.workspace = true
 reqwest.workspace = true
 scarb-build-metadata = { path = "../utils/scarb-build-metadata" }

--- a/scarb/src/compiler/plugin/proc_macro/compilation.rs
+++ b/scarb/src/compiler/plugin/proc_macro/compilation.rs
@@ -5,6 +5,7 @@ use crate::process::exec_piping;
 use anyhow::Result;
 use camino::Utf8PathBuf;
 use libloading::library_filename;
+use ra_ap_toolchain::Tool;
 use scarb_ui::{Message, OutputFormat};
 use serde::{Serialize, Serializer};
 use serde_json::value::RawValue;
@@ -118,7 +119,7 @@ impl From<OutputFormat> for CargoOutputFormat {
 
 impl From<CargoCommand> for Command {
     fn from(args: CargoCommand) -> Self {
-        let mut cmd = Command::new("cargo");
+        let mut cmd = Command::new(Tool::Cargo.path());
         cmd.current_dir(args.current_dir);
         match args.action {
             CargoAction::Fetch => cmd.arg("fetch"),


### PR DESCRIPTION
This commit borrows the logic for looking for Cargo from Rust Analyzer, via its published `ra_ap_toolchain` crate.
This change makes Scarb aware of:
1. The `CARGO` environment variable
2. The relatively well-known `$CARGO_HOME` directory

This should make Scarb succeed to run `cargo fetch`/`build` when being run outside the interactive shell
(i.e. without environment set by `rustup`).
This includes running Scarb from CairoLS that is being run from a desktop application (like VSCode launched from macOS Dock).