### PR TITLE
Fix ignored test case

### DIFF
--- a/scarb/src/resolver/mod.rs
+++ b/scarb/src/resolver/mod.rs
@@ -449,8 +449,8 @@ mod tests {
             // TODO(#2): Expected result is commented out.
             // Ok(pkgs![
             //     "bar v1.1.1",
-            //     "baz v1.8.0",
-            //     "foo v2.9.0"
+            //     "baz v1.7.1",
+            //     "foo v2.7.0"
             // ]),
             Err(indoc! {"
             Version solving failed:


### PR DESCRIPTION
~2.7 <=> >=2.7.0 && < 2.8.0 which does not accept 2.9.0
