### PR TITLE
Add `publish` field to Scarb.toml to mark package as not publishable to the registry

### DIFF
--- a/scarb/src/core/manifest/mod.rs
+++ b/scarb/src/core/manifest/mod.rs
@@ -48,6 +48,8 @@ pub struct Manifest {
     #[builder(default)]
     pub edition: Edition,
     #[builder(default)]
+    pub publish: bool,
+    #[builder(default)]
     pub metadata: ManifestMetadata,
     #[builder(default = "ManifestCompilerConfig::default_for_profile(&Profile::DEV)")]
     pub compiler_config: ManifestCompilerConfig,

--- a/scarb/src/core/manifest/toml_manifest.rs
+++ b/scarb/src/core/manifest/toml_manifest.rs
@@ -186,6 +186,7 @@ pub struct TomlPackage {
     pub name: PackageName,
     pub version: MaybeWorkspaceField<Version>,
     pub edition: Option<MaybeWorkspaceField<Edition>>,
+    pub publish: Option<bool>,
     pub authors: Option<MaybeWorkspaceField<Vec<String>>>,
     pub urls: Option<BTreeMap<String, String>>,
     pub description: Option<MaybeWorkspaceField<String>>,

--- a/scarb/src/core/manifest/toml_manifest.rs
+++ b/scarb/src/core/manifest/toml_manifest.rs
@@ -455,6 +455,8 @@ impl TomlManifest {
 
         let targets = self.collect_targets(package.name.to_smol_str(), root)?;
 
+        let publish = package.publish.unwrap_or(true);
+
         let summary = Summary::builder()
             .package_id(package_id)
             .dependencies(dependencies)
@@ -575,6 +577,7 @@ impl TomlManifest {
         let manifest = ManifestBuilder::default()
             .summary(summary)
             .targets(targets)
+            .publish(publish)
             .edition(edition)
             .metadata(metadata)
             .compiler_config(compiler_config)

--- a/scarb/src/core/package/mod.rs
+++ b/scarb/src/core/package/mod.rs
@@ -70,6 +70,10 @@ impl Package {
         self.manifest.targets.iter().any(Target::is_cairo_plugin)
     }
 
+    pub fn is_publishable(&self) -> bool {
+        self.manifest.publish
+    }
+
     pub fn classify(&self) -> PackageClass {
         if self.is_cairo_plugin() {
             PackageClass::CairoPlugin

--- a/scarb/src/core/publishing/manifest_normalization.rs
+++ b/scarb/src/core/publishing/manifest_normalization.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use anyhow::{bail, Result};
+use anyhow::{bail, ensure, Result};
 use camino::Utf8PathBuf;
 use indoc::formatdoc;
 
@@ -14,6 +14,16 @@ use crate::{
 };
 
 pub fn prepare_manifest_for_publish(pkg: &Package) -> Result<TomlManifest> {
+    ensure!(
+        pkg.is_publishable(),
+        formatdoc! {
+            r#"
+                publishing disabled for package {package_name}
+                help: set `publish = true` in package manifest
+            "#,
+            package_name = pkg.id.name,
+        }
+    );
     let package = Some(generate_package(pkg));
 
     let dependencies = Some(generate_dependencies(

--- a/scarb/src/core/publishing/manifest_normalization.rs
+++ b/scarb/src/core/publishing/manifest_normalization.rs
@@ -58,6 +58,7 @@ fn generate_package(pkg: &Package) -> Box<TomlPackage> {
         name: summary.package_id.name.clone(),
         version: MaybeWorkspace::Defined(summary.package_id.version.clone()),
         edition: Some(MaybeWorkspace::Defined(pkg.manifest.edition)),
+        publish: (!pkg.manifest.publish).then_some(false),
         authors: metadata.authors.clone().map(MaybeWorkspace::Defined),
         urls: metadata.urls.clone(),
         description: metadata.description.clone().map(MaybeWorkspace::Defined),

--- a/scarb/tests/local_registry.rs
+++ b/scarb/tests/local_registry.rs
@@ -217,6 +217,34 @@ fn publish() {
 }
 
 #[test]
+fn publish_disabled() {
+    let t = TempDir::new().unwrap();
+    let index = t.child("index");
+    index.create_dir_all().unwrap();
+
+    ProjectBuilder::start()
+        .name("foobar")
+        .version("1.0.0")
+        .manifest_package_extra("publish = false")
+        .lib_cairo("fn main() -> felt252 { 0 }")
+        .build(&t);
+
+
+    Scarb::quick_snapbox()
+        .arg("publish")
+        .arg("--no-verify")
+        .arg("--index")
+        .arg(Url::from_directory_path(&index).unwrap().to_string())
+        .current_dir(&t)
+        .assert()
+        .failure()
+        .stdout_matches(indoc! {r#"
+        error: publishing disabled for package foobar v1.0.0 ([..]Scarb.toml)
+        help: set `publish = true` in package manifest
+        "#});
+}
+
+#[test]
 fn publish_overwrites_existing() {
     let index = TempDir::new().unwrap();
 

--- a/scarb/tests/local_registry.rs
+++ b/scarb/tests/local_registry.rs
@@ -219,8 +219,7 @@ fn publish() {
 #[test]
 fn publish_disabled() {
     let t = TempDir::new().unwrap();
-    let index = t.child("index");
-    index.create_dir_all().unwrap();
+    let index = TempDir::new().unwrap();
 
     ProjectBuilder::start()
         .name("foobar")

--- a/scarb/tests/local_registry.rs
+++ b/scarb/tests/local_registry.rs
@@ -229,7 +229,6 @@ fn publish_disabled() {
         .lib_cairo("fn main() -> felt252 { 0 }")
         .build(&t);
 
-
     Scarb::quick_snapbox()
         .arg("publish")
         .arg("--no-verify")

--- a/scarb/tests/package.rs
+++ b/scarb/tests/package.rs
@@ -1328,7 +1328,7 @@ fn package_without_publish_metadata() {
 }
 
 #[test]
-fn package_with_disabled_publish() {
+fn package_with_publish_disabled() {
     let t = TempDir::new().unwrap();
     ProjectBuilder::start()
         .name("foo")

--- a/scarb/tests/package.rs
+++ b/scarb/tests/package.rs
@@ -1326,3 +1326,25 @@ fn package_without_publish_metadata() {
         [..]  Packaged [..] files, [..] ([..] compressed)
         "#});
 }
+
+#[test]
+fn package_with_disabled_publish() {
+    let t = TempDir::new().unwrap();
+    ProjectBuilder::start()
+        .name("foo")
+        .version("1.0.0")
+        .manifest_package_extra("publish = false")
+        .build(&t);
+
+    Scarb::quick_snapbox()
+        .arg("package")
+        .arg("--no-metadata")
+        .arg("--no-verify")
+        .current_dir(&t)
+        .assert()
+        .failure().stdout_matches(indoc! {r#"
+        [..] Packaging [..]
+        error: publishing disabled for package foo
+        help: set `publish = true` in package manifest
+        "#});
+}

--- a/scarb/tests/package.rs
+++ b/scarb/tests/package.rs
@@ -1342,7 +1342,8 @@ fn package_with_disabled_publish() {
         .arg("--no-verify")
         .current_dir(&t)
         .assert()
-        .failure().stdout_matches(indoc! {r#"
+        .failure()
+        .stdout_matches(indoc! {r#"
         [..] Packaging [..]
         error: publishing disabled for package foo
         help: set `publish = true` in package manifest


### PR DESCRIPTION
Closes #636 