### PR TITLE
starknet_multiple_contracts example refurbishment

### DIFF
--- a/examples/starknet_multiple_contracts/src/forty_two.cairo
+++ b/examples/starknet_multiple_contracts/src/forty_two.cairo
@@ -1,10 +1,17 @@
+#[starknet::interface]
+pub trait IFortyTwo<TContractState> {
+    fn answer(self: @TContractState) -> felt252;
+}
+
 #[starknet::contract]
 mod FortyTwo {
     #[storage]
     struct Storage {}
 
     #[abi(embed_v0)]
-    fn answer(ref self: ContractState) -> felt252 {
-        42
+    impl FortyTwo of super::IFortyTwo<ContractState> {
+        fn answer(self: @ContractState) -> felt252 {
+            42
+        }
     }
 }


### PR DESCRIPTION
The https://github.com/software-mansion/scarb/blob/main/examples/starknet_multiple_contracts/src/forty_two.cairo sample included a 'shorthand' styled contract code (no explicitly specified contract interface), and the `answer()` method is interpreted as a 'write' method by the compiler, even though it does not alter stae. 

The proposed contract code is hopefully less confusing.