### PR TITLE
Pass pkg parent to snforge init

### DIFF
--- a/scarb/src/ops/new.rs
+++ b/scarb/src/ops/new.rs
@@ -201,18 +201,19 @@ fn mk(
     }
 
     if snforge {
-        init_snforge(name, path, config)?;
+        init_snforge(name, canonical_path, config)?;
     }
 
     Ok(())
 }
 
 fn init_snforge(name: PackageName, target_dir: Utf8PathBuf, config: &Config) -> Result<()> {
+    let target_dir = target_dir.parent().context("package must have a parent")?;
     let mut process = Command::new("snforge")
         .arg("init")
         .arg(name.as_str())
-        .current_dir(fsx::canonicalize_utf8(&target_dir)?)
-        .envs(get_env_vars(config, Some(target_dir))?)
+        .current_dir(target_dir)
+        .envs(get_env_vars(config, None)?)
         .stderr(Stdio::inherit())
         .stdout(Stdio::inherit())
         .spawn()?;


### PR DESCRIPTION
It seems that's what is expected there https://github.com/foundry-rs/starknet-foundry/blob/74da40441b7bf51582fc053dcc4d4d751bef1f44/crates/forge/src/init.rs#L104

Also, I've submitted a PR in snforge repo that sets correct manifest paths in scarb new https://github.com/foundry-rs/starknet-foundry/pull/2223