### PR TITLE
Update highlight.js / hidden line rust.

### DIFF
--- a/extensions/scarb-doc/src/docs_generation/markdown/book_toml.rs
+++ b/extensions/scarb-doc/src/docs_generation/markdown/book_toml.rs
@@ -4,7 +4,7 @@ use crate::AdditionalMetadata;
 
 pub fn generate_book_toml_content(package_metadata: &AdditionalMetadata) -> String {
     formatdoc! {
-        r#"
+        r##"
             [book]
             authors = {:?}
             language = "en"
@@ -21,7 +21,10 @@ pub fn generate_book_toml_content(package_metadata: &AdditionalMetadata) -> Stri
             [output.html.fold]
             enable = true
             level = 0
-        "#,
+
+            [output.html.code.hidelines]
+            cairo = "#"
+        "##,
         package_metadata.authors.clone().unwrap_or_else(|| vec!["<unknown>".to_string()]),
         package_metadata.name
     }

--- a/extensions/scarb-doc/tests/data/hello_world_no_features/book.toml
+++ b/extensions/scarb-doc/tests/data/hello_world_no_features/book.toml
@@ -14,3 +14,6 @@ runnable = false
 [output.html.fold]
 enable = true
 level = 0
+
+[output.html.code.hidelines]
+cairo = "#"

--- a/extensions/scarb-doc/tests/data/hello_world_sub_package_no_features/book.toml
+++ b/extensions/scarb-doc/tests/data/hello_world_sub_package_no_features/book.toml
@@ -14,3 +14,6 @@ runnable = false
 [output.html.fold]
 enable = true
 level = 0
+
+[output.html.code.hidelines]
+cairo = "#"

--- a/extensions/scarb-doc/tests/data/hello_world_sub_package_with_features/book.toml
+++ b/extensions/scarb-doc/tests/data/hello_world_sub_package_with_features/book.toml
@@ -14,3 +14,6 @@ runnable = false
 [output.html.fold]
 enable = true
 level = 0
+
+[output.html.code.hidelines]
+cairo = "#"

--- a/extensions/scarb-doc/tests/data/hello_world_sub_package_without_features/book.toml
+++ b/extensions/scarb-doc/tests/data/hello_world_sub_package_without_features/book.toml
@@ -14,3 +14,6 @@ runnable = false
 [output.html.fold]
 enable = true
 level = 0
+
+[output.html.code.hidelines]
+cairo = "#"

--- a/extensions/scarb-doc/tests/data/hello_world_with_features/book.toml
+++ b/extensions/scarb-doc/tests/data/hello_world_with_features/book.toml
@@ -14,3 +14,6 @@ runnable = false
 [output.html.fold]
 enable = true
 level = 0
+
+[output.html.code.hidelines]
+cairo = "#"

--- a/extensions/scarb-doc/tests/data/hello_world_without_features/book.toml
+++ b/extensions/scarb-doc/tests/data/hello_world_without_features/book.toml
@@ -14,3 +14,6 @@ runnable = false
 [output.html.fold]
 enable = true
 level = 0
+
+[output.html.code.hidelines]
+cairo = "#"

--- a/extensions/scarb-doc/theme/CONTRIBUTING.md
+++ b/extensions/scarb-doc/theme/CONTRIBUTING.md
@@ -1,10 +1,3 @@
 # Contributing
 
-If you want to modify the way that the highlighting of Cairo code sample works, you need to:
-
-1. Clone the repository at https://github.com/highlightjs/highlight.js
-2. Copy our [cairo.js](./cairo.js) into `highlight.js/src/languages` directory
-3. Run `npm install`
-4. Modify the copied `cairo.js`
-5. Run `node tools/build.js :common apache armasm coffeescript d handlebars haskell http julia nginx nim nix properties r scala x86asm yaml cairo`
-6. Replace our [highlight.js](./highlight.js) content with newly built `highlight.js/build/highlight.min.js`
+If you want to modify the way that the highlighting of Cairo code sample works, you just need to change the `cairo` language definition inside the `highlight.js`. 

--- a/extensions/scarb-doc/theme/highlight.js
+++ b/extensions/scarb-doc/theme/highlight.js
@@ -1,337 +1,279 @@
-/*!
-  Highlight.js v11.10.0 (git: 1a2ec4c539)
-  (c) 2006-2024 Josh Goebel <hello@joshgoebel.com> and other contributors
+/*
+  Highlight.js 10.1.1 (93fd0d73)
   License: BSD-3-Clause
- */
-  var hljs = (function () {
-    "use strict";
-    function e(n) {
+  Copyright (c) 2006-2020, Ivan Sagalaev
+*/
+var hljs = (function () {
+  "use strict";
+  function e(n) {
+    Object.freeze(n);
+    var t = "function" == typeof n;
+    return (
+      Object.getOwnPropertyNames(n).forEach(function (r) {
+        !Object.hasOwnProperty.call(n, r) ||
+          null === n[r] ||
+          ("object" != typeof n[r] && "function" != typeof n[r]) ||
+          (t && ("caller" === r || "callee" === r || "arguments" === r)) ||
+          Object.isFrozen(n[r]) ||
+          e(n[r]);
+      }),
+      n
+    );
+  }
+  class n {
+    constructor(e) {
+      void 0 === e.data && (e.data = {}), (this.data = e.data);
+    }
+    ignoreMatch() {
+      this.ignore = !0;
+    }
+  }
+  function t(e) {
+    return e
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#x27;");
+  }
+  function r(e, ...n) {
+    var t = {};
+    for (const n in e) t[n] = e[n];
+    return (
+      n.forEach(function (e) {
+        for (const n in e) t[n] = e[n];
+      }),
+      t
+    );
+  }
+  function a(e) {
+    return e.nodeName.toLowerCase();
+  }
+  var i = Object.freeze({
+    __proto__: null,
+    escapeHTML: t,
+    inherit: r,
+    nodeStream: function (e) {
+      var n = [];
       return (
-        n instanceof Map
-          ? (n.clear =
-              n.delete =
-              n.set =
-                () => {
-                  throw Error("map is read-only");
-                })
-          : n instanceof Set &&
-            (n.add =
-              n.clear =
-              n.delete =
-                () => {
-                  throw Error("set is read-only");
-                }),
-        Object.freeze(n),
-        Object.getOwnPropertyNames(n).forEach((t) => {
-          const s = n[t],
-            a = typeof s;
-          ("object" !== a && "function" !== a) || Object.isFrozen(s) || e(s);
-        }),
+        (function e(t, r) {
+          for (var i = t.firstChild; i; i = i.nextSibling)
+            3 === i.nodeType
+              ? (r += i.nodeValue.length)
+              : 1 === i.nodeType &&
+                (n.push({ event: "start", offset: r, node: i }),
+                (r = e(i, r)),
+                a(i).match(/br|hr|img|input/) ||
+                  n.push({ event: "stop", offset: r, node: i }));
+          return r;
+        })(e, 0),
         n
       );
-    }
-    class n {
-      constructor(e) {
-        void 0 === e.data && (e.data = {}),
-          (this.data = e.data),
-          (this.isMatchIgnored = !1);
+    },
+    mergeStreams: function (e, n, r) {
+      var i = 0,
+        s = "",
+        o = [];
+      function l() {
+        return e.length && n.length
+          ? e[0].offset !== n[0].offset
+            ? e[0].offset < n[0].offset
+              ? e
+              : n
+            : "start" === n[0].event
+            ? e
+            : n
+          : e.length
+          ? e
+          : n;
       }
-      ignoreMatch() {
-        this.isMatchIgnored = !0;
+      function c(e) {
+        s +=
+          "<" +
+          a(e) +
+          [].map
+            .call(e.attributes, function (e) {
+              return " " + e.nodeName + '="' + t(e.value) + '"';
+            })
+            .join("") +
+          ">";
       }
+      function u(e) {
+        s += "</" + a(e) + ">";
+      }
+      function d(e) {
+        ("start" === e.event ? c : u)(e.node);
+      }
+      for (; e.length || n.length; ) {
+        var g = l();
+        if (
+          ((s += t(r.substring(i, g[0].offset))), (i = g[0].offset), g === e)
+        ) {
+          o.reverse().forEach(u);
+          do {
+            d(g.splice(0, 1)[0]), (g = l());
+          } while (g === e && g.length && g[0].offset === i);
+          o.reverse().forEach(c);
+        } else
+          "start" === g[0].event ? o.push(g[0].node) : o.pop(),
+            d(g.splice(0, 1)[0]);
+      }
+      return s + t(r.substr(i));
+    },
+  });
+  const s = "</span>",
+    o = (e) => !!e.kind;
+  class l {
+    constructor(e, n) {
+      (this.buffer = ""), (this.classPrefix = n.classPrefix), e.walk(this);
     }
-    function t(e) {
-      return e
-        .replace(/&/g, "&amp;")
-        .replace(/</g, "&lt;")
-        .replace(/>/g, "&gt;")
-        .replace(/"/g, "&quot;")
-        .replace(/'/g, "&#x27;");
+    addText(e) {
+      this.buffer += t(e);
     }
-    function s(e, ...n) {
-      const t = Object.create(null);
-      for (const n in e) t[n] = e[n];
+    openNode(e) {
+      if (!o(e)) return;
+      let n = e.kind;
+      e.sublanguage || (n = `${this.classPrefix}${n}`), this.span(n);
+    }
+    closeNode(e) {
+      o(e) && (this.buffer += s);
+    }
+    value() {
+      return this.buffer;
+    }
+    span(e) {
+      this.buffer += `<span class="${e}">`;
+    }
+  }
+  class c {
+    constructor() {
+      (this.rootNode = { children: [] }), (this.stack = [this.rootNode]);
+    }
+    get top() {
+      return this.stack[this.stack.length - 1];
+    }
+    get root() {
+      return this.rootNode;
+    }
+    add(e) {
+      this.top.children.push(e);
+    }
+    openNode(e) {
+      const n = { kind: e, children: [] };
+      this.add(n), this.stack.push(n);
+    }
+    closeNode() {
+      if (this.stack.length > 1) return this.stack.pop();
+    }
+    closeAllNodes() {
+      for (; this.closeNode(); );
+    }
+    toJSON() {
+      return JSON.stringify(this.rootNode, null, 4);
+    }
+    walk(e) {
+      return this.constructor._walk(e, this.rootNode);
+    }
+    static _walk(e, n) {
       return (
-        n.forEach((e) => {
-          for (const n in e) t[n] = e[n];
-        }),
-        t
+        "string" == typeof n
+          ? e.addText(n)
+          : n.children &&
+            (e.openNode(n),
+            n.children.forEach((n) => this._walk(e, n)),
+            e.closeNode(n)),
+        e
       );
     }
-    const a = (e) => !!e.scope;
-    class i {
-      constructor(e, n) {
-        (this.buffer = ""), (this.classPrefix = n.classPrefix), e.walk(this);
-      }
-      addText(e) {
-        this.buffer += t(e);
-      }
-      openNode(e) {
-        if (!a(e)) return;
-        const n = ((e, { prefix: n }) => {
-          if (e.startsWith("language:"))
-            return e.replace("language:", "language-");
-          if (e.includes(".")) {
-            const t = e.split(".");
-            return [
-              `${n}${t.shift()}`,
-              ...t.map((e, n) => `${e}${"_".repeat(n + 1)}`),
-            ].join(" ");
-          }
-          return `${n}${e}`;
-        })(e.scope, { prefix: this.classPrefix });
-        this.span(n);
-      }
-      closeNode(e) {
-        a(e) && (this.buffer += "</span>");
-      }
-      value() {
-        return this.buffer;
-      }
-      span(e) {
-        this.buffer += `<span class="${e}">`;
-      }
+    static _collapse(e) {
+      "string" != typeof e &&
+        e.children &&
+        (e.children.every((e) => "string" == typeof e)
+          ? (e.children = [e.children.join("")])
+          : e.children.forEach((e) => {
+              c._collapse(e);
+            }));
     }
-    const r = (e = {}) => {
-      const n = { children: [] };
-      return Object.assign(n, e), n;
-    };
-    class o {
-      constructor() {
-        (this.rootNode = r()), (this.stack = [this.rootNode]);
-      }
-      get top() {
-        return this.stack[this.stack.length - 1];
-      }
-      get root() {
-        return this.rootNode;
-      }
-      add(e) {
-        this.top.children.push(e);
-      }
-      openNode(e) {
-        const n = r({ scope: e });
-        this.add(n), this.stack.push(n);
-      }
-      closeNode() {
-        if (this.stack.length > 1) return this.stack.pop();
-      }
-      closeAllNodes() {
-        for (; this.closeNode(); );
-      }
-      toJSON() {
-        return JSON.stringify(this.rootNode, null, 4);
-      }
-      walk(e) {
-        return this.constructor._walk(e, this.rootNode);
-      }
-      static _walk(e, n) {
-        return (
-          "string" == typeof n
-            ? e.addText(n)
-            : n.children &&
-              (e.openNode(n),
-              n.children.forEach((n) => this._walk(e, n)),
-              e.closeNode(n)),
-          e
-        );
-      }
-      static _collapse(e) {
-        "string" != typeof e &&
-          e.children &&
-          (e.children.every((e) => "string" == typeof e)
-            ? (e.children = [e.children.join("")])
-            : e.children.forEach((e) => {
-                o._collapse(e);
-              }));
-      }
+  }
+  class u extends c {
+    constructor(e) {
+      super(), (this.options = e);
     }
-    class c extends o {
-      constructor(e) {
-        super(), (this.options = e);
-      }
-      addText(e) {
-        "" !== e && this.add(e);
-      }
-      startScope(e) {
-        this.openNode(e);
-      }
-      endScope() {
-        this.closeNode();
-      }
-      __addSublanguage(e, n) {
-        const t = e.root;
-        n && (t.scope = "language:" + n), this.add(t);
-      }
-      toHTML() {
-        return new i(this, this.options).value();
-      }
-      finalize() {
-        return this.closeAllNodes(), !0;
-      }
+    addKeyword(e, n) {
+      "" !== e && (this.openNode(n), this.addText(e), this.closeNode());
     }
-    function l(e) {
-      return e ? ("string" == typeof e ? e : e.source) : null;
+    addText(e) {
+      "" !== e && this.add(e);
     }
-    function d(e) {
-      return u("(?=", e, ")");
+    addSublanguage(e, n) {
+      const t = e.root;
+      (t.kind = n), (t.sublanguage = !0), this.add(t);
     }
-    function p(e) {
-      return u("(?:", e, ")*");
+    toHTML() {
+      return new l(this, this.options).value();
     }
-    function m(e) {
-      return u("(?:", e, ")?");
+    finalize() {
+      return !0;
     }
-    function u(...e) {
-      return e.map((e) => l(e)).join("");
-    }
-    function b(...e) {
-      const n = ((e) => {
-        const n = e[e.length - 1];
-        return "object" == typeof n && n.constructor === Object
-          ? (e.splice(e.length - 1, 1), n)
-          : {};
-      })(e);
-      return "(" + (n.capture ? "" : "?:") + e.map((e) => l(e)).join("|") + ")";
-    }
-    function g(e) {
-      return RegExp(e.toString() + "|").exec("").length - 1;
-    }
-    const v = /\[(?:[^\\\]]|\\.)*\]|\(\??|\\([1-9][0-9]*)|\\./;
-    function _(e, { joinWith: n }) {
-      let t = 0;
-      return e
-        .map((e) => {
-          t += 1;
-          const n = t;
-          let s = l(e),
-            a = "";
-          for (; s.length > 0; ) {
-            const e = v.exec(s);
-            if (!e) {
-              a += s;
-              break;
-            }
-            (a += s.substring(0, e.index)),
-              (s = s.substring(e.index + e[0].length)),
-              "\\" === e[0][0] && e[1]
-                ? (a += "\\" + (Number(e[1]) + n))
-                : ((a += e[0]), "(" === e[0] && t++);
-          }
-          return a;
-        })
-        .map((e) => `(${e})`)
-        .join(n);
-    }
-    const f = "[a-zA-Z]\\w*",
-      h = "[a-zA-Z_]\\w*",
-      E = "\\b\\d+(\\.\\d+)?",
-      w =
-        "(-?)(\\b0[xX][a-fA-F0-9]+|(\\b\\d+(\\.\\d*)?|\\.\\d+)([eE][-+]?\\d+)?)",
-      y = "\\b(0b[01]+)",
-      N = {
-        begin: "\\\\[\\s\\S]",
-        relevance: 0,
-      },
-      x = {
-        scope: "string",
-        begin: "'",
-        end: "'",
-        illegal: "\\n",
-        contains: [N],
-      },
-      k = {
-        scope: "string",
-        begin: '"',
-        end: '"',
-        illegal: "\\n",
-        contains: [N],
-      },
-      O = (e, n, t = {}) => {
-        const a = s({ scope: "comment", begin: e, end: n, contains: [] }, t);
+  }
+  function d(e) {
+    return e ? ("string" == typeof e ? e : e.source) : null;
+  }
+  const g =
+      "(-?)(\\b0[xX][a-fA-F0-9]+|(\\b\\d+(\\.\\d*)?|\\.\\d+)([eE][-+]?\\d+)?)",
+    h = { begin: "\\\\[\\s\\S]", relevance: 0 },
+    f = {
+      className: "string",
+      begin: "'",
+      end: "'",
+      illegal: "\\n",
+      contains: [h],
+    },
+    p = {
+      className: "string",
+      begin: '"',
+      end: '"',
+      illegal: "\\n",
+      contains: [h],
+    },
+    b = {
+      begin:
+        /\b(a|an|the|are|I'm|isn't|don't|doesn't|won't|but|just|should|pretty|simply|enough|gonna|going|wtf|so|such|will|you|your|they|like|more)\b/,
+    },
+    m = function (e, n, t = {}) {
+      var a = r({ className: "comment", begin: e, end: n, contains: [] }, t);
+      return (
+        a.contains.push(b),
         a.contains.push({
-          scope: "doctag",
-          begin: "[ ]*(?=(TODO|FIXME|NOTE|BUG|OPTIMIZE|HACK|XXX):)",
-          end: /(TODO|FIXME|NOTE|BUG|OPTIMIZE|HACK|XXX):/,
-          excludeBegin: !0,
+          className: "doctag",
+          begin: "(?:TODO|FIXME|NOTE|BUG|OPTIMIZE|HACK|XXX):",
           relevance: 0,
-        });
-        const i = b(
-          "I",
-          "a",
-          "is",
-          "so",
-          "us",
-          "to",
-          "at",
-          "if",
-          "in",
-          "it",
-          "on",
-          /[A-Za-z]+['](d|ve|re|ll|t|s|n)/,
-          /[A-Za-z]+[-][a-z]+/,
-          /[A-Za-z][a-z]{2,}/
-        );
-        return (
-          a.contains.push({
-            begin: u(/[ ]+/, "(", i, /[.]?[:]?([.][ ]|[ ])/, "){3}"),
-          }),
-          a
-        );
-      },
-      M = O("//", "$"),
-      A = O("/\\*", "\\*/"),
-      S = O("#", "$");
-    var C = Object.freeze({
-      __proto__: null,
-      APOS_STRING_MODE: x,
-      BACKSLASH_ESCAPE: N,
-      BINARY_NUMBER_MODE: {
-        scope: "number",
-        begin: y,
-        relevance: 0,
-      },
-      BINARY_NUMBER_RE: y,
-      COMMENT: O,
-      C_BLOCK_COMMENT_MODE: A,
-      C_LINE_COMMENT_MODE: M,
-      C_NUMBER_MODE: { scope: "number", begin: w, relevance: 0 },
-      C_NUMBER_RE: w,
-      END_SAME_AS_BEGIN: (e) =>
-        Object.assign(e, {
-          "on:begin": (e, n) => {
-            n.data._beginMatch = e[1];
-          },
-          "on:end": (e, n) => {
-            n.data._beginMatch !== e[1] && n.ignoreMatch();
-          },
         }),
-      HASH_COMMENT_MODE: S,
-      IDENT_RE: f,
-      MATCH_NOTHING_RE: /\b\B/,
-      METHOD_GUARD: { begin: "\\.\\s*" + h, relevance: 0 },
-      NUMBER_MODE: { scope: "number", begin: E, relevance: 0 },
-      NUMBER_RE: E,
-      PHRASAL_WORDS_MODE: {
-        begin:
-          /\b(a|an|the|are|I'm|isn't|don't|doesn't|won't|but|just|should|pretty|simply|enough|gonna|going|wtf|so|such|will|you|your|they|like|more)\b/,
-      },
-      QUOTE_STRING_MODE: k,
-      REGEXP_MODE: {
-        scope: "regexp",
-        begin: /\/(?=[^/\n]*\/)/,
-        end: /\/[gimuy]*/,
-        contains: [N, { begin: /\[/, end: /\]/, relevance: 0, contains: [N] }],
-      },
+        a
+      );
+    },
+    v = m("//", "$"),
+    x = m("/\\*", "\\*/"),
+    E = m("#", "$");
+  var _ = Object.freeze({
+      __proto__: null,
+      IDENT_RE: "[a-zA-Z]\\w*",
+      UNDERSCORE_IDENT_RE: "[a-zA-Z_]\\w*",
+      NUMBER_RE: "\\b\\d+(\\.\\d+)?",
+      C_NUMBER_RE: g,
+      BINARY_NUMBER_RE: "\\b(0b[01]+)",
       RE_STARTERS_RE:
         "!|!=|!==|%|%=|&|&&|&=|\\*|\\*=|\\+|\\+=|,|-|-=|/=|/|:|;|<<|<<=|<=|<|===|==|=|>>>=|>>=|>=|>>>|>>|>|\\?|\\[|\\{|\\(|\\^|\\^=|\\||\\|=|\\|\\||~",
       SHEBANG: (e = {}) => {
         const n = /^#![ ]*\//;
         return (
-          e.binary && (e.begin = u(n, /.*\b/, e.binary, /\b.*/)),
-          s(
+          e.binary &&
+            (e.begin = (function (...e) {
+              return e.map((e) => d(e)).join("");
+            })(n, /.*\b/, e.binary, /\b.*/)),
+          r(
             {
-              scope: "meta",
+              className: "meta",
               begin: n,
               end: /$/,
               relevance: 0,
@@ -343,1677 +285,1054 @@
           )
         );
       },
-      TITLE_MODE: { scope: "title", begin: f, relevance: 0 },
-      UNDERSCORE_IDENT_RE: h,
-      UNDERSCORE_TITLE_MODE: { scope: "title", begin: h, relevance: 0 },
-    });
-    function T(e, n) {
-      "." === e.input[e.index - 1] && n.ignoreMatch();
-    }
-    function q(e, n) {
-      void 0 !== e.className && ((e.scope = e.className), delete e.className);
-    }
-    function D(e, n) {
-      n &&
-        e.beginKeywords &&
-        ((e.begin =
-          "\\b(" + e.beginKeywords.split(" ").join("|") + ")(?!\\.)(?=\\b|\\s)"),
-        (e.__beforeBegin = T),
-        (e.keywords = e.keywords || e.beginKeywords),
-        delete e.beginKeywords,
-        void 0 === e.relevance && (e.relevance = 0));
-    }
-    function R(e, n) {
-      Array.isArray(e.illegal) && (e.illegal = b(...e.illegal));
-    }
-    function I(e, n) {
-      if (e.match) {
-        if (e.begin || e.end)
-          throw Error("begin & end are not supported with match");
-        (e.begin = e.match), delete e.match;
-      }
-    }
-    function L(e, n) {
-      void 0 === e.relevance && (e.relevance = 1);
-    }
-    const B = (e, n) => {
-        if (!e.beforeMatch) return;
-        if (e.starts) throw Error("beforeMatch cannot be used with starts");
-        const t = Object.assign({}, e);
-        Object.keys(e).forEach((n) => {
-          delete e[n];
-        }),
-          (e.keywords = t.keywords),
-          (e.begin = u(t.beforeMatch, d(t.begin))),
-          (e.starts = {
-            relevance: 0,
-            contains: [Object.assign(t, { endsParent: !0 })],
-          }),
-          (e.relevance = 0),
-          delete t.beforeMatch;
+      BACKSLASH_ESCAPE: h,
+      APOS_STRING_MODE: f,
+      QUOTE_STRING_MODE: p,
+      PHRASAL_WORDS_MODE: b,
+      COMMENT: m,
+      C_LINE_COMMENT_MODE: v,
+      C_BLOCK_COMMENT_MODE: x,
+      HASH_COMMENT_MODE: E,
+      NUMBER_MODE: {
+        className: "number",
+        begin: "\\b\\d+(\\.\\d+)?",
+        relevance: 0,
       },
-      z = [
-        "of",
-        "and",
-        "for",
-        "in",
-        "not",
-        "or",
-        "if",
-        "then",
-        "parent",
-        "list",
-        "value",
-      ],
-      F = "keyword";
-    function $(e, n, t = F) {
-      const s = Object.create(null);
-      return (
-        "string" == typeof e
-          ? a(t, e.split(" "))
-          : Array.isArray(e)
-          ? a(t, e)
-          : Object.keys(e).forEach((t) => {
-              Object.assign(s, $(e[t], n, t));
-            }),
-        s
-      );
-      function a(e, t) {
-        n && (t = t.map((e) => e.toLowerCase())),
-          t.forEach((n) => {
-            const t = n.split("|");
-            s[t[0]] = [e, U(t[0], t[1])];
-          });
-      }
-    }
-    function U(e, n) {
-      return n ? Number(n) : ((e) => z.includes(e.toLowerCase()))(e) ? 0 : 1;
-    }
-    const P = {},
-      j = (e) => {
-        console.error(e);
+      C_NUMBER_MODE: { className: "number", begin: g, relevance: 0 },
+      BINARY_NUMBER_MODE: {
+        className: "number",
+        begin: "\\b(0b[01]+)",
+        relevance: 0,
       },
-      K = (e, ...n) => {
-        console.log("WARN: " + e, ...n);
+      CSS_NUMBER_MODE: {
+        className: "number",
+        begin:
+          "\\b\\d+(\\.\\d+)?(%|em|ex|ch|rem|vw|vh|vmin|vmax|cm|mm|in|pt|pc|px|deg|grad|rad|turn|s|ms|Hz|kHz|dpi|dpcm|dppx)?",
+        relevance: 0,
       },
-      H = (e, n) => {
-        P[`${e}/${n}`] ||
-          (console.log(`Deprecated as of ${e}. ${n}`), (P[`${e}/${n}`] = !0));
+      REGEXP_MODE: {
+        begin: /(?=\/[^/\n]*\/)/,
+        contains: [
+          {
+            className: "regexp",
+            begin: /\//,
+            end: /\/[gimuy]*/,
+            illegal: /\n/,
+            contains: [
+              h,
+              { begin: /\[/, end: /\]/, relevance: 0, contains: [h] },
+            ],
+          },
+        ],
       },
-      Z = Error();
-    function G(e, n, { key: t }) {
-      let s = 0;
-      const a = e[t],
-        i = {},
-        r = {};
-      for (let e = 1; e <= n.length; e++)
-        (r[e + s] = a[e]), (i[e + s] = !0), (s += g(n[e - 1]));
-      (e[t] = r), (e[t]._emit = i), (e[t]._multi = !0);
+      TITLE_MODE: { className: "title", begin: "[a-zA-Z]\\w*", relevance: 0 },
+      UNDERSCORE_TITLE_MODE: {
+        className: "title",
+        begin: "[a-zA-Z_]\\w*",
+        relevance: 0,
+      },
+      METHOD_GUARD: { begin: "\\.\\s*[a-zA-Z_]\\w*", relevance: 0 },
+      END_SAME_AS_BEGIN: function (e) {
+        return Object.assign(e, {
+          "on:begin": (e, n) => {
+            n.data._beginMatch = e[1];
+          },
+          "on:end": (e, n) => {
+            n.data._beginMatch !== e[1] && n.ignoreMatch();
+          },
+        });
+      },
+    }),
+    N = "of and for in not or if then".split(" ");
+  function w(e, n) {
+    return n
+      ? +n
+      : (function (e) {
+          return N.includes(e.toLowerCase());
+        })(e)
+      ? 0
+      : 1;
+  }
+  const R = t,
+    y = r,
+    { nodeStream: k, mergeStreams: O } = i,
+    M = Symbol("nomatch");
+  return (function (t) {
+    var a = [],
+      i = {},
+      s = {},
+      o = [],
+      l = !0,
+      c = /(^(<[^>]+>|\t|)+|\n)/gm,
+      g =
+        "Could not find the language '{}', did you forget to load/include a language module?";
+    const h = { disableAutodetect: !0, name: "Plain text", contains: [] };
+    var f = {
+      noHighlightRe: /^(no-?highlight)$/i,
+      languageDetectRe: /\blang(?:uage)?-([\w-]+)\b/i,
+      classPrefix: "hljs-",
+      tabReplace: null,
+      useBR: !1,
+      languages: null,
+      __emitter: u,
+    };
+    function p(e) {
+      return f.noHighlightRe.test(e);
     }
-    function W(e) {
-      ((e) => {
-        e.scope &&
-          "object" == typeof e.scope &&
-          null !== e.scope &&
-          ((e.beginScope = e.scope), delete e.scope);
-      })(e),
-        "string" == typeof e.beginScope &&
-          (e.beginScope = {
-            _wrap: e.beginScope,
-          }),
-        "string" == typeof e.endScope && (e.endScope = { _wrap: e.endScope }),
-        ((e) => {
-          if (Array.isArray(e.begin)) {
-            if (e.skip || e.excludeBegin || e.returnBegin)
-              throw (
-                (j(
-                  "skip, excludeBegin, returnBegin not compatible with beginScope: {}"
-                ),
-                Z)
-              );
-            if ("object" != typeof e.beginScope || null === e.beginScope)
-              throw (j("beginScope must be object"), Z);
-            G(e, e.begin, { key: "beginScope" }),
-              (e.begin = _(e.begin, { joinWith: "" }));
-          }
-        })(e),
-        ((e) => {
-          if (Array.isArray(e.end)) {
-            if (e.skip || e.excludeEnd || e.returnEnd)
-              throw (
-                (j(
-                  "skip, excludeEnd, returnEnd not compatible with endScope: {}"
-                ),
-                Z)
-              );
-            if ("object" != typeof e.endScope || null === e.endScope)
-              throw (j("endScope must be object"), Z);
-            G(e, e.end, { key: "endScope" }),
-              (e.end = _(e.end, { joinWith: "" }));
-          }
-        })(e);
+    function b(e, n, t, r) {
+      var a = { code: n, language: e };
+      S("before:highlight", a);
+      var i = a.result ? a.result : m(a.language, a.code, t, r);
+      return (i.code = a.code), S("after:highlight", i), i;
     }
-    function Q(e) {
-      function n(n, t) {
-        return RegExp(
-          l(n),
-          "m" +
-            (e.case_insensitive ? "i" : "") +
-            (e.unicodeRegex ? "u" : "") +
-            (t ? "g" : "")
+    function m(e, t, a, s) {
+      var o = t;
+      function c(e, n) {
+        var t = E.case_insensitive ? n[0].toLowerCase() : n[0];
+        return (
+          Object.prototype.hasOwnProperty.call(e.keywords, t) && e.keywords[t]
         );
       }
-      class t {
-        constructor() {
-          (this.matchIndexes = {}),
-            (this.regexes = []),
-            (this.matchAt = 1),
-            (this.position = 0);
-        }
-        addRule(e, n) {
-          (n.position = this.position++),
-            (this.matchIndexes[this.matchAt] = n),
-            this.regexes.push([n, e]),
-            (this.matchAt += g(e) + 1);
-        }
-        compile() {
-          0 === this.regexes.length && (this.exec = () => null);
-          const e = this.regexes.map((e) => e[1]);
-          (this.matcherRe = n(_(e, { joinWith: "|" }), !0)), (this.lastIndex = 0);
-        }
-        exec(e) {
-          this.matcherRe.lastIndex = this.lastIndex;
-          const n = this.matcherRe.exec(e);
-          if (!n) return null;
-          const t = n.findIndex((e, n) => n > 0 && void 0 !== e),
-            s = this.matchIndexes[t];
-          return n.splice(0, t), Object.assign(n, s);
-        }
+      function u() {
+        null != y.subLanguage
+          ? (function () {
+              if ("" !== A) {
+                var e = null;
+                if ("string" == typeof y.subLanguage) {
+                  if (!i[y.subLanguage]) return void O.addText(A);
+                  (e = m(y.subLanguage, A, !0, k[y.subLanguage])),
+                    (k[y.subLanguage] = e.top);
+                } else e = v(A, y.subLanguage.length ? y.subLanguage : null);
+                y.relevance > 0 && (I += e.relevance),
+                  O.addSublanguage(e.emitter, e.language);
+              }
+            })()
+          : (function () {
+              if (!y.keywords) return void O.addText(A);
+              let e = 0;
+              y.keywordPatternRe.lastIndex = 0;
+              let n = y.keywordPatternRe.exec(A),
+                t = "";
+              for (; n; ) {
+                t += A.substring(e, n.index);
+                const r = c(y, n);
+                if (r) {
+                  const [e, a] = r;
+                  O.addText(t), (t = ""), (I += a), O.addKeyword(n[0], e);
+                } else t += n[0];
+                (e = y.keywordPatternRe.lastIndex),
+                  (n = y.keywordPatternRe.exec(A));
+              }
+              (t += A.substr(e)), O.addText(t);
+            })(),
+          (A = "");
       }
-      class a {
-        constructor() {
-          (this.rules = []),
-            (this.multiRegexes = []),
-            (this.count = 0),
-            (this.lastIndex = 0),
-            (this.regexIndex = 0);
+      function h(e) {
+        return (
+          e.className && O.openNode(e.className),
+          (y = Object.create(e, { parent: { value: y } }))
+        );
+      }
+      function p(e) {
+        return 0 === y.matcher.regexIndex ? ((A += e[0]), 1) : ((L = !0), 0);
+      }
+      var b = {};
+      function x(t, r) {
+        var i = r && r[0];
+        if (((A += t), null == i)) return u(), 0;
+        if (
+          "begin" === b.type &&
+          "end" === r.type &&
+          b.index === r.index &&
+          "" === i
+        ) {
+          if (((A += o.slice(r.index, r.index + 1)), !l)) {
+            const n = Error("0 width match regex");
+            throw ((n.languageName = e), (n.badRule = b.rule), n);
+          }
+          return 1;
         }
-        getMatcher(e) {
-          if (this.multiRegexes[e]) return this.multiRegexes[e];
-          const n = new t();
-          return (
-            this.rules.slice(e).forEach(([e, t]) => n.addRule(e, t)),
-            n.compile(),
-            (this.multiRegexes[e] = n),
-            n
+        if (((b = r), "begin" === r.type))
+          return (function (e) {
+            var t = e[0],
+              r = e.rule;
+            const a = new n(r),
+              i = [r.__beforeBegin, r["on:begin"]];
+            for (const n of i) if (n && (n(e, a), a.ignore)) return p(t);
+            return (
+              r &&
+                r.endSameAsBegin &&
+                (r.endRe = RegExp(
+                  t.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&"),
+                  "m"
+                )),
+              r.skip
+                ? (A += t)
+                : (r.excludeBegin && (A += t),
+                  u(),
+                  r.returnBegin || r.excludeBegin || (A = t)),
+              h(r),
+              r.returnBegin ? 0 : t.length
+            );
+          })(r);
+        if ("illegal" === r.type && !a) {
+          const e = Error(
+            'Illegal lexeme "' +
+              i +
+              '" for mode "' +
+              (y.className || "<unnamed>") +
+              '"'
           );
+          throw ((e.mode = y), e);
         }
-        resumingScanAtSamePosition() {
-          return 0 !== this.regexIndex;
+        if ("end" === r.type) {
+          var s = (function (e) {
+            var t = e[0],
+              r = o.substr(e.index),
+              a = (function e(t, r, a) {
+                let i = (function (e, n) {
+                  var t = e && e.exec(n);
+                  return t && 0 === t.index;
+                })(t.endRe, a);
+                if (i) {
+                  if (t["on:end"]) {
+                    const e = new n(t);
+                    t["on:end"](r, e), e.ignore && (i = !1);
+                  }
+                  if (i) {
+                    for (; t.endsParent && t.parent; ) t = t.parent;
+                    return t;
+                  }
+                }
+                if (t.endsWithParent) return e(t.parent, r, a);
+              })(y, e, r);
+            if (!a) return M;
+            var i = y;
+            i.skip
+              ? (A += t)
+              : (i.returnEnd || i.excludeEnd || (A += t),
+                u(),
+                i.excludeEnd && (A = t));
+            do {
+              y.className && O.closeNode(),
+                y.skip || y.subLanguage || (I += y.relevance),
+                (y = y.parent);
+            } while (y !== a.parent);
+            return (
+              a.starts &&
+                (a.endSameAsBegin && (a.starts.endRe = a.endRe), h(a.starts)),
+              i.returnEnd ? 0 : t.length
+            );
+          })(r);
+          if (s !== M) return s;
         }
-        considerAll() {
-          this.regexIndex = 0;
-        }
-        addRule(e, n) {
-          this.rules.push([e, n]), "begin" === n.type && this.count++;
-        }
-        exec(e) {
-          const n = this.getMatcher(this.regexIndex);
-          n.lastIndex = this.lastIndex;
-          let t = n.exec(e);
-          if (this.resumingScanAtSamePosition())
-            if (t && t.index === this.lastIndex);
-            else {
-              const n = this.getMatcher(0);
-              (n.lastIndex = this.lastIndex + 1), (t = n.exec(e));
+        if ("illegal" === r.type && "" === i) return 1;
+        if (B > 1e5 && B > 3 * r.index)
+          throw Error(
+            "potential infinite loop, way more iterations than matches"
+          );
+        return (A += i), i.length;
+      }
+      var E = T(e);
+      if (!E)
+        throw (
+          (console.error(g.replace("{}", e)),
+          Error('Unknown language: "' + e + '"'))
+        );
+      var _ = (function (e) {
+          function n(n, t) {
+            return RegExp(
+              d(n),
+              "m" + (e.case_insensitive ? "i" : "") + (t ? "g" : "")
+            );
+          }
+          class t {
+            constructor() {
+              (this.matchIndexes = {}),
+                (this.regexes = []),
+                (this.matchAt = 1),
+                (this.position = 0);
             }
-          return (
-            t &&
-              ((this.regexIndex += t.position + 1),
-              this.regexIndex === this.count && this.considerAll()),
-            t
-          );
-        }
-      }
-      if (
-        (e.compilerExtensions || (e.compilerExtensions = []),
-        e.contains && e.contains.includes("self"))
-      )
-        throw Error(
-          "ERR: contains `self` is not supported at the top-level of a language.  See documentation."
-        );
-      return (
-        (e.classNameAliases = s(e.classNameAliases || {})),
-        (function t(i, r) {
-          const o = i;
-          if (i.isCompiled) return o;
-          [q, I, W, B].forEach((e) => e(i, r)),
-            e.compilerExtensions.forEach((e) => e(i, r)),
-            (i.__beforeBegin = null),
-            [D, R, L].forEach((e) => e(i, r)),
-            (i.isCompiled = !0);
-          let c = null;
-          return (
-            "object" == typeof i.keywords &&
-              i.keywords.$pattern &&
-              ((i.keywords = Object.assign({}, i.keywords)),
-              (c = i.keywords.$pattern),
-              delete i.keywords.$pattern),
-            (c = c || /\w+/),
-            i.keywords && (i.keywords = $(i.keywords, e.case_insensitive)),
-            (o.keywordPatternRe = n(c, !0)),
-            r &&
-              (i.begin || (i.begin = /\B|\b/),
-              (o.beginRe = n(o.begin)),
-              i.end || i.endsWithParent || (i.end = /\B|\b/),
-              i.end && (o.endRe = n(o.end)),
-              (o.terminatorEnd = l(o.end) || ""),
-              i.endsWithParent &&
-                r.terminatorEnd &&
-                (o.terminatorEnd += (i.end ? "|" : "") + r.terminatorEnd)),
-            i.illegal && (o.illegalRe = n(i.illegal)),
-            i.contains || (i.contains = []),
-            (i.contains = [].concat(
-              ...i.contains.map((e) =>
-                ((e) => (
-                  e.variants &&
-                    !e.cachedVariants &&
-                    (e.cachedVariants = e.variants.map((n) =>
-                      s(
-                        e,
-                        {
-                          variants: null,
-                        },
-                        n
-                      )
-                    )),
-                  e.cachedVariants
-                    ? e.cachedVariants
-                    : X(e)
-                    ? s(e, {
-                        starts: e.starts ? s(e.starts) : null,
-                      })
-                    : Object.isFrozen(e)
-                    ? s(e)
-                    : e
-                ))("self" === e ? i : e)
-              )
-            )),
-            i.contains.forEach((e) => {
-              t(e, o);
-            }),
-            i.starts && t(i.starts, r),
-            (o.matcher = ((e) => {
-              const n = new a();
+            addRule(e, n) {
+              (n.position = this.position++),
+                (this.matchIndexes[this.matchAt] = n),
+                this.regexes.push([n, e]),
+                (this.matchAt +=
+                  (function (e) {
+                    return RegExp(e.toString() + "|").exec("").length - 1;
+                  })(e) + 1);
+            }
+            compile() {
+              0 === this.regexes.length && (this.exec = () => null);
+              const e = this.regexes.map((e) => e[1]);
+              (this.matcherRe = n(
+                (function (e, n = "|") {
+                  for (
+                    var t = /\[(?:[^\\\]]|\\.)*\]|\(\??|\\([1-9][0-9]*)|\\./,
+                      r = 0,
+                      a = "",
+                      i = 0;
+                    i < e.length;
+                    i++
+                  ) {
+                    var s = (r += 1),
+                      o = d(e[i]);
+                    for (i > 0 && (a += n), a += "("; o.length > 0; ) {
+                      var l = t.exec(o);
+                      if (null == l) {
+                        a += o;
+                        break;
+                      }
+                      (a += o.substring(0, l.index)),
+                        (o = o.substring(l.index + l[0].length)),
+                        "\\" === l[0][0] && l[1]
+                          ? (a += "\\" + (+l[1] + s))
+                          : ((a += l[0]), "(" === l[0] && r++);
+                    }
+                    a += ")";
+                  }
+                  return a;
+                })(e),
+                !0
+              )),
+                (this.lastIndex = 0);
+            }
+            exec(e) {
+              this.matcherRe.lastIndex = this.lastIndex;
+              const n = this.matcherRe.exec(e);
+              if (!n) return null;
+              const t = n.findIndex((e, n) => n > 0 && void 0 !== e),
+                r = this.matchIndexes[t];
+              return n.splice(0, t), Object.assign(n, r);
+            }
+          }
+          class a {
+            constructor() {
+              (this.rules = []),
+                (this.multiRegexes = []),
+                (this.count = 0),
+                (this.lastIndex = 0),
+                (this.regexIndex = 0);
+            }
+            getMatcher(e) {
+              if (this.multiRegexes[e]) return this.multiRegexes[e];
+              const n = new t();
               return (
-                e.contains.forEach((e) =>
-                  n.addRule(e.begin, { rule: e, type: "begin" })
-                ),
-                e.terminatorEnd && n.addRule(e.terminatorEnd, { type: "end" }),
-                e.illegal && n.addRule(e.illegal, { type: "illegal" }),
+                this.rules.slice(e).forEach(([e, t]) => n.addRule(e, t)),
+                n.compile(),
+                (this.multiRegexes[e] = n),
                 n
               );
-            })(o)),
-            o
-          );
-        })(e)
-      );
-    }
-    function X(e) {
-      return !!e && (e.endsWithParent || X(e.starts));
-    }
-    class V extends Error {
-      constructor(e, n) {
-        super(e), (this.name = "HTMLInjectionError"), (this.html = n);
+            }
+            considerAll() {
+              this.regexIndex = 0;
+            }
+            addRule(e, n) {
+              this.rules.push([e, n]), "begin" === n.type && this.count++;
+            }
+            exec(e) {
+              const n = this.getMatcher(this.regexIndex);
+              n.lastIndex = this.lastIndex;
+              const t = n.exec(e);
+              return (
+                t &&
+                  ((this.regexIndex += t.position + 1),
+                  this.regexIndex === this.count && (this.regexIndex = 0)),
+                t
+              );
+            }
+          }
+          function i(e, n) {
+            const t = e.input[e.index - 1],
+              r = e.input[e.index + e[0].length];
+            ("." !== t && "." !== r) || n.ignoreMatch();
+          }
+          if (e.contains && e.contains.includes("self"))
+            throw Error(
+              "ERR: contains `self` is not supported at the top-level of a language.  See documentation."
+            );
+          return (function t(s, o) {
+            const l = s;
+            if (s.compiled) return l;
+            (s.compiled = !0),
+              (s.__beforeBegin = null),
+              (s.keywords = s.keywords || s.beginKeywords);
+            let c = null;
+            if (
+              ("object" == typeof s.keywords &&
+                ((c = s.keywords.$pattern), delete s.keywords.$pattern),
+              s.keywords &&
+                (s.keywords = (function (e, n) {
+                  var t = {};
+                  return (
+                    "string" == typeof e
+                      ? r("keyword", e)
+                      : Object.keys(e).forEach(function (n) {
+                          r(n, e[n]);
+                        }),
+                    t
+                  );
+                  function r(e, r) {
+                    n && (r = r.toLowerCase()),
+                      r.split(" ").forEach(function (n) {
+                        var r = n.split("|");
+                        t[r[0]] = [e, w(r[0], r[1])];
+                      });
+                  }
+                })(s.keywords, e.case_insensitive)),
+              s.lexemes && c)
+            )
+              throw Error(
+                "ERR: Prefer `keywords.$pattern` to `mode.lexemes`, BOTH are not allowed. (see mode reference) "
+              );
+            return (
+              (l.keywordPatternRe = n(s.lexemes || c || /\w+/, !0)),
+              o &&
+                (s.beginKeywords &&
+                  ((s.begin =
+                    "\\b(" +
+                    s.beginKeywords.split(" ").join("|") +
+                    ")(?=\\b|\\s)"),
+                  (s.__beforeBegin = i)),
+                s.begin || (s.begin = /\B|\b/),
+                (l.beginRe = n(s.begin)),
+                s.endSameAsBegin && (s.end = s.begin),
+                s.end || s.endsWithParent || (s.end = /\B|\b/),
+                s.end && (l.endRe = n(s.end)),
+                (l.terminator_end = d(s.end) || ""),
+                s.endsWithParent &&
+                  o.terminator_end &&
+                  (l.terminator_end += (s.end ? "|" : "") + o.terminator_end)),
+              s.illegal && (l.illegalRe = n(s.illegal)),
+              void 0 === s.relevance && (s.relevance = 1),
+              s.contains || (s.contains = []),
+              (s.contains = [].concat(
+                ...s.contains.map(function (e) {
+                  return (function (e) {
+                    return (
+                      e.variants &&
+                        !e.cached_variants &&
+                        (e.cached_variants = e.variants.map(function (n) {
+                          return r(e, { variants: null }, n);
+                        })),
+                      e.cached_variants
+                        ? e.cached_variants
+                        : (function e(n) {
+                            return !!n && (n.endsWithParent || e(n.starts));
+                          })(e)
+                        ? r(e, { starts: e.starts ? r(e.starts) : null })
+                        : Object.isFrozen(e)
+                        ? r(e)
+                        : e
+                    );
+                  })("self" === e ? s : e);
+                })
+              )),
+              s.contains.forEach(function (e) {
+                t(e, l);
+              }),
+              s.starts && t(s.starts, o),
+              (l.matcher = (function (e) {
+                const n = new a();
+                return (
+                  e.contains.forEach((e) =>
+                    n.addRule(e.begin, { rule: e, type: "begin" })
+                  ),
+                  e.terminator_end &&
+                    n.addRule(e.terminator_end, { type: "end" }),
+                  e.illegal && n.addRule(e.illegal, { type: "illegal" }),
+                  n
+                );
+              })(l)),
+              l
+            );
+          })(e);
+        })(E),
+        N = "",
+        y = s || _,
+        k = {},
+        O = new f.__emitter(f);
+      !(function () {
+        for (var e = [], n = y; n !== E; n = n.parent)
+          n.className && e.unshift(n.className);
+        e.forEach((e) => O.openNode(e));
+      })();
+      var A = "",
+        I = 0,
+        S = 0,
+        B = 0,
+        L = !1;
+      try {
+        for (y.matcher.considerAll(); ; ) {
+          B++,
+            L ? (L = !1) : ((y.matcher.lastIndex = S), y.matcher.considerAll());
+          const e = y.matcher.exec(o);
+          if (!e) break;
+          const n = x(o.substring(S, e.index), e);
+          S = e.index + n;
+        }
+        return (
+          x(o.substr(S)),
+          O.closeAllNodes(),
+          O.finalize(),
+          (N = O.toHTML()),
+          {
+            relevance: I,
+            value: N,
+            language: e,
+            illegal: !1,
+            emitter: O,
+            top: y,
+          }
+        );
+      } catch (n) {
+        if (n.message && n.message.includes("Illegal"))
+          return {
+            illegal: !0,
+            illegalBy: {
+              msg: n.message,
+              context: o.slice(S - 100, S + 100),
+              mode: n.mode,
+            },
+            sofar: N,
+            relevance: 0,
+            value: R(o),
+            emitter: O,
+          };
+        if (l)
+          return {
+            illegal: !1,
+            relevance: 0,
+            value: R(o),
+            emitter: O,
+            language: e,
+            top: y,
+            errorRaised: n,
+          };
+        throw n;
       }
     }
-    const J = t,
-      Y = s,
-      ee = Symbol("nomatch"),
-      ne = (t) => {
-        const s = Object.create(null),
-          a = Object.create(null),
-          i = [];
-        let r = !0;
-        const o =
-            "Could not find the language '{}', did you forget to load/include a language module?",
-          l = {
-            disableAutodetect: !0,
-            name: "Plain text",
-            contains: [],
+    function v(e, n) {
+      n = n || f.languages || Object.keys(i);
+      var t = (function (e) {
+          const n = {
+            relevance: 0,
+            emitter: new f.__emitter(f),
+            value: R(e),
+            illegal: !1,
+            top: h,
           };
-        let g = {
-          ignoreUnescapedHTML: !1,
-          throwUnescapedHTML: !1,
-          noHighlightRe: /^(no-?highlight)$/i,
-          languageDetectRe: /\blang(?:uage)?-([\w-]+)\b/i,
-          classPrefix: "hljs-",
-          cssSelector: "pre code",
-          languages: null,
-          __emitter: c,
-        };
-        function v(e) {
-          return g.noHighlightRe.test(e);
-        }
-        function _(e, n, t) {
-          let s = "",
-            a = "";
-          "object" == typeof n
-            ? ((s = e), (t = n.ignoreIllegals), (a = n.language))
-            : (H("10.7.0", "highlight(lang, code, ...args) has been deprecated."),
-              H(
-                "10.7.0",
-                "Please use highlight(code, options) instead.\nhttps://github.com/highlightjs/highlight.js/issues/2277"
-              ),
-              (a = e),
-              (s = n)),
-            void 0 === t && (t = !0);
-          const i = { code: s, language: a };
-          O("before:highlight", i);
-          const r = i.result ? i.result : f(i.language, i.code, t);
-          return (r.code = i.code), O("after:highlight", r), r;
-        }
-        function f(e, t, a, i) {
-          const c = Object.create(null);
-          function l() {
-            if (!O.keywords) return void A.addText(S);
-            let e = 0;
-            O.keywordPatternRe.lastIndex = 0;
-            let n = O.keywordPatternRe.exec(S),
-              t = "";
-            for (; n; ) {
-              t += S.substring(e, n.index);
-              const a = y.case_insensitive ? n[0].toLowerCase() : n[0],
-                i = ((s = a), O.keywords[s]);
-              if (i) {
-                const [e, s] = i;
-                if (
-                  (A.addText(t),
-                  (t = ""),
-                  (c[a] = (c[a] || 0) + 1),
-                  c[a] <= 7 && (C += s),
-                  e.startsWith("_"))
-                )
-                  t += n[0];
-                else {
-                  const t = y.classNameAliases[e] || e;
-                  p(n[0], t);
-                }
-              } else t += n[0];
-              (e = O.keywordPatternRe.lastIndex),
-                (n = O.keywordPatternRe.exec(S));
-            }
-            var s;
-            (t += S.substring(e)), A.addText(t);
-          }
-          function d() {
-            null != O.subLanguage
-              ? (() => {
-                  if ("" === S) return;
-                  let e = null;
-                  if ("string" == typeof O.subLanguage) {
-                    if (!s[O.subLanguage]) return void A.addText(S);
-                    (e = f(O.subLanguage, S, !0, M[O.subLanguage])),
-                      (M[O.subLanguage] = e._top);
-                  } else e = h(S, O.subLanguage.length ? O.subLanguage : null);
-                  O.relevance > 0 && (C += e.relevance),
-                    A.__addSublanguage(e._emitter, e.language);
-                })()
-              : l(),
-              (S = "");
-          }
-          function p(e, n) {
-            "" !== e && (A.startScope(n), A.addText(e), A.endScope());
-          }
-          function m(e, n) {
-            let t = 1;
-            const s = n.length - 1;
-            for (; t <= s; ) {
-              if (!e._emit[t]) {
-                t++;
-                continue;
-              }
-              const s = y.classNameAliases[e[t]] || e[t],
-                a = n[t];
-              s ? p(a, s) : ((S = a), l(), (S = "")), t++;
-            }
-          }
-          function u(e, n) {
-            return (
-              e.scope &&
-                "string" == typeof e.scope &&
-                A.openNode(y.classNameAliases[e.scope] || e.scope),
-              e.beginScope &&
-                (e.beginScope._wrap
-                  ? (p(
-                      S,
-                      y.classNameAliases[e.beginScope._wrap] || e.beginScope._wrap
-                    ),
-                    (S = ""))
-                  : e.beginScope._multi && (m(e.beginScope, n), (S = ""))),
-              (O = Object.create(e, {
-                parent: {
-                  value: O,
-                },
-              })),
-              O
-            );
-          }
-          function b(e, t, s) {
-            let a = ((e, n) => {
-              const t = e && e.exec(n);
-              return t && 0 === t.index;
-            })(e.endRe, s);
-            if (a) {
-              if (e["on:end"]) {
-                const s = new n(e);
-                e["on:end"](t, s), s.isMatchIgnored && (a = !1);
-              }
-              if (a) {
-                for (; e.endsParent && e.parent; ) e = e.parent;
-                return e;
-              }
-            }
-            if (e.endsWithParent) return b(e.parent, t, s);
-          }
-          function v(e) {
-            return 0 === O.matcher.regexIndex ? ((S += e[0]), 1) : ((D = !0), 0);
-          }
-          function _(e) {
-            const n = e[0],
-              s = t.substring(e.index),
-              a = b(O, e, s);
-            if (!a) return ee;
-            const i = O;
-            O.endScope && O.endScope._wrap
-              ? (d(), p(n, O.endScope._wrap))
-              : O.endScope && O.endScope._multi
-              ? (d(), m(O.endScope, e))
-              : i.skip
-              ? (S += n)
-              : (i.returnEnd || i.excludeEnd || (S += n),
-                d(),
-                i.excludeEnd && (S = n));
-            do {
-              O.scope && A.closeNode(),
-                O.skip || O.subLanguage || (C += O.relevance),
-                (O = O.parent);
-            } while (O !== a.parent);
-            return a.starts && u(a.starts, e), i.returnEnd ? 0 : n.length;
-          }
-          let E = {};
-          function w(s, i) {
-            const o = i && i[0];
-            if (((S += s), null == o)) return d(), 0;
-            if (
-              "begin" === E.type &&
-              "end" === i.type &&
-              E.index === i.index &&
-              "" === o
-            ) {
-              if (((S += t.slice(i.index, i.index + 1)), !r)) {
-                const n = Error(`0 width match regex (${e})`);
-                throw ((n.languageName = e), (n.badRule = E.rule), n);
-              }
-              return 1;
-            }
-            if (((E = i), "begin" === i.type))
-              return ((e) => {
-                const t = e[0],
-                  s = e.rule,
-                  a = new n(s),
-                  i = [s.__beforeBegin, s["on:begin"]];
-                for (const n of i)
-                  if (n && (n(e, a), a.isMatchIgnored)) return v(t);
-                return (
-                  s.skip
-                    ? (S += t)
-                    : (s.excludeBegin && (S += t),
-                      d(),
-                      s.returnBegin || s.excludeBegin || (S = t)),
-                  u(s, e),
-                  s.returnBegin ? 0 : t.length
-                );
-              })(i);
-            if ("illegal" === i.type && !a) {
-              const e = Error(
-                'Illegal lexeme "' +
-                  o +
-                  '" for mode "' +
-                  (O.scope || "<unnamed>") +
-                  '"'
-              );
-              throw ((e.mode = O), e);
-            }
-            if ("end" === i.type) {
-              const e = _(i);
-              if (e !== ee) return e;
-            }
-            if ("illegal" === i.type && "" === o) return 1;
-            if (q > 1e5 && q > 3 * i.index)
-              throw Error(
-                "potential infinite loop, way more iterations than matches"
-              );
-            return (S += o), o.length;
-          }
-          const y = N(e);
-          if (!y)
-            throw (j(o.replace("{}", e)), Error('Unknown language: "' + e + '"'));
-          const x = Q(y);
-          let k = "",
-            O = i || x;
-          const M = {},
-            A = new g.__emitter(g);
-          (() => {
-            const e = [];
-            for (let n = O; n !== y; n = n.parent) n.scope && e.unshift(n.scope);
-            e.forEach((e) => A.openNode(e));
-          })();
-          let S = "",
-            C = 0,
-            T = 0,
-            q = 0,
-            D = !1;
-          try {
-            if (y.__emitTokens) y.__emitTokens(t, A);
-            else {
-              for (O.matcher.considerAll(); ; ) {
-                q++,
-                  D ? (D = !1) : O.matcher.considerAll(),
-                  (O.matcher.lastIndex = T);
-                const e = O.matcher.exec(t);
-                if (!e) break;
-                const n = w(t.substring(T, e.index), e);
-                T = e.index + n;
-              }
-              w(t.substring(T));
-            }
-            return (
-              A.finalize(),
-              (k = A.toHTML()),
-              {
-                language: e,
-                value: k,
-                relevance: C,
-                illegal: !1,
-                _emitter: A,
-                _top: O,
-              }
-            );
-          } catch (n) {
-            if (n.message && n.message.includes("Illegal"))
-              return {
-                language: e,
-                value: J(t),
-                illegal: !0,
-                relevance: 0,
-                _illegalBy: {
-                  message: n.message,
-                  index: T,
-                  context: t.slice(T - 100, T + 100),
-                  mode: n.mode,
-                  resultSoFar: k,
-                },
-                _emitter: A,
-              };
-            if (r)
-              return {
-                language: e,
-                value: J(t),
-                illegal: !1,
-                relevance: 0,
-                errorRaised: n,
-                _emitter: A,
-                _top: O,
-              };
-            throw n;
-          }
-        }
-        function h(e, n) {
-          n = n || g.languages || Object.keys(s);
-          const t = ((e) => {
-              const n = {
-                value: J(e),
-                illegal: !1,
-                relevance: 0,
-                _top: l,
-                _emitter: new g.__emitter(g),
-              };
-              return n._emitter.addText(e), n;
-            })(e),
-            a = n
-              .filter(N)
-              .filter(k)
-              .map((n) => f(n, e, !1));
-          a.unshift(t);
-          const i = a.sort((e, n) => {
-              if (e.relevance !== n.relevance) return n.relevance - e.relevance;
-              if (e.language && n.language) {
-                if (N(e.language).supersetOf === n.language) return 1;
-                if (N(n.language).supersetOf === e.language) return -1;
-              }
-              return 0;
-            }),
-            [r, o] = i,
-            c = r;
-          return (c.secondBest = o), c;
-        }
-        function E(e) {
-          let n = null;
-          const t = ((e) => {
-            let n = e.className + " ";
-            n += e.parentNode ? e.parentNode.className : "";
-            const t = g.languageDetectRe.exec(n);
-            if (t) {
-              const n = N(t[1]);
-              return (
-                n ||
-                  (K(o.replace("{}", t[1])),
-                  K("Falling back to no-highlight mode for this block.", e)),
-                n ? t[1] : "no-highlight"
-              );
-            }
-            return n.split(/\s+/).find((e) => v(e) || N(e));
-          })(e);
-          if (v(t)) return;
-          if (
-            (O("before:highlightElement", { el: e, language: t }),
-            e.dataset.highlighted)
+          return n.emitter.addText(e), n;
+        })(e),
+        r = t;
+      return (
+        n
+          .filter(T)
+          .filter(I)
+          .forEach(function (n) {
+            var a = m(n, e, !1);
+            (a.language = n),
+              a.relevance > r.relevance && (r = a),
+              a.relevance > t.relevance && ((r = t), (t = a));
+          }),
+        r.language && (t.second_best = r),
+        t
+      );
+    }
+    function x(e) {
+      return f.tabReplace || f.useBR
+        ? e.replace(c, (e) =>
+            "\n" === e
+              ? f.useBR
+                ? "<br>"
+                : e
+              : f.tabReplace
+              ? e.replace(/\t/g, f.tabReplace)
+              : e
           )
-            return void console.log(
-              "Element previously highlighted. To highlight again, first unset `dataset.highlighted`.",
-              e
-            );
-          if (
-            e.children.length > 0 &&
-            (g.ignoreUnescapedHTML ||
-              (console.warn(
-                "One of your code blocks includes unescaped HTML. This is a potentially serious security risk."
-              ),
+        : e;
+    }
+    function E(e) {
+      let n = null;
+      const t = (function (e) {
+        var n = e.className + " ";
+        n += e.parentNode ? e.parentNode.className : "";
+        const t = f.languageDetectRe.exec(n);
+        if (t) {
+          var r = T(t[1]);
+          return (
+            r ||
+              (console.warn(g.replace("{}", t[1])),
               console.warn(
-                "https://github.com/highlightjs/highlight.js/wiki/security"
-              ),
-              console.warn("The element with unescaped HTML:"),
-              console.warn(e)),
-            g.throwUnescapedHTML)
-          )
-            throw new V(
-              "One of your code blocks includes unescaped HTML.",
-              e.innerHTML
-            );
-          n = e;
-          const s = n.textContent,
-            i = t ? _(s, { language: t, ignoreIllegals: !0 }) : h(s);
-          (e.innerHTML = i.value),
-            (e.dataset.highlighted = "yes"),
-            ((e, n, t) => {
-              const s = (n && a[n]) || t;
-              e.classList.add("hljs"), e.classList.add("language-" + s);
-            })(e, t, i.language),
-            (e.result = {
-              language: i.language,
-              re: i.relevance,
-              relevance: i.relevance,
-            }),
-            i.secondBest &&
-              (e.secondBest = {
-                language: i.secondBest.language,
-                relevance: i.secondBest.relevance,
-              }),
-            O("after:highlightElement", { el: e, result: i, text: s });
+                "Falling back to no-highlight mode for this block.",
+                e
+              )),
+            r ? t[1] : "no-highlight"
+          );
         }
-        let w = !1;
-        function y() {
-          "loading" !== document.readyState
-            ? document.querySelectorAll(g.cssSelector).forEach(E)
-            : (w = !0);
-        }
-        function N(e) {
-          return (e = (e || "").toLowerCase()), s[e] || s[a[e]];
-        }
-        function x(e, { languageName: n }) {
-          "string" == typeof e && (e = [e]),
-            e.forEach((e) => {
-              a[e.toLowerCase()] = n;
-            });
-        }
-        function k(e) {
-          const n = N(e);
-          return n && !n.disableAutodetect;
-        }
-        function O(e, n) {
-          const t = e;
-          i.forEach((e) => {
-            e[t] && e[t](n);
+        return n.split(/\s+/).find((e) => p(e) || T(e));
+      })(e);
+      if (p(t)) return;
+      S("before:highlightBlock", { block: e, language: t }),
+        f.useBR
+          ? ((n = document.createElement("div")).innerHTML = e.innerHTML
+              .replace(/\n/g, "")
+              .replace(/<br[ /]*>/g, "\n"))
+          : (n = e);
+      const r = n.textContent,
+        a = t ? b(t, r, !0) : v(r),
+        i = k(n);
+      if (i.length) {
+        const e = document.createElement("div");
+        (e.innerHTML = a.value), (a.value = O(i, k(e), r));
+      }
+      (a.value = x(a.value)),
+        S("after:highlightBlock", { block: e, result: a }),
+        (e.innerHTML = a.value),
+        (e.className = (function (e, n, t) {
+          var r = n ? s[n] : t,
+            a = [e.trim()];
+          return (
+            e.match(/\bhljs\b/) || a.push("hljs"),
+            e.includes(r) || a.push(r),
+            a.join(" ").trim()
+          );
+        })(e.className, t, a.language)),
+        (e.result = {
+          language: a.language,
+          re: a.relevance,
+          relavance: a.relevance,
+        }),
+        a.second_best &&
+          (e.second_best = {
+            language: a.second_best.language,
+            re: a.second_best.relevance,
+            relavance: a.second_best.relevance,
           });
-        }
-        "undefined" != typeof window &&
-          window.addEventListener &&
-          window.addEventListener(
-            "DOMContentLoaded",
-            () => {
-              w && y();
-            },
-            !1
-          ),
-          Object.assign(t, {
-            highlight: _,
-            highlightAuto: h,
-            highlightAll: y,
-            highlightElement: E,
-            highlightBlock: (e) => (
-              H("10.7.0", "highlightBlock will be removed entirely in v12.0"),
-              H("10.7.0", "Please use highlightElement now."),
-              E(e)
-            ),
-            configure: (e) => {
-              g = Y(g, e);
-            },
-            initHighlighting: () => {
-              y(),
-                H(
-                  "10.6.0",
-                  "initHighlighting() deprecated.  Use highlightAll() now."
-                );
-            },
-            initHighlightingOnLoad: () => {
-              y(),
-                H(
-                  "10.6.0",
-                  "initHighlightingOnLoad() deprecated.  Use highlightAll() now."
-                );
-            },
-            registerLanguage: (e, n) => {
-              let a = null;
-              try {
-                a = n(t);
-              } catch (n) {
-                if (
-                  (j(
-                    "Language definition for '{}' could not be registered.".replace(
-                      "{}",
-                      e
-                    )
-                  ),
-                  !r)
-                )
-                  throw n;
-                j(n), (a = l);
-              }
-              a.name || (a.name = e),
-                (s[e] = a),
-                (a.rawDefinition = n.bind(null, t)),
-                a.aliases &&
-                  x(a.aliases, {
-                    languageName: e,
-                  });
-            },
-            unregisterLanguage: (e) => {
-              delete s[e];
-              for (const n of Object.keys(a)) a[n] === e && delete a[n];
-            },
-            listLanguages: () => Object.keys(s),
-            getLanguage: N,
-            registerAliases: x,
-            autoDetection: k,
-            inherit: Y,
-            addPlugin: (e) => {
-              ((e) => {
-                e["before:highlightBlock"] &&
-                  !e["before:highlightElement"] &&
-                  (e["before:highlightElement"] = (n) => {
-                    e["before:highlightBlock"](Object.assign({ block: n.el }, n));
-                  }),
-                  e["after:highlightBlock"] &&
-                    !e["after:highlightElement"] &&
-                    (e["after:highlightElement"] = (n) => {
-                      e["after:highlightBlock"](
-                        Object.assign({ block: n.el }, n)
-                      );
-                    });
-              })(e),
-                i.push(e);
-            },
-            removePlugin: (e) => {
-              const n = i.indexOf(e);
-              -1 !== n && i.splice(n, 1);
-            },
-          }),
-          (t.debugMode = () => {
-            r = !1;
-          }),
-          (t.safeMode = () => {
-            r = !0;
-          }),
-          (t.versionString = "11.10.0"),
-          (t.regex = {
-            concat: u,
-            lookahead: d,
-            either: b,
-            optional: m,
-            anyNumberOfTimes: p,
-          });
-        for (const n in C) "object" == typeof C[n] && e(C[n]);
-        return Object.assign(t, C), t;
+    }
+    const N = () => {
+      if (!N.called) {
+        N.called = !0;
+        var e = document.querySelectorAll("pre code");
+        a.forEach.call(e, E);
+      }
+    };
+    function T(e) {
+      return (e = (e || "").toLowerCase()), i[e] || i[s[e]];
+    }
+    function A(e, { languageName: n }) {
+      "string" == typeof e && (e = [e]),
+        e.forEach((e) => {
+          s[e] = n;
+        });
+    }
+    function I(e) {
+      var n = T(e);
+      return n && !n.disableAutodetect;
+    }
+    function S(e, n) {
+      var t = e;
+      o.forEach(function (e) {
+        e[t] && e[t](n);
+      });
+    }
+    Object.assign(t, {
+      highlight: b,
+      highlightAuto: v,
+      fixMarkup: x,
+      highlightBlock: E,
+      configure: function (e) {
+        f = y(f, e);
       },
-      te = ne({});
-    te.newInstance = () => ne({});
-    const se = (e) => ({
-        IMPORTANT: { scope: "meta", begin: "!important" },
-        BLOCK_COMMENT: e.C_BLOCK_COMMENT_MODE,
-        HEXCOLOR: {
-          scope: "number",
-          begin: /#(([0-9a-fA-F]{3,4})|(([0-9a-fA-F]{2}){3,4}))\b/,
+      initHighlighting: N,
+      initHighlightingOnLoad: function () {
+        window.addEventListener("DOMContentLoaded", N, !1);
+      },
+      registerLanguage: function (e, n) {
+        var r = null;
+        try {
+          r = n(t);
+        } catch (n) {
+          if (
+            (console.error(
+              "Language definition for '{}' could not be registered.".replace(
+                "{}",
+                e
+              )
+            ),
+            !l)
+          )
+            throw n;
+          console.error(n), (r = h);
+        }
+        r.name || (r.name = e),
+          (i[e] = r),
+          (r.rawDefinition = n.bind(null, t)),
+          r.aliases && A(r.aliases, { languageName: e });
+      },
+      listLanguages: function () {
+        return Object.keys(i);
+      },
+      getLanguage: T,
+      registerAliases: A,
+      requireLanguage: function (e) {
+        var n = T(e);
+        if (n) return n;
+        throw Error(
+          "The '{}' language is required, but not loaded.".replace("{}", e)
+        );
+      },
+      autoDetection: I,
+      inherit: y,
+      addPlugin: function (e) {
+        o.push(e);
+      },
+    }),
+      (t.debugMode = function () {
+        l = !1;
+      }),
+      (t.safeMode = function () {
+        l = !0;
+      }),
+      (t.versionString = "10.1.1");
+    for (const n in _) "object" == typeof _[n] && e(_[n]);
+    return Object.assign(t, _), t;
+  })({});
+})();
+"object" == typeof exports &&
+  "undefined" != typeof module &&
+  (module.exports = hljs);
+hljs.registerLanguage(
+  "apache",
+  (function () {
+    "use strict";
+    return function (e) {
+      var n = {
+        className: "number",
+        begin: "\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}(:\\d{1,5})?",
+      };
+      return {
+        name: "Apache config",
+        aliases: ["apacheconf"],
+        case_insensitive: !0,
+        contains: [
+          e.HASH_COMMENT_MODE,
+          {
+            className: "section",
+            begin: "</?",
+            end: ">",
+            contains: [
+              n,
+              { className: "number", begin: ":\\d{1,5}" },
+              e.inherit(e.QUOTE_STRING_MODE, { relevance: 0 }),
+            ],
+          },
+          {
+            className: "attribute",
+            begin: /\w+/,
+            relevance: 0,
+            keywords: {
+              nomarkup:
+                "order deny allow setenv rewriterule rewriteengine rewritecond documentroot sethandler errordocument loadmodule options header listen serverroot servername",
+            },
+            starts: {
+              end: /$/,
+              relevance: 0,
+              keywords: { literal: "on off all deny allow" },
+              contains: [
+                { className: "meta", begin: "\\s\\[", end: "\\]$" },
+                {
+                  className: "variable",
+                  begin: "[\\$%]\\{",
+                  end: "\\}",
+                  contains: [
+                    "self",
+                    { className: "number", begin: "[\\$%]\\d+" },
+                  ],
+                },
+                n,
+                { className: "number", begin: "\\d+" },
+                e.QUOTE_STRING_MODE,
+              ],
+            },
+          },
+        ],
+        illegal: /\S/,
+      };
+    };
+  })()
+);
+hljs.registerLanguage(
+  "bash",
+  (function () {
+    "use strict";
+    return function (e) {
+      const s = {};
+      Object.assign(s, {
+        className: "variable",
+        variants: [
+          { begin: /\$[\w\d#@][\w\d_]*/ },
+          {
+            begin: /\$\{/,
+            end: /\}/,
+            contains: [{ begin: /:-/, contains: [s] }],
+          },
+        ],
+      });
+      const t = {
+          className: "subst",
+          begin: /\$\(/,
+          end: /\)/,
+          contains: [e.BACKSLASH_ESCAPE],
         },
-        FUNCTION_DISPATCH: { className: "built_in", begin: /[\w-]+(?=\()/ },
-        ATTRIBUTE_SELECTOR_MODE: {
-          scope: "selector-attr",
-          begin: /\[/,
-          end: /\]/,
-          illegal: "$",
-          contains: [e.APOS_STRING_MODE, e.QUOTE_STRING_MODE],
+        n = {
+          className: "string",
+          begin: /"/,
+          end: /"/,
+          contains: [e.BACKSLASH_ESCAPE, s, t],
+        };
+      t.contains.push(n);
+      const a = {
+          begin: /\$\(\(/,
+          end: /\)\)/,
+          contains: [
+            { begin: /\d+#[0-9a-f]+/, className: "number" },
+            e.NUMBER_MODE,
+            s,
+          ],
         },
-        CSS_NUMBER_MODE: {
-          scope: "number",
-          begin:
-            e.NUMBER_RE +
-            "(%|em|ex|ch|rem|vw|vh|vmin|vmax|cm|mm|in|pt|pc|px|deg|grad|rad|turn|s|ms|Hz|kHz|dpi|dpcm|dppx)?",
+        i = e.SHEBANG({
+          binary: "(fish|bash|zsh|sh|csh|ksh|tcsh|dash|scsh)",
+          relevance: 10,
+        }),
+        c = {
+          className: "function",
+          begin: /\w[\w\d_]*\s*\(\s*\)\s*\{/,
+          returnBegin: !0,
+          contains: [e.inherit(e.TITLE_MODE, { begin: /\w[\w\d_]*/ })],
+          relevance: 0,
+        };
+      return {
+        name: "Bash",
+        aliases: ["sh", "zsh"],
+        keywords: {
+          $pattern: /\b-?[a-z\._]+\b/,
+          keyword:
+            "if then else elif fi for while in do done case esac function",
+          literal: "true false",
+          built_in:
+            "break cd continue eval exec exit export getopts hash pwd readonly return shift test times trap umask unset alias bind builtin caller command declare echo enable help let local logout mapfile printf read readarray source type typeset ulimit unalias set shopt autoload bg bindkey bye cap chdir clone comparguments compcall compctl compdescribe compfiles compgroups compquote comptags comptry compvalues dirs disable disown echotc echoti emulate fc fg float functions getcap getln history integer jobs kill limit log noglob popd print pushd pushln rehash sched setcap setopt stat suspend ttyctl unfunction unhash unlimit unsetopt vared wait whence where which zcompile zformat zftp zle zmodload zparseopts zprof zpty zregexparse zsocket zstyle ztcp",
+          _: "-ne -eq -lt -gt -f -d -e -s -l -a",
+        },
+        contains: [
+          i,
+          e.SHEBANG(),
+          c,
+          a,
+          e.HASH_COMMENT_MODE,
+          n,
+          { className: "", begin: /\\"/ },
+          { className: "string", begin: /'/, end: /'/ },
+          s,
+        ],
+      };
+    };
+  })()
+);
+hljs.registerLanguage(
+  "c-like",
+  (function () {
+    "use strict";
+    return function (e) {
+      function t(e) {
+        return "(?:" + e + ")?";
+      }
+      var n =
+          "(decltype\\(auto\\)|" +
+          t("[a-zA-Z_]\\w*::") +
+          "[a-zA-Z_]\\w*" +
+          t("<.*?>") +
+          ")",
+        r = { className: "keyword", begin: "\\b[a-z\\d_]*_t\\b" },
+        a = {
+          className: "string",
+          variants: [
+            {
+              begin: '(u8?|U|L)?"',
+              end: '"',
+              illegal: "\\n",
+              contains: [e.BACKSLASH_ESCAPE],
+            },
+            {
+              begin:
+                "(u8?|U|L)?'(\\\\(x[0-9A-Fa-f]{2}|u[0-9A-Fa-f]{4,8}|[0-7]{3}|\\S)|.)",
+              end: "'",
+              illegal: ".",
+            },
+            e.END_SAME_AS_BEGIN({
+              begin: /(?:u8?|U|L)?R"([^()\\ ]{0,16})\(/,
+              end: /\)([^()\\ ]{0,16})"/,
+            }),
+          ],
+        },
+        i = {
+          className: "number",
+          variants: [
+            { begin: "\\b(0b[01']+)" },
+            {
+              begin:
+                "(-?)\\b([\\d']+(\\.[\\d']*)?|\\.[\\d']+)(u|U|l|L|ul|UL|f|F|b|B)",
+            },
+            {
+              begin:
+                "(-?)(\\b0[xX][a-fA-F0-9']+|(\\b[\\d']+(\\.[\\d']*)?|\\.[\\d']+)([eE][-+]?[\\d']+)?)",
+            },
+          ],
           relevance: 0,
         },
-        CSS_VARIABLE: { className: "attr", begin: /--[A-Za-z_][A-Za-z0-9_-]*/ },
-      }),
-      ae = [
-        "a",
-        "abbr",
-        "address",
-        "article",
-        "aside",
-        "audio",
-        "b",
-        "blockquote",
-        "body",
-        "button",
-        "canvas",
-        "caption",
-        "cite",
-        "code",
-        "dd",
-        "del",
-        "details",
-        "dfn",
-        "div",
-        "dl",
-        "dt",
-        "em",
-        "fieldset",
-        "figcaption",
-        "figure",
-        "footer",
-        "form",
-        "h1",
-        "h2",
-        "h3",
-        "h4",
-        "h5",
-        "h6",
-        "header",
-        "hgroup",
-        "html",
-        "i",
-        "iframe",
-        "img",
-        "input",
-        "ins",
-        "kbd",
-        "label",
-        "legend",
-        "li",
-        "main",
-        "mark",
-        "menu",
-        "nav",
-        "object",
-        "ol",
-        "optgroup",
-        "option",
-        "p",
-        "picture",
-        "q",
-        "quote",
-        "samp",
-        "section",
-        "select",
-        "source",
-        "span",
-        "strong",
-        "summary",
-        "sup",
-        "table",
-        "tbody",
-        "td",
-        "textarea",
-        "tfoot",
-        "th",
-        "thead",
-        "time",
-        "tr",
-        "ul",
-        "var",
-        "video",
-        "defs",
-        "g",
-        "marker",
-        "mask",
-        "pattern",
-        "svg",
-        "switch",
-        "symbol",
-        "feBlend",
-        "feColorMatrix",
-        "feComponentTransfer",
-        "feComposite",
-        "feConvolveMatrix",
-        "feDiffuseLighting",
-        "feDisplacementMap",
-        "feFlood",
-        "feGaussianBlur",
-        "feImage",
-        "feMerge",
-        "feMorphology",
-        "feOffset",
-        "feSpecularLighting",
-        "feTile",
-        "feTurbulence",
-        "linearGradient",
-        "radialGradient",
-        "stop",
-        "circle",
-        "ellipse",
-        "image",
-        "line",
-        "path",
-        "polygon",
-        "polyline",
-        "rect",
-        "text",
-        "use",
-        "textPath",
-        "tspan",
-        "foreignObject",
-        "clipPath",
-      ],
-      ie = [
-        "any-hover",
-        "any-pointer",
-        "aspect-ratio",
-        "color",
-        "color-gamut",
-        "color-index",
-        "device-aspect-ratio",
-        "device-height",
-        "device-width",
-        "display-mode",
-        "forced-colors",
-        "grid",
-        "height",
-        "hover",
-        "inverted-colors",
-        "monochrome",
-        "orientation",
-        "overflow-block",
-        "overflow-inline",
-        "pointer",
-        "prefers-color-scheme",
-        "prefers-contrast",
-        "prefers-reduced-motion",
-        "prefers-reduced-transparency",
-        "resolution",
-        "scan",
-        "scripting",
-        "update",
-        "width",
-        "min-width",
-        "max-width",
-        "min-height",
-        "max-height",
-      ]
-        .sort()
-        .reverse(),
-      re = [
-        "active",
-        "any-link",
-        "blank",
-        "checked",
-        "current",
-        "default",
-        "defined",
-        "dir",
-        "disabled",
-        "drop",
-        "empty",
-        "enabled",
-        "first",
-        "first-child",
-        "first-of-type",
-        "fullscreen",
-        "future",
-        "focus",
-        "focus-visible",
-        "focus-within",
-        "has",
-        "host",
-        "host-context",
-        "hover",
-        "indeterminate",
-        "in-range",
-        "invalid",
-        "is",
-        "lang",
-        "last-child",
-        "last-of-type",
-        "left",
-        "link",
-        "local-link",
-        "not",
-        "nth-child",
-        "nth-col",
-        "nth-last-child",
-        "nth-last-col",
-        "nth-last-of-type",
-        "nth-of-type",
-        "only-child",
-        "only-of-type",
-        "optional",
-        "out-of-range",
-        "past",
-        "placeholder-shown",
-        "read-only",
-        "read-write",
-        "required",
-        "right",
-        "root",
-        "scope",
-        "target",
-        "target-within",
-        "user-invalid",
-        "valid",
-        "visited",
-        "where",
-      ]
-        .sort()
-        .reverse(),
-      oe = [
-        "after",
-        "backdrop",
-        "before",
-        "cue",
-        "cue-region",
-        "first-letter",
-        "first-line",
-        "grammar-error",
-        "marker",
-        "part",
-        "placeholder",
-        "selection",
-        "slotted",
-        "spelling-error",
-      ]
-        .sort()
-        .reverse(),
-      ce = [
-        "accent-color",
-        "align-content",
-        "align-items",
-        "align-self",
-        "alignment-baseline",
-        "all",
-        "anchor-name",
-        "animation",
-        "animation-composition",
-        "animation-delay",
-        "animation-direction",
-        "animation-duration",
-        "animation-fill-mode",
-        "animation-iteration-count",
-        "animation-name",
-        "animation-play-state",
-        "animation-range",
-        "animation-range-end",
-        "animation-range-start",
-        "animation-timeline",
-        "animation-timing-function",
-        "appearance",
-        "aspect-ratio",
-        "backdrop-filter",
-        "backface-visibility",
-        "background",
-        "background-attachment",
-        "background-blend-mode",
-        "background-clip",
-        "background-color",
-        "background-image",
-        "background-origin",
-        "background-position",
-        "background-position-x",
-        "background-position-y",
-        "background-repeat",
-        "background-size",
-        "baseline-shift",
-        "block-size",
-        "border",
-        "border-block",
-        "border-block-color",
-        "border-block-end",
-        "border-block-end-color",
-        "border-block-end-style",
-        "border-block-end-width",
-        "border-block-start",
-        "border-block-start-color",
-        "border-block-start-style",
-        "border-block-start-width",
-        "border-block-style",
-        "border-block-width",
-        "border-bottom",
-        "border-bottom-color",
-        "border-bottom-left-radius",
-        "border-bottom-right-radius",
-        "border-bottom-style",
-        "border-bottom-width",
-        "border-collapse",
-        "border-color",
-        "border-end-end-radius",
-        "border-end-start-radius",
-        "border-image",
-        "border-image-outset",
-        "border-image-repeat",
-        "border-image-slice",
-        "border-image-source",
-        "border-image-width",
-        "border-inline",
-        "border-inline-color",
-        "border-inline-end",
-        "border-inline-end-color",
-        "border-inline-end-style",
-        "border-inline-end-width",
-        "border-inline-start",
-        "border-inline-start-color",
-        "border-inline-start-style",
-        "border-inline-start-width",
-        "border-inline-style",
-        "border-inline-width",
-        "border-left",
-        "border-left-color",
-        "border-left-style",
-        "border-left-width",
-        "border-radius",
-        "border-right",
-        "border-right-color",
-        "border-right-style",
-        "border-right-width",
-        "border-spacing",
-        "border-start-end-radius",
-        "border-start-start-radius",
-        "border-style",
-        "border-top",
-        "border-top-color",
-        "border-top-left-radius",
-        "border-top-right-radius",
-        "border-top-style",
-        "border-top-width",
-        "border-width",
-        "bottom",
-        "box-align",
-        "box-decoration-break",
-        "box-direction",
-        "box-flex",
-        "box-flex-group",
-        "box-lines",
-        "box-ordinal-group",
-        "box-orient",
-        "box-pack",
-        "box-shadow",
-        "box-sizing",
-        "break-after",
-        "break-before",
-        "break-inside",
-        "caption-side",
-        "caret-color",
-        "clear",
-        "clip",
-        "clip-path",
-        "clip-rule",
-        "color",
-        "color-interpolation",
-        "color-interpolation-filters",
-        "color-profile",
-        "color-rendering",
-        "color-scheme",
-        "column-count",
-        "column-fill",
-        "column-gap",
-        "column-rule",
-        "column-rule-color",
-        "column-rule-style",
-        "column-rule-width",
-        "column-span",
-        "column-width",
-        "columns",
-        "contain",
-        "contain-intrinsic-block-size",
-        "contain-intrinsic-height",
-        "contain-intrinsic-inline-size",
-        "contain-intrinsic-size",
-        "contain-intrinsic-width",
-        "container",
-        "container-name",
-        "container-type",
-        "content",
-        "content-visibility",
-        "counter-increment",
-        "counter-reset",
-        "counter-set",
-        "cue",
-        "cue-after",
-        "cue-before",
-        "cursor",
-        "cx",
-        "cy",
-        "direction",
-        "display",
-        "dominant-baseline",
-        "empty-cells",
-        "enable-background",
-        "field-sizing",
-        "fill",
-        "fill-opacity",
-        "fill-rule",
-        "filter",
-        "flex",
-        "flex-basis",
-        "flex-direction",
-        "flex-flow",
-        "flex-grow",
-        "flex-shrink",
-        "flex-wrap",
-        "float",
-        "flood-color",
-        "flood-opacity",
-        "flow",
-        "font",
-        "font-display",
-        "font-family",
-        "font-feature-settings",
-        "font-kerning",
-        "font-language-override",
-        "font-optical-sizing",
-        "font-palette",
-        "font-size",
-        "font-size-adjust",
-        "font-smooth",
-        "font-smoothing",
-        "font-stretch",
-        "font-style",
-        "font-synthesis",
-        "font-synthesis-position",
-        "font-synthesis-small-caps",
-        "font-synthesis-style",
-        "font-synthesis-weight",
-        "font-variant",
-        "font-variant-alternates",
-        "font-variant-caps",
-        "font-variant-east-asian",
-        "font-variant-emoji",
-        "font-variant-ligatures",
-        "font-variant-numeric",
-        "font-variant-position",
-        "font-variation-settings",
-        "font-weight",
-        "forced-color-adjust",
-        "gap",
-        "glyph-orientation-horizontal",
-        "glyph-orientation-vertical",
-        "grid",
-        "grid-area",
-        "grid-auto-columns",
-        "grid-auto-flow",
-        "grid-auto-rows",
-        "grid-column",
-        "grid-column-end",
-        "grid-column-start",
-        "grid-gap",
-        "grid-row",
-        "grid-row-end",
-        "grid-row-start",
-        "grid-template",
-        "grid-template-areas",
-        "grid-template-columns",
-        "grid-template-rows",
-        "hanging-punctuation",
-        "height",
-        "hyphenate-character",
-        "hyphenate-limit-chars",
-        "hyphens",
-        "icon",
-        "image-orientation",
-        "image-rendering",
-        "image-resolution",
-        "ime-mode",
-        "initial-letter",
-        "initial-letter-align",
-        "inline-size",
-        "inset",
-        "inset-area",
-        "inset-block",
-        "inset-block-end",
-        "inset-block-start",
-        "inset-inline",
-        "inset-inline-end",
-        "inset-inline-start",
-        "isolation",
-        "justify-content",
-        "justify-items",
-        "justify-self",
-        "kerning",
-        "left",
-        "letter-spacing",
-        "lighting-color",
-        "line-break",
-        "line-height",
-        "line-height-step",
-        "list-style",
-        "list-style-image",
-        "list-style-position",
-        "list-style-type",
-        "margin",
-        "margin-block",
-        "margin-block-end",
-        "margin-block-start",
-        "margin-bottom",
-        "margin-inline",
-        "margin-inline-end",
-        "margin-inline-start",
-        "margin-left",
-        "margin-right",
-        "margin-top",
-        "margin-trim",
-        "marker",
-        "marker-end",
-        "marker-mid",
-        "marker-start",
-        "marks",
-        "mask",
-        "mask-border",
-        "mask-border-mode",
-        "mask-border-outset",
-        "mask-border-repeat",
-        "mask-border-slice",
-        "mask-border-source",
-        "mask-border-width",
-        "mask-clip",
-        "mask-composite",
-        "mask-image",
-        "mask-mode",
-        "mask-origin",
-        "mask-position",
-        "mask-repeat",
-        "mask-size",
-        "mask-type",
-        "masonry-auto-flow",
-        "math-depth",
-        "math-shift",
-        "math-style",
-        "max-block-size",
-        "max-height",
-        "max-inline-size",
-        "max-width",
-        "min-block-size",
-        "min-height",
-        "min-inline-size",
-        "min-width",
-        "mix-blend-mode",
-        "nav-down",
-        "nav-index",
-        "nav-left",
-        "nav-right",
-        "nav-up",
-        "none",
-        "normal",
-        "object-fit",
-        "object-position",
-        "offset",
-        "offset-anchor",
-        "offset-distance",
-        "offset-path",
-        "offset-position",
-        "offset-rotate",
-        "opacity",
-        "order",
-        "orphans",
-        "outline",
-        "outline-color",
-        "outline-offset",
-        "outline-style",
-        "outline-width",
-        "overflow",
-        "overflow-anchor",
-        "overflow-block",
-        "overflow-clip-margin",
-        "overflow-inline",
-        "overflow-wrap",
-        "overflow-x",
-        "overflow-y",
-        "overlay",
-        "overscroll-behavior",
-        "overscroll-behavior-block",
-        "overscroll-behavior-inline",
-        "overscroll-behavior-x",
-        "overscroll-behavior-y",
-        "padding",
-        "padding-block",
-        "padding-block-end",
-        "padding-block-start",
-        "padding-bottom",
-        "padding-inline",
-        "padding-inline-end",
-        "padding-inline-start",
-        "padding-left",
-        "padding-right",
-        "padding-top",
-        "page",
-        "page-break-after",
-        "page-break-before",
-        "page-break-inside",
-        "paint-order",
-        "pause",
-        "pause-after",
-        "pause-before",
-        "perspective",
-        "perspective-origin",
-        "place-content",
-        "place-items",
-        "place-self",
-        "pointer-events",
-        "position",
-        "position-anchor",
-        "position-visibility",
-        "print-color-adjust",
-        "quotes",
-        "r",
-        "resize",
-        "rest",
-        "rest-after",
-        "rest-before",
-        "right",
-        "rotate",
-        "row-gap",
-        "ruby-align",
-        "ruby-position",
-        "scale",
-        "scroll-behavior",
-        "scroll-margin",
-        "scroll-margin-block",
-        "scroll-margin-block-end",
-        "scroll-margin-block-start",
-        "scroll-margin-bottom",
-        "scroll-margin-inline",
-        "scroll-margin-inline-end",
-        "scroll-margin-inline-start",
-        "scroll-margin-left",
-        "scroll-margin-right",
-        "scroll-margin-top",
-        "scroll-padding",
-        "scroll-padding-block",
-        "scroll-padding-block-end",
-        "scroll-padding-block-start",
-        "scroll-padding-bottom",
-        "scroll-padding-inline",
-        "scroll-padding-inline-end",
-        "scroll-padding-inline-start",
-        "scroll-padding-left",
-        "scroll-padding-right",
-        "scroll-padding-top",
-        "scroll-snap-align",
-        "scroll-snap-stop",
-        "scroll-snap-type",
-        "scroll-timeline",
-        "scroll-timeline-axis",
-        "scroll-timeline-name",
-        "scrollbar-color",
-        "scrollbar-gutter",
-        "scrollbar-width",
-        "shape-image-threshold",
-        "shape-margin",
-        "shape-outside",
-        "shape-rendering",
-        "speak",
-        "speak-as",
-        "src",
-        "stop-color",
-        "stop-opacity",
-        "stroke",
-        "stroke-dasharray",
-        "stroke-dashoffset",
-        "stroke-linecap",
-        "stroke-linejoin",
-        "stroke-miterlimit",
-        "stroke-opacity",
-        "stroke-width",
-        "tab-size",
-        "table-layout",
-        "text-align",
-        "text-align-all",
-        "text-align-last",
-        "text-anchor",
-        "text-combine-upright",
-        "text-decoration",
-        "text-decoration-color",
-        "text-decoration-line",
-        "text-decoration-skip",
-        "text-decoration-skip-ink",
-        "text-decoration-style",
-        "text-decoration-thickness",
-        "text-emphasis",
-        "text-emphasis-color",
-        "text-emphasis-position",
-        "text-emphasis-style",
-        "text-indent",
-        "text-justify",
-        "text-orientation",
-        "text-overflow",
-        "text-rendering",
-        "text-shadow",
-        "text-size-adjust",
-        "text-transform",
-        "text-underline-offset",
-        "text-underline-position",
-        "text-wrap",
-        "text-wrap-mode",
-        "text-wrap-style",
-        "timeline-scope",
-        "top",
-        "touch-action",
-        "transform",
-        "transform-box",
-        "transform-origin",
-        "transform-style",
-        "transition",
-        "transition-behavior",
-        "transition-delay",
-        "transition-duration",
-        "transition-property",
-        "transition-timing-function",
-        "translate",
-        "unicode-bidi",
-        "user-modify",
-        "user-select",
-        "vector-effect",
-        "vertical-align",
-        "view-timeline",
-        "view-timeline-axis",
-        "view-timeline-inset",
-        "view-timeline-name",
-        "view-transition-name",
-        "visibility",
-        "voice-balance",
-        "voice-duration",
-        "voice-family",
-        "voice-pitch",
-        "voice-range",
-        "voice-rate",
-        "voice-stress",
-        "voice-volume",
-        "white-space",
-        "white-space-collapse",
-        "widows",
-        "width",
-        "will-change",
-        "word-break",
-        "word-spacing",
-        "word-wrap",
-        "writing-mode",
-        "x",
-        "y",
-        "z-index",
-        "zoom",
-      ]
-        .sort()
-        .reverse(),
-      le = re.concat(oe).sort().reverse();
-    var de = "[0-9](_*[0-9])*",
-      pe = `\\.(${de})`,
-      me = "[0-9a-fA-F](_*[0-9a-fA-F])*",
-      ue = {
-        className: "number",
-        variants: [
-          {
-            begin: `(\\b(${de})((${pe})|\\.)?|(${pe}))[eE][+-]?(${de})[fFdD]?\\b`,
+        s = {
+          className: "meta",
+          begin: /#\s*[a-z]+\b/,
+          end: /$/,
+          keywords: {
+            "meta-keyword":
+              "if else elif endif define undef warning error line pragma _Pragma ifdef ifndef include",
           },
+          contains: [
+            { begin: /\\\n/, relevance: 0 },
+            e.inherit(a, { className: "meta-string" }),
+            {
+              className: "meta-string",
+              begin: /<.*?>/,
+              end: /$/,
+              illegal: "\\n",
+            },
+            e.C_LINE_COMMENT_MODE,
+            e.C_BLOCK_COMMENT_MODE,
+          ],
+        },
+        o = {
+          className: "title",
+          begin: t("[a-zA-Z_]\\w*::") + e.IDENT_RE,
+          relevance: 0,
+        },
+        c = t("[a-zA-Z_]\\w*::") + e.IDENT_RE + "\\s*\\(",
+        l = {
+          keyword:
+            "int float while private char char8_t char16_t char32_t catch import module export virtual operator sizeof dynamic_cast|10 typedef const_cast|10 const for static_cast|10 union namespace unsigned long volatile static protected bool template mutable if public friend do goto auto void enum else break extern using asm case typeid wchar_t short reinterpret_cast|10 default double register explicit signed typename try this switch continue inline delete alignas alignof constexpr consteval constinit decltype concept co_await co_return co_yield requires noexcept static_assert thread_local restrict final override atomic_bool atomic_char atomic_schar atomic_uchar atomic_short atomic_ushort atomic_int atomic_uint atomic_long atomic_ulong atomic_llong atomic_ullong new throw return and and_eq bitand bitor compl not not_eq or or_eq xor xor_eq",
+          built_in:
+            "std string wstring cin cout cerr clog stdin stdout stderr stringstream istringstream ostringstream auto_ptr deque list queue stack vector map set pair bitset multiset multimap unordered_set unordered_map unordered_multiset unordered_multimap priority_queue make_pair array shared_ptr abort terminate abs acos asin atan2 atan calloc ceil cosh cos exit exp fabs floor fmod fprintf fputs free frexp fscanf future isalnum isalpha iscntrl isdigit isgraph islower isprint ispunct isspace isupper isxdigit tolower toupper labs ldexp log10 log malloc realloc memchr memcmp memcpy memset modf pow printf putchar puts scanf sinh sin snprintf sprintf sqrt sscanf strcat strchr strcmp strcpy strcspn strlen strncat strncmp strncpy strpbrk strrchr strspn strstr tanh tan vfprintf vprintf vsprintf endl initializer_list unique_ptr _Bool complex _Complex imaginary _Imaginary",
+          literal: "true false nullptr NULL",
+        },
+        d = [r, e.C_LINE_COMMENT_MODE, e.C_BLOCK_COMMENT_MODE, i, a],
+        _ = {
+          variants: [
+            { begin: /=/, end: /;/ },
+            { begin: /\(/, end: /\)/ },
+            { beginKeywords: "new throw return else", end: /;/ },
+          ],
+          keywords: l,
+          contains: d.concat([
+            {
+              begin: /\(/,
+              end: /\)/,
+              keywords: l,
+              contains: d.concat(["self"]),
+              relevance: 0,
+            },
+          ]),
+          relevance: 0,
+        },
+        u = {
+          className: "function",
+          begin: "(" + n + "[\\*&\\s]+)+" + c,
+          returnBegin: !0,
+          end: /[{;=]/,
+          excludeEnd: !0,
+          keywords: l,
+          illegal: /[^\w\s\*&:<>]/,
+          contains: [
+            { begin: "decltype\\(auto\\)", keywords: l, relevance: 0 },
+            { begin: c, returnBegin: !0, contains: [o], relevance: 0 },
+            {
+              className: "params",
+              begin: /\(/,
+              end: /\)/,
+              keywords: l,
+              relevance: 0,
+              contains: [
+                e.C_LINE_COMMENT_MODE,
+                e.C_BLOCK_COMMENT_MODE,
+                a,
+                i,
+                r,
+                {
+                  begin: /\(/,
+                  end: /\)/,
+                  keywords: l,
+                  relevance: 0,
+                  contains: [
+                    "self",
+                    e.C_LINE_COMMENT_MODE,
+                    e.C_BLOCK_COMMENT_MODE,
+                    a,
+                    i,
+                    r,
+                  ],
+                },
+              ],
+            },
+            r,
+            e.C_LINE_COMMENT_MODE,
+            e.C_BLOCK_COMMENT_MODE,
+            s,
+          ],
+        };
+      return {
+        aliases: ["c", "cc", "h", "c++", "h++", "hpp", "hh", "hxx", "cxx"],
+        keywords: l,
+        disableAutodetect: !0,
+        illegal: "</",
+        contains: [].concat(_, u, d, [
+          s,
           {
-            begin: `\\b(${de})((${pe})[fFdD]?\\b|\\.([fFdD]\\b)?)`,
+            begin:
+              "\\b(deque|list|queue|priority_queue|pair|stack|vector|map|set|bitset|multiset|multimap|unordered_map|unordered_set|unordered_multiset|unordered_multimap|array)\\s*<",
+            end: ">",
+            keywords: l,
+            contains: ["self", r],
           },
+          { begin: e.IDENT_RE + "::", keywords: l },
           {
-            begin: `(${pe})[fFdD]?\\b`,
+            className: "class",
+            beginKeywords: "class struct",
+            end: /[{;:]/,
+            contains: [
+              { begin: /</, end: />/, contains: ["self"] },
+              e.TITLE_MODE,
+            ],
           },
-          { begin: `\\b(${de})[fFdD]\\b` },
-          {
-            begin: `\\b0[xX]((${me})\\.?|(${me})?\\.(${me}))[pP][+-]?(${de})[fFdD]?\\b`,
-          },
-          {
-            begin: "\\b(0|[1-9](_*[0-9])*)[lL]?\\b",
-          },
-          { begin: `\\b0[xX](${me})[lL]?\\b` },
-          {
-            begin: "\\b0(_*[0-7])*[lL]?\\b",
-          },
-          { begin: "\\b0[bB][01](_*[01])*[lL]?\\b" },
-        ],
-        relevance: 0,
+        ]),
+        exports: { preprocessor: s, strings: a, keywords: l },
       };
-    function be(e, n, t) {
-      return -1 === t ? "" : e.replace(n, (s) => be(e, n, t - 1));
-    }
-    const ge = "[A-Za-z$_][0-9A-Za-z$_]*",
-      ve = [
+    };
+  })()
+);
+hljs.registerLanguage(
+  "c",
+  (function () {
+    "use strict";
+    return function (e) {
+      var n = e.getLanguage("c-like").rawDefinition();
+      return (n.name = "C"), (n.aliases = ["c", "h"]), n;
+    };
+  })()
+);
+hljs.registerLanguage(
+  "coffeescript",
+  (function () {
+    "use strict";
+    const e = [
         "as",
         "in",
         "of",
@@ -2053,1637 +1372,84 @@
         "export",
         "extends",
       ],
-      _e = ["true", "false", "null", "undefined", "NaN", "Infinity"],
-      fe = [
-        "Object",
-        "Function",
-        "Boolean",
-        "Symbol",
-        "Math",
-        "Date",
-        "Number",
-        "BigInt",
-        "String",
-        "RegExp",
-        "Array",
-        "Float32Array",
-        "Float64Array",
-        "Int8Array",
-        "Uint8Array",
-        "Uint8ClampedArray",
-        "Int16Array",
-        "Int32Array",
-        "Uint16Array",
-        "Uint32Array",
-        "BigInt64Array",
-        "BigUint64Array",
-        "Set",
-        "Map",
-        "WeakSet",
-        "WeakMap",
-        "ArrayBuffer",
-        "SharedArrayBuffer",
-        "Atomics",
-        "DataView",
-        "JSON",
-        "Promise",
-        "Generator",
-        "GeneratorFunction",
-        "AsyncFunction",
-        "Reflect",
-        "Proxy",
-        "Intl",
-        "WebAssembly",
-      ],
-      he = [
-        "Error",
-        "EvalError",
-        "InternalError",
-        "RangeError",
-        "ReferenceError",
-        "SyntaxError",
-        "TypeError",
-        "URIError",
-      ],
-      Ee = [
-        "setInterval",
-        "setTimeout",
-        "clearInterval",
-        "clearTimeout",
-        "require",
-        "exports",
-        "eval",
-        "isFinite",
-        "isNaN",
-        "parseFloat",
-        "parseInt",
-        "decodeURI",
-        "decodeURIComponent",
-        "encodeURI",
-        "encodeURIComponent",
-        "escape",
-        "unescape",
-      ],
-      we = [
-        "arguments",
-        "this",
-        "super",
-        "console",
-        "window",
-        "document",
-        "localStorage",
-        "sessionStorage",
-        "module",
-        "global",
-      ],
-      ye = [].concat(Ee, fe, he);
-    function Ne(e) {
-      const n = e.regex,
-        t = ge,
-        s = {
-          begin: /<[A-Za-z0-9\\._:-]+/,
-          end: /\/[A-Za-z0-9\\._:-]+>|\/>/,
-          isTrulyOpeningTag: (e, n) => {
-            const t = e[0].length + e.index,
-              s = e.input[t];
-            if ("<" === s || "," === s) return void n.ignoreMatch();
-            let a;
-            ">" === s &&
-              (((e, { after: n }) => {
-                const t = "</" + e[0].slice(1);
-                return -1 !== e.input.indexOf(t, n);
-              })(e, { after: t }) ||
-                n.ignoreMatch());
-            const i = e.input.substring(t);
-            ((a = i.match(/^\s*=/)) ||
-              ((a = i.match(/^\s+extends\s+/)) && 0 === a.index)) &&
-              n.ignoreMatch();
-          },
-        },
-        a = {
-          $pattern: ge,
-          keyword: ve,
-          literal: _e,
-          built_in: ye,
-          "variable.language": we,
-        },
-        i = "[0-9](_?[0-9])*",
-        r = `\\.(${i})`,
-        o = "0|[1-9](_?[0-9])*|0[0-7]*[89][0-9]*",
-        c = {
-          className: "number",
-          variants: [
-            {
-              begin: `(\\b(${o})((${r})|\\.)?|(${r}))[eE][+-]?(${i})\\b`,
-            },
-            {
-              begin: `\\b(${o})\\b((${r})\\b|\\.)?|(${r})\\b`,
-            },
-            {
-              begin: "\\b(0|[1-9](_?[0-9])*)n\\b",
-            },
-            {
-              begin: "\\b0[xX][0-9a-fA-F](_?[0-9a-fA-F])*n?\\b",
-            },
-            {
-              begin: "\\b0[bB][0-1](_?[0-1])*n?\\b",
-            },
-            { begin: "\\b0[oO][0-7](_?[0-7])*n?\\b" },
-            {
-              begin: "\\b0[0-7]+n?\\b",
-            },
-          ],
-          relevance: 0,
-        },
-        l = {
-          className: "subst",
-          begin: "\\$\\{",
-          end: "\\}",
-          keywords: a,
-          contains: [],
-        },
-        d = {
-          begin: ".?html`",
-          end: "",
-          starts: {
-            end: "`",
-            returnEnd: !1,
-            contains: [e.BACKSLASH_ESCAPE, l],
-            subLanguage: "xml",
-          },
-        },
-        p = {
-          begin: ".?css`",
-          end: "",
-          starts: {
-            end: "`",
-            returnEnd: !1,
-            contains: [e.BACKSLASH_ESCAPE, l],
-            subLanguage: "css",
-          },
-        },
-        m = {
-          begin: ".?gql`",
-          end: "",
-          starts: {
-            end: "`",
-            returnEnd: !1,
-            contains: [e.BACKSLASH_ESCAPE, l],
-            subLanguage: "graphql",
-          },
-        },
-        u = {
-          className: "string",
-          begin: "`",
-          end: "`",
-          contains: [e.BACKSLASH_ESCAPE, l],
-        },
-        b = {
-          className: "comment",
-          variants: [
-            e.COMMENT(/\/\*\*(?!\/)/, "\\*/", {
-              relevance: 0,
-              contains: [
-                {
-                  begin: "(?=@[A-Za-z]+)",
-                  relevance: 0,
-                  contains: [
-                    { className: "doctag", begin: "@[A-Za-z]+" },
-                    {
-                      className: "type",
-                      begin: "\\{",
-                      end: "\\}",
-                      excludeEnd: !0,
-                      excludeBegin: !0,
-                      relevance: 0,
-                    },
-                    {
-                      className: "variable",
-                      begin: t + "(?=\\s*(-)|$)",
-                      endsParent: !0,
-                      relevance: 0,
-                    },
-                    { begin: /(?=[^\n])\s/, relevance: 0 },
-                  ],
-                },
-              ],
-            }),
-            e.C_BLOCK_COMMENT_MODE,
-            e.C_LINE_COMMENT_MODE,
-          ],
-        },
-        g = [
-          e.APOS_STRING_MODE,
-          e.QUOTE_STRING_MODE,
-          d,
-          p,
-          m,
-          u,
-          { match: /\$\d+/ },
-          c,
-        ];
-      l.contains = g.concat({
-        begin: /\{/,
-        end: /\}/,
-        keywords: a,
-        contains: ["self"].concat(g),
-      });
-      const v = [].concat(b, l.contains),
-        _ = v.concat([
-          {
-            begin: /(\s*)\(/,
-            end: /\)/,
-            keywords: a,
-            contains: ["self"].concat(v),
-          },
-        ]),
-        f = {
-          className: "params",
-          begin: /(\s*)\(/,
-          end: /\)/,
-          excludeBegin: !0,
-          excludeEnd: !0,
-          keywords: a,
-          contains: _,
-        },
-        h = {
-          variants: [
-            {
-              match: [
-                /class/,
-                /\s+/,
-                t,
-                /\s+/,
-                /extends/,
-                /\s+/,
-                n.concat(t, "(", n.concat(/\./, t), ")*"),
-              ],
-              scope: {
-                1: "keyword",
-                3: "title.class",
-                5: "keyword",
-                7: "title.class.inherited",
-              },
-            },
-            {
-              match: [/class/, /\s+/, t],
-              scope: { 1: "keyword", 3: "title.class" },
-            },
-          ],
-        },
-        E = {
-          relevance: 0,
-          match: n.either(
-            /\bJSON/,
-            /\b[A-Z][a-z]+([A-Z][a-z]*|\d)*/,
-            /\b[A-Z]{2,}([A-Z][a-z]+|\d)+([A-Z][a-z]*)*/,
-            /\b[A-Z]{2,}[a-z]+([A-Z][a-z]+|\d)*([A-Z][a-z]*)*/
-          ),
-          className: "title.class",
-          keywords: { _: [...fe, ...he] },
-        },
-        w = {
-          variants: [
-            {
-              match: [/function/, /\s+/, t, /(?=\s*\()/],
-            },
-            { match: [/function/, /\s*(?=\()/] },
-          ],
-          className: { 1: "keyword", 3: "title.function" },
-          label: "func.def",
-          contains: [f],
-          illegal: /%/,
-        },
-        y = {
-          match: n.concat(
-            /\b/,
-            ((N = [...Ee, "super", "import"].map((e) => e + "\\s*\\(")),
-            n.concat("(?!", N.join("|"), ")")),
-            t,
-            n.lookahead(/\s*\(/)
-          ),
-          className: "title.function",
-          relevance: 0,
-        };
-      var N;
-      const x = {
-          begin: n.concat(/\./, n.lookahead(n.concat(t, /(?![0-9A-Za-z$_(])/))),
-          end: t,
-          excludeBegin: !0,
-          keywords: "prototype",
-          className: "property",
-          relevance: 0,
-        },
-        k = {
-          match: [/get|set/, /\s+/, t, /(?=\()/],
-          className: { 1: "keyword", 3: "title.function" },
-          contains: [{ begin: /\(\)/ }, f],
-        },
-        O =
-          "(\\([^()]*(\\([^()]*(\\([^()]*\\)[^()]*)*\\)[^()]*)*\\)|" +
-          e.UNDERSCORE_IDENT_RE +
-          ")\\s*=>",
-        M = {
-          match: [
-            /const|var|let/,
-            /\s+/,
-            t,
-            /\s*/,
-            /=\s*/,
-            /(async\s*)?/,
-            n.lookahead(O),
-          ],
-          keywords: "async",
-          className: { 1: "keyword", 3: "title.function" },
-          contains: [f],
-        };
-      return {
-        name: "JavaScript",
-        aliases: ["js", "jsx", "mjs", "cjs"],
-        keywords: a,
-        exports: {
-          PARAMS_CONTAINS: _,
-          CLASS_REFERENCE: E,
-        },
-        illegal: /#(?![$_A-z])/,
-        contains: [
-          e.SHEBANG({ label: "shebang", binary: "node", relevance: 5 }),
-          {
-            label: "use_strict",
-            className: "meta",
-            relevance: 10,
-            begin: /^\s*['"]use (strict|asm)['"]/,
-          },
-          e.APOS_STRING_MODE,
-          e.QUOTE_STRING_MODE,
-          d,
-          p,
-          m,
-          u,
-          b,
-          { match: /\$\d+/ },
-          c,
-          E,
-          {
-            className: "attr",
-            begin: t + n.lookahead(":"),
-            relevance: 0,
-          },
-          M,
-          {
-            begin: "(" + e.RE_STARTERS_RE + "|\\b(case|return|throw)\\b)\\s*",
-            keywords: "return throw case",
-            relevance: 0,
-            contains: [
-              b,
-              e.REGEXP_MODE,
-              {
-                className: "function",
-                begin: O,
-                returnBegin: !0,
-                end: "\\s*=>",
-                contains: [
-                  {
-                    className: "params",
-                    variants: [
-                      { begin: e.UNDERSCORE_IDENT_RE, relevance: 0 },
-                      {
-                        className: null,
-                        begin: /\(\s*\)/,
-                        skip: !0,
-                      },
-                      {
-                        begin: /(\s*)\(/,
-                        end: /\)/,
-                        excludeBegin: !0,
-                        excludeEnd: !0,
-                        keywords: a,
-                        contains: _,
-                      },
-                    ],
-                  },
-                ],
-              },
-              { begin: /,/, relevance: 0 },
-              { match: /\s+/, relevance: 0 },
-              {
-                variants: [
-                  { begin: "<>", end: "</>" },
-                  {
-                    match: /<[A-Za-z0-9\\._:-]+\s*\/>/,
-                  },
-                  { begin: s.begin, "on:begin": s.isTrulyOpeningTag, end: s.end },
-                ],
-                subLanguage: "xml",
-                contains: [
-                  {
-                    begin: s.begin,
-                    end: s.end,
-                    skip: !0,
-                    contains: ["self"],
-                  },
-                ],
-              },
-            ],
-          },
-          w,
-          {
-            beginKeywords: "while if switch catch for",
-          },
-          {
-            begin:
-              "\\b(?!function)" +
-              e.UNDERSCORE_IDENT_RE +
-              "\\([^()]*(\\([^()]*(\\([^()]*\\)[^()]*)*\\)[^()]*)*\\)\\s*\\{",
-            returnBegin: !0,
-            label: "func.def",
-            contains: [
-              f,
-              e.inherit(e.TITLE_MODE, { begin: t, className: "title.function" }),
-            ],
-          },
-          { match: /\.\.\./, relevance: 0 },
-          x,
-          { match: "\\$" + t, relevance: 0 },
-          {
-            match: [/\bconstructor(?=\s*\()/],
-            className: { 1: "title.function" },
-            contains: [f],
-          },
-          y,
-          {
-            relevance: 0,
-            match: /\b[A-Z][A-Z_0-9]+\b/,
-            className: "variable.constant",
-          },
-          h,
-          k,
-          { match: /\$[(.]/ },
+      n = ["true", "false", "null", "undefined", "NaN", "Infinity"],
+      a = [].concat(
+        [
+          "setInterval",
+          "setTimeout",
+          "clearInterval",
+          "clearTimeout",
+          "require",
+          "exports",
+          "eval",
+          "isFinite",
+          "isNaN",
+          "parseFloat",
+          "parseInt",
+          "decodeURI",
+          "decodeURIComponent",
+          "encodeURI",
+          "encodeURIComponent",
+          "escape",
+          "unescape",
         ],
-      };
-    }
-    const xe = (e) => u(/\b/, e, /\w$/.test(e) ? /\b/ : /\B/),
-      ke = ["Protocol", "Type"].map(xe),
-      Oe = ["init", "self"].map(xe),
-      Me = ["Any", "Self"],
-      Ae = [
-        "actor",
-        "any",
-        "associatedtype",
-        "async",
-        "await",
-        /as\?/,
-        /as!/,
-        "as",
-        "borrowing",
-        "break",
-        "case",
-        "catch",
-        "class",
-        "consume",
-        "consuming",
-        "continue",
-        "convenience",
-        "copy",
-        "default",
-        "defer",
-        "deinit",
-        "didSet",
-        "distributed",
-        "do",
-        "dynamic",
-        "each",
-        "else",
-        "enum",
-        "extension",
-        "fallthrough",
-        /fileprivate\(set\)/,
-        "fileprivate",
-        "final",
-        "for",
-        "func",
-        "get",
-        "guard",
-        "if",
-        "import",
-        "indirect",
-        "infix",
-        /init\?/,
-        /init!/,
-        "inout",
-        /internal\(set\)/,
-        "internal",
-        "in",
-        "is",
-        "isolated",
-        "nonisolated",
-        "lazy",
-        "let",
-        "macro",
-        "mutating",
-        "nonmutating",
-        /open\(set\)/,
-        "open",
-        "operator",
-        "optional",
-        "override",
-        "package",
-        "postfix",
-        "precedencegroup",
-        "prefix",
-        /private\(set\)/,
-        "private",
-        "protocol",
-        /public\(set\)/,
-        "public",
-        "repeat",
-        "required",
-        "rethrows",
-        "return",
-        "set",
-        "some",
-        "static",
-        "struct",
-        "subscript",
-        "super",
-        "switch",
-        "throws",
-        "throw",
-        /try\?/,
-        /try!/,
-        "try",
-        "typealias",
-        /unowned\(safe\)/,
-        /unowned\(unsafe\)/,
-        "unowned",
-        "var",
-        "weak",
-        "where",
-        "while",
-        "willSet",
-      ],
-      Se = ["false", "nil", "true"],
-      Ce = [
-        "assignment",
-        "associativity",
-        "higherThan",
-        "left",
-        "lowerThan",
-        "none",
-        "right",
-      ],
-      Te = [
-        "#colorLiteral",
-        "#column",
-        "#dsohandle",
-        "#else",
-        "#elseif",
-        "#endif",
-        "#error",
-        "#file",
-        "#fileID",
-        "#fileLiteral",
-        "#filePath",
-        "#function",
-        "#if",
-        "#imageLiteral",
-        "#keyPath",
-        "#line",
-        "#selector",
-        "#sourceLocation",
-        "#warning",
-      ],
-      qe = [
-        "abs",
-        "all",
-        "any",
-        "assert",
-        "assertionFailure",
-        "debugPrint",
-        "dump",
-        "fatalError",
-        "getVaList",
-        "isKnownUniquelyReferenced",
-        "max",
-        "min",
-        "numericCast",
-        "pointwiseMax",
-        "pointwiseMin",
-        "precondition",
-        "preconditionFailure",
-        "print",
-        "readLine",
-        "repeatElement",
-        "sequence",
-        "stride",
-        "swap",
-        "swift_unboxFromSwiftValueWithType",
-        "transcode",
-        "type",
-        "unsafeBitCast",
-        "unsafeDowncast",
-        "withExtendedLifetime",
-        "withUnsafeMutablePointer",
-        "withUnsafePointer",
-        "withVaList",
-        "withoutActuallyEscaping",
-        "zip",
-      ],
-      De = b(
-        /[/=\-+!*%<>&|^~?]/,
-        /[\u00A1-\u00A7]/,
-        /[\u00A9\u00AB]/,
-        /[\u00AC\u00AE]/,
-        /[\u00B0\u00B1]/,
-        /[\u00B6\u00BB\u00BF\u00D7\u00F7]/,
-        /[\u2016-\u2017]/,
-        /[\u2020-\u2027]/,
-        /[\u2030-\u203E]/,
-        /[\u2041-\u2053]/,
-        /[\u2055-\u205E]/,
-        /[\u2190-\u23FF]/,
-        /[\u2500-\u2775]/,
-        /[\u2794-\u2BFF]/,
-        /[\u2E00-\u2E7F]/,
-        /[\u3001-\u3003]/,
-        /[\u3008-\u3020]/,
-        /[\u3030]/
-      ),
-      Re = b(
-        De,
-        /[\u0300-\u036F]/,
-        /[\u1DC0-\u1DFF]/,
-        /[\u20D0-\u20FF]/,
-        /[\uFE00-\uFE0F]/,
-        /[\uFE20-\uFE2F]/
-      ),
-      Ie = u(De, Re, "*"),
-      Le = b(
-        /[a-zA-Z_]/,
-        /[\u00A8\u00AA\u00AD\u00AF\u00B2-\u00B5\u00B7-\u00BA]/,
-        /[\u00BC-\u00BE\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u00FF]/,
-        /[\u0100-\u02FF\u0370-\u167F\u1681-\u180D\u180F-\u1DBF]/,
-        /[\u1E00-\u1FFF]/,
-        /[\u200B-\u200D\u202A-\u202E\u203F-\u2040\u2054\u2060-\u206F]/,
-        /[\u2070-\u20CF\u2100-\u218F\u2460-\u24FF\u2776-\u2793]/,
-        /[\u2C00-\u2DFF\u2E80-\u2FFF]/,
-        /[\u3004-\u3007\u3021-\u302F\u3031-\u303F\u3040-\uD7FF]/,
-        /[\uF900-\uFD3D\uFD40-\uFDCF\uFDF0-\uFE1F\uFE30-\uFE44]/,
-        /[\uFE47-\uFEFE\uFF00-\uFFFD]/
-      ),
-      Be = b(Le, /\d/, /[\u0300-\u036F\u1DC0-\u1DFF\u20D0-\u20FF\uFE20-\uFE2F]/),
-      ze = u(Le, Be, "*"),
-      Fe = u(/[A-Z]/, Be, "*"),
-      $e = [
-        "attached",
-        "autoclosure",
-        u(/convention\(/, b("swift", "block", "c"), /\)/),
-        "discardableResult",
-        "dynamicCallable",
-        "dynamicMemberLookup",
-        "escaping",
-        "freestanding",
-        "frozen",
-        "GKInspectable",
-        "IBAction",
-        "IBDesignable",
-        "IBInspectable",
-        "IBOutlet",
-        "IBSegueAction",
-        "inlinable",
-        "main",
-        "nonobjc",
-        "NSApplicationMain",
-        "NSCopying",
-        "NSManaged",
-        u(/objc\(/, ze, /\)/),
-        "objc",
-        "objcMembers",
-        "propertyWrapper",
-        "requires_stored_property_inits",
-        "resultBuilder",
-        "Sendable",
-        "testable",
-        "UIApplicationMain",
-        "unchecked",
-        "unknown",
-        "usableFromInline",
-        "warn_unqualified_access",
-      ],
-      Ue = [
-        "iOS",
-        "iOSApplicationExtension",
-        "macOS",
-        "macOSApplicationExtension",
-        "macCatalyst",
-        "macCatalystApplicationExtension",
-        "watchOS",
-        "watchOSApplicationExtension",
-        "tvOS",
-        "tvOSApplicationExtension",
-        "swift",
-      ];
-    var Pe = Object.freeze({
-      __proto__: null,
-      grmr_apache: (e) => {
-        const n = {
-          className: "number",
-          begin: /\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}(:\d{1,5})?/,
-        };
-        return {
-          name: "Apache config",
-          aliases: ["apacheconf"],
-          case_insensitive: !0,
-          contains: [
-            e.HASH_COMMENT_MODE,
-            {
-              className: "section",
-              begin: /<\/?/,
-              end: />/,
-              contains: [
-                n,
-                { className: "number", begin: /:\d{1,5}/ },
-                e.inherit(e.QUOTE_STRING_MODE, { relevance: 0 }),
-              ],
-            },
-            {
-              className: "attribute",
-              begin: /\w+/,
-              relevance: 0,
-              keywords: {
-                _: [
-                  "order",
-                  "deny",
-                  "allow",
-                  "setenv",
-                  "rewriterule",
-                  "rewriteengine",
-                  "rewritecond",
-                  "documentroot",
-                  "sethandler",
-                  "errordocument",
-                  "loadmodule",
-                  "options",
-                  "header",
-                  "listen",
-                  "serverroot",
-                  "servername",
-                ],
-              },
-              starts: {
-                end: /$/,
-                relevance: 0,
-                keywords: { literal: "on off all deny allow" },
-                contains: [
-                  { className: "meta", begin: /\s\[/, end: /\]$/ },
-                  {
-                    className: "variable",
-                    begin: /[\$%]\{/,
-                    end: /\}/,
-                    contains: ["self", { className: "number", begin: /[$%]\d+/ }],
-                  },
-                  n,
-                  { className: "number", begin: /\b\d+/ },
-                  e.QUOTE_STRING_MODE,
-                ],
-              },
-            },
-          ],
-          illegal: /\S/,
-        };
-      },
-      grmr_armasm: (e) => {
-        const n = {
-          variants: [
-            e.COMMENT("^[ \\t]*(?=#)", "$", { relevance: 0, excludeBegin: !0 }),
-            e.COMMENT("[;@]", "$", { relevance: 0 }),
-            e.C_LINE_COMMENT_MODE,
-            e.C_BLOCK_COMMENT_MODE,
-          ],
-        };
-        return {
-          name: "ARM Assembly",
-          case_insensitive: !0,
-          aliases: ["arm"],
-          keywords: {
-            $pattern: "\\.?" + e.IDENT_RE,
-            meta: ".2byte .4byte .align .ascii .asciz .balign .byte .code .data .else .end .endif .endm .endr .equ .err .exitm .extern .global .hword .if .ifdef .ifndef .include .irp .long .macro .rept .req .section .set .skip .space .text .word .arm .thumb .code16 .code32 .force_thumb .thumb_func .ltorg ALIAS ALIGN ARM AREA ASSERT ATTR CN CODE CODE16 CODE32 COMMON CP DATA DCB DCD DCDU DCDO DCFD DCFDU DCI DCQ DCQU DCW DCWU DN ELIF ELSE END ENDFUNC ENDIF ENDP ENTRY EQU EXPORT EXPORTAS EXTERN FIELD FILL FUNCTION GBLA GBLL GBLS GET GLOBAL IF IMPORT INCBIN INCLUDE INFO KEEP LCLA LCLL LCLS LTORG MACRO MAP MEND MEXIT NOFP OPT PRESERVE8 PROC QN READONLY RELOC REQUIRE REQUIRE8 RLIST FN ROUT SETA SETL SETS SN SPACE SUBT THUMB THUMBX TTL WHILE WEND ",
-            built_in:
-              "r0 r1 r2 r3 r4 r5 r6 r7 r8 r9 r10 r11 r12 r13 r14 r15 w0 w1 w2 w3 w4 w5 w6 w7 w8 w9 w10 w11 w12 w13 w14 w15 w16 w17 w18 w19 w20 w21 w22 w23 w24 w25 w26 w27 w28 w29 w30 x0 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27 x28 x29 x30 pc lr sp ip sl sb fp a1 a2 a3 a4 v1 v2 v3 v4 v5 v6 v7 v8 f0 f1 f2 f3 f4 f5 f6 f7 p0 p1 p2 p3 p4 p5 p6 p7 p8 p9 p10 p11 p12 p13 p14 p15 c0 c1 c2 c3 c4 c5 c6 c7 c8 c9 c10 c11 c12 c13 c14 c15 q0 q1 q2 q3 q4 q5 q6 q7 q8 q9 q10 q11 q12 q13 q14 q15 cpsr_c cpsr_x cpsr_s cpsr_f cpsr_cx cpsr_cxs cpsr_xs cpsr_xsf cpsr_sf cpsr_cxsf spsr_c spsr_x spsr_s spsr_f spsr_cx spsr_cxs spsr_xs spsr_xsf spsr_sf spsr_cxsf s0 s1 s2 s3 s4 s5 s6 s7 s8 s9 s10 s11 s12 s13 s14 s15 s16 s17 s18 s19 s20 s21 s22 s23 s24 s25 s26 s27 s28 s29 s30 s31 d0 d1 d2 d3 d4 d5 d6 d7 d8 d9 d10 d11 d12 d13 d14 d15 d16 d17 d18 d19 d20 d21 d22 d23 d24 d25 d26 d27 d28 d29 d30 d31 {PC} {VAR} {TRUE} {FALSE} {OPT} {CONFIG} {ENDIAN} {CODESIZE} {CPU} {FPU} {ARCHITECTURE} {PCSTOREOFFSET} {ARMASM_VERSION} {INTER} {ROPI} {RWPI} {SWST} {NOSWST} . @",
-          },
-          contains: [
-            {
-              className: "keyword",
-              begin:
-                "\\b(adc|(qd?|sh?|u[qh]?)?add(8|16)?|usada?8|(q|sh?|u[qh]?)?(as|sa)x|and|adrl?|sbc|rs[bc]|asr|b[lx]?|blx|bxj|cbn?z|tb[bh]|bic|bfc|bfi|[su]bfx|bkpt|cdp2?|clz|clrex|cmp|cmn|cpsi[ed]|cps|setend|dbg|dmb|dsb|eor|isb|it[te]{0,3}|lsl|lsr|ror|rrx|ldm(([id][ab])|f[ds])?|ldr((s|ex)?[bhd])?|movt?|mvn|mra|mar|mul|[us]mull|smul[bwt][bt]|smu[as]d|smmul|smmla|mla|umlaal|smlal?([wbt][bt]|d)|mls|smlsl?[ds]|smc|svc|sev|mia([bt]{2}|ph)?|mrr?c2?|mcrr2?|mrs|msr|orr|orn|pkh(tb|bt)|rbit|rev(16|sh)?|sel|[su]sat(16)?|nop|pop|push|rfe([id][ab])?|stm([id][ab])?|str(ex)?[bhd]?|(qd?)?sub|(sh?|q|u[qh]?)?sub(8|16)|[su]xt(a?h|a?b(16)?)|srs([id][ab])?|swpb?|swi|smi|tst|teq|wfe|wfi|yield)(eq|ne|cs|cc|mi|pl|vs|vc|hi|ls|ge|lt|gt|le|al|hs|lo)?[sptrx]?(?=\\s)",
-            },
-            n,
-            e.QUOTE_STRING_MODE,
-            { className: "string", begin: "'", end: "[^\\\\]'", relevance: 0 },
-            {
-              className: "title",
-              begin: "\\|",
-              end: "\\|",
-              illegal: "\\n",
-              relevance: 0,
-            },
-            {
-              className: "number",
-              variants: [
-                { begin: "[#$=]?0x[0-9a-f]+" },
-                { begin: "[#$=]?0b[01]+" },
-                { begin: "[#$=]\\d+" },
-                { begin: "\\b\\d+" },
-              ],
-              relevance: 0,
-            },
-            {
-              className: "symbol",
-              variants: [
-                { begin: "^[ \\t]*[a-z_\\.\\$][a-z0-9_\\.\\$]+:" },
-                {
-                  begin: "^[a-z_\\.\\$][a-z0-9_\\.\\$]+",
-                },
-                { begin: "[=#]\\w+" },
-              ],
-              relevance: 0,
-            },
-          ],
-        };
-      },
-      grmr_bash: (e) => {
-        const n = e.regex,
-          t = {},
-          s = {
-            begin: /\$\{/,
-            end: /\}/,
-            contains: [
-              "self",
-              {
-                begin: /:-/,
-                contains: [t],
-              },
-            ],
-          };
-        Object.assign(t, {
-          className: "variable",
-          variants: [
-            {
-              begin: n.concat(/\$[\w\d#@][\w\d_]*/, "(?![\\w\\d])(?![$])"),
-            },
-            s,
-          ],
-        });
-        const a = {
-            className: "subst",
-            begin: /\$\(/,
-            end: /\)/,
-            contains: [e.BACKSLASH_ESCAPE],
-          },
-          i = e.inherit(e.COMMENT(), {
-            match: [/(^|\s)/, /#.*$/],
-            scope: { 2: "comment" },
-          }),
-          r = {
-            begin: /<<-?\s*(?=\w+)/,
-            starts: {
-              contains: [
-                e.END_SAME_AS_BEGIN({
-                  begin: /(\w+)/,
-                  end: /(\w+)/,
-                  className: "string",
-                }),
-              ],
-            },
-          },
-          o = {
-            className: "string",
-            begin: /"/,
-            end: /"/,
-            contains: [e.BACKSLASH_ESCAPE, t, a],
-          };
-        a.contains.push(o);
-        const c = {
-            begin: /\$?\(\(/,
-            end: /\)\)/,
-            contains: [
-              { begin: /\d+#[0-9a-f]+/, className: "number" },
-              e.NUMBER_MODE,
-              t,
-            ],
-          },
-          l = e.SHEBANG({
-            binary: "(fish|bash|zsh|sh|csh|ksh|tcsh|dash|scsh)",
-            relevance: 10,
-          }),
-          d = {
-            className: "function",
-            begin: /\w[\w\d_]*\s*\(\s*\)\s*\{/,
-            returnBegin: !0,
-            contains: [e.inherit(e.TITLE_MODE, { begin: /\w[\w\d_]*/ })],
-            relevance: 0,
-          };
-        return {
-          name: "Bash",
-          aliases: ["sh", "zsh"],
-          keywords: {
-            $pattern: /\b[a-z][a-z0-9._-]+\b/,
-            keyword: [
-              "if",
-              "then",
-              "else",
-              "elif",
-              "fi",
-              "for",
-              "while",
-              "until",
-              "in",
-              "do",
-              "done",
-              "case",
-              "esac",
-              "function",
-              "select",
-            ],
-            literal: ["true", "false"],
-            built_in: [
-              "break",
-              "cd",
-              "continue",
-              "eval",
-              "exec",
-              "exit",
-              "export",
-              "getopts",
-              "hash",
-              "pwd",
-              "readonly",
-              "return",
-              "shift",
-              "test",
-              "times",
-              "trap",
-              "umask",
-              "unset",
-              "alias",
-              "bind",
-              "builtin",
-              "caller",
-              "command",
-              "declare",
-              "echo",
-              "enable",
-              "help",
-              "let",
-              "local",
-              "logout",
-              "mapfile",
-              "printf",
-              "read",
-              "readarray",
-              "source",
-              "sudo",
-              "type",
-              "typeset",
-              "ulimit",
-              "unalias",
-              "set",
-              "shopt",
-              "autoload",
-              "bg",
-              "bindkey",
-              "bye",
-              "cap",
-              "chdir",
-              "clone",
-              "comparguments",
-              "compcall",
-              "compctl",
-              "compdescribe",
-              "compfiles",
-              "compgroups",
-              "compquote",
-              "comptags",
-              "comptry",
-              "compvalues",
-              "dirs",
-              "disable",
-              "disown",
-              "echotc",
-              "echoti",
-              "emulate",
-              "fc",
-              "fg",
-              "float",
-              "functions",
-              "getcap",
-              "getln",
-              "history",
-              "integer",
-              "jobs",
-              "kill",
-              "limit",
-              "log",
-              "noglob",
-              "popd",
-              "print",
-              "pushd",
-              "pushln",
-              "rehash",
-              "sched",
-              "setcap",
-              "setopt",
-              "stat",
-              "suspend",
-              "ttyctl",
-              "unfunction",
-              "unhash",
-              "unlimit",
-              "unsetopt",
-              "vared",
-              "wait",
-              "whence",
-              "where",
-              "which",
-              "zcompile",
-              "zformat",
-              "zftp",
-              "zle",
-              "zmodload",
-              "zparseopts",
-              "zprof",
-              "zpty",
-              "zregexparse",
-              "zsocket",
-              "zstyle",
-              "ztcp",
-              "chcon",
-              "chgrp",
-              "chown",
-              "chmod",
-              "cp",
-              "dd",
-              "df",
-              "dir",
-              "dircolors",
-              "ln",
-              "ls",
-              "mkdir",
-              "mkfifo",
-              "mknod",
-              "mktemp",
-              "mv",
-              "realpath",
-              "rm",
-              "rmdir",
-              "shred",
-              "sync",
-              "touch",
-              "truncate",
-              "vdir",
-              "b2sum",
-              "base32",
-              "base64",
-              "cat",
-              "cksum",
-              "comm",
-              "csplit",
-              "cut",
-              "expand",
-              "fmt",
-              "fold",
-              "head",
-              "join",
-              "md5sum",
-              "nl",
-              "numfmt",
-              "od",
-              "paste",
-              "ptx",
-              "pr",
-              "sha1sum",
-              "sha224sum",
-              "sha256sum",
-              "sha384sum",
-              "sha512sum",
-              "shuf",
-              "sort",
-              "split",
-              "sum",
-              "tac",
-              "tail",
-              "tr",
-              "tsort",
-              "unexpand",
-              "uniq",
-              "wc",
-              "arch",
-              "basename",
-              "chroot",
-              "date",
-              "dirname",
-              "du",
-              "echo",
-              "env",
-              "expr",
-              "factor",
-              "groups",
-              "hostid",
-              "id",
-              "link",
-              "logname",
-              "nice",
-              "nohup",
-              "nproc",
-              "pathchk",
-              "pinky",
-              "printenv",
-              "printf",
-              "pwd",
-              "readlink",
-              "runcon",
-              "seq",
-              "sleep",
-              "stat",
-              "stdbuf",
-              "stty",
-              "tee",
-              "test",
-              "timeout",
-              "tty",
-              "uname",
-              "unlink",
-              "uptime",
-              "users",
-              "who",
-              "whoami",
-              "yes",
-            ],
-          },
-          contains: [
-            l,
-            e.SHEBANG(),
-            d,
-            c,
-            i,
-            r,
-            { match: /(\/[a-z._-]+)+/ },
-            o,
-            { match: /\\"/ },
-            {
-              className: "string",
-              begin: /'/,
-              end: /'/,
-            },
-            { match: /\\'/ },
-            t,
-          ],
-        };
-      },
-      grmr_c: (e) => {
-        const n = e.regex,
-          t = e.COMMENT("//", "$", { contains: [{ begin: /\\\n/ }] }),
-          s = "decltype\\(auto\\)",
-          a = "[a-zA-Z_]\\w*::",
-          i =
-            "(" +
-            s +
-            "|" +
-            n.optional(a) +
-            "[a-zA-Z_]\\w*" +
-            n.optional("<[^<>]+>") +
-            ")",
-          r = {
-            className: "type",
-            variants: [
-              { begin: "\\b[a-z\\d_]*_t\\b" },
-              {
-                match: /\batomic_[a-z]{3,6}\b/,
-              },
-            ],
-          },
-          o = {
-            className: "string",
-            variants: [
-              {
-                begin: '(u8?|U|L)?"',
-                end: '"',
-                illegal: "\\n",
-                contains: [e.BACKSLASH_ESCAPE],
-              },
-              {
-                begin:
-                  "(u8?|U|L)?'(\\\\(x[0-9A-Fa-f]{2}|u[0-9A-Fa-f]{4,8}|[0-7]{3}|\\S)|.)",
-                end: "'",
-                illegal: ".",
-              },
-              e.END_SAME_AS_BEGIN({
-                begin: /(?:u8?|U|L)?R"([^()\\ ]{0,16})\(/,
-                end: /\)([^()\\ ]{0,16})"/,
-              }),
-            ],
-          },
-          c = {
-            className: "number",
-            variants: [
-              { begin: "\\b(0b[01']+)" },
-              {
-                begin:
-                  "(-?)\\b([\\d']+(\\.[\\d']*)?|\\.[\\d']+)((ll|LL|l|L)(u|U)?|(u|U)(ll|LL|l|L)?|f|F|b|B)",
-              },
-              {
-                begin:
-                  "(-?)(\\b0[xX][a-fA-F0-9']+|(\\b[\\d']+(\\.[\\d']*)?|\\.[\\d']+)([eE][-+]?[\\d']+)?)",
-              },
-            ],
-            relevance: 0,
-          },
-          l = {
-            className: "meta",
-            begin: /#\s*[a-z]+\b/,
-            end: /$/,
-            keywords: {
-              keyword:
-                "if else elif endif define undef warning error line pragma _Pragma ifdef ifndef elifdef elifndef include",
-            },
-            contains: [
-              { begin: /\\\n/, relevance: 0 },
-              e.inherit(o, { className: "string" }),
-              {
-                className: "string",
-                begin: /<.*?>/,
-              },
-              t,
-              e.C_BLOCK_COMMENT_MODE,
-            ],
-          },
-          d = {
-            className: "title",
-            begin: n.optional(a) + e.IDENT_RE,
-            relevance: 0,
-          },
-          p = n.optional(a) + e.IDENT_RE + "\\s*\\(",
-          m = {
-            keyword: [
-              "asm",
-              "auto",
-              "break",
-              "case",
-              "continue",
-              "default",
-              "do",
-              "else",
-              "enum",
-              "extern",
-              "for",
-              "fortran",
-              "goto",
-              "if",
-              "inline",
-              "register",
-              "restrict",
-              "return",
-              "sizeof",
-              "typeof",
-              "typeof_unqual",
-              "struct",
-              "switch",
-              "typedef",
-              "union",
-              "volatile",
-              "while",
-              "_Alignas",
-              "_Alignof",
-              "_Atomic",
-              "_Generic",
-              "_Noreturn",
-              "_Static_assert",
-              "_Thread_local",
-              "alignas",
-              "alignof",
-              "noreturn",
-              "static_assert",
-              "thread_local",
-              "_Pragma",
-            ],
-            type: [
-              "float",
-              "double",
-              "signed",
-              "unsigned",
-              "int",
-              "short",
-              "long",
-              "char",
-              "void",
-              "_Bool",
-              "_BitInt",
-              "_Complex",
-              "_Imaginary",
-              "_Decimal32",
-              "_Decimal64",
-              "_Decimal96",
-              "_Decimal128",
-              "_Decimal64x",
-              "_Decimal128x",
-              "_Float16",
-              "_Float32",
-              "_Float64",
-              "_Float128",
-              "_Float32x",
-              "_Float64x",
-              "_Float128x",
-              "const",
-              "static",
-              "constexpr",
-              "complex",
-              "bool",
-              "imaginary",
-            ],
-            literal: "true false NULL",
-            built_in:
-              "std string wstring cin cout cerr clog stdin stdout stderr stringstream istringstream ostringstream auto_ptr deque list queue stack vector map set pair bitset multiset multimap unordered_set unordered_map unordered_multiset unordered_multimap priority_queue make_pair array shared_ptr abort terminate abs acos asin atan2 atan calloc ceil cosh cos exit exp fabs floor fmod fprintf fputs free frexp fscanf future isalnum isalpha iscntrl isdigit isgraph islower isprint ispunct isspace isupper isxdigit tolower toupper labs ldexp log10 log malloc realloc memchr memcmp memcpy memset modf pow printf putchar puts scanf sinh sin snprintf sprintf sqrt sscanf strcat strchr strcmp strcpy strcspn strlen strncat strncmp strncpy strpbrk strrchr strspn strstr tanh tan vfprintf vprintf vsprintf endl initializer_list unique_ptr",
-          },
-          u = [l, r, t, e.C_BLOCK_COMMENT_MODE, c, o],
-          b = {
-            variants: [
-              { begin: /=/, end: /;/ },
-              {
-                begin: /\(/,
-                end: /\)/,
-              },
-              { beginKeywords: "new throw return else", end: /;/ },
-            ],
-            keywords: m,
-            contains: u.concat([
-              {
-                begin: /\(/,
-                end: /\)/,
-                keywords: m,
-                contains: u.concat(["self"]),
-                relevance: 0,
-              },
-            ]),
-            relevance: 0,
-          },
-          g = {
-            begin: "(" + i + "[\\*&\\s]+)+" + p,
-            returnBegin: !0,
-            end: /[{;=]/,
-            excludeEnd: !0,
-            keywords: m,
-            illegal: /[^\w\s\*&:<>.]/,
-            contains: [
-              { begin: s, keywords: m, relevance: 0 },
-              {
-                begin: p,
-                returnBegin: !0,
-                contains: [e.inherit(d, { className: "title.function" })],
-                relevance: 0,
-              },
-              { relevance: 0, match: /,/ },
-              {
-                className: "params",
-                begin: /\(/,
-                end: /\)/,
-                keywords: m,
-                relevance: 0,
-                contains: [
-                  t,
-                  e.C_BLOCK_COMMENT_MODE,
-                  o,
-                  c,
-                  r,
-                  {
-                    begin: /\(/,
-                    end: /\)/,
-                    keywords: m,
-                    relevance: 0,
-                    contains: ["self", t, e.C_BLOCK_COMMENT_MODE, o, c, r],
-                  },
-                ],
-              },
-              r,
-              t,
-              e.C_BLOCK_COMMENT_MODE,
-              l,
-            ],
-          };
-        return {
-          name: "C",
-          aliases: ["h"],
-          keywords: m,
-          disableAutodetect: !0,
-          illegal: "</",
-          contains: [].concat(b, g, u, [
-            l,
-            {
-              begin: e.IDENT_RE + "::",
-              keywords: m,
-            },
-            {
-              className: "class",
-              beginKeywords: "enum class struct union",
-              end: /[{;:<>=]/,
-              contains: [
-                {
-                  beginKeywords: "final class struct",
-                },
-                e.TITLE_MODE,
-              ],
-            },
-          ]),
-          exports: { preprocessor: l, strings: o, keywords: m },
-        };
-      },
-      grmr_cairo: (e) => {
-        const n = e.UNDERSCORE_IDENT_RE,
-          t = [
-            "assert ",
-            "panic ",
-            "Copy",
-            "Send",
-            "Serde",
-            "Sized",
-            "Sync",
-            "Drop",
-            "Fn",
-            "FnMut",
-            "FnOnce",
-            "ToOwned",
-            "Clone",
-            "Debug",
-            "PartialEq",
-            "PartialOrd",
-            "Eq",
-            "Ord",
-            "AsRef",
-            "AsMut",
-            "Into",
-            "From",
-            "Default",
-            "Iterator",
-            "Extend",
-            "IntoIterator",
-            "DoubleEndedIterator",
-            "ExactSizeIterator",
-            "SliceConcatExt",
-            "ToString",
-            "assert!",
-            "assert_eq!",
-            "assert_ne!",
-            "assert_lt!",
-            "assert_le!",
-            "assert_gt!",
-            "assert_ge!",
-            "format!",
-            "write!",
-            "writeln!",
-            "get_dep_component!",
-            "get_dep_component_mut!",
-            "component!",
-            "consteval_int!",
-            "array!",
-            "panic!",
-            "print!",
-            "println!",
-          ],
-          s = [
-            "felt252",
-            "i8",
-            "i16",
-            "i32",
-            "i64",
-            "i128",
-            "u8",
-            "u16",
-            "u32",
-            "u64",
-            "u128",
-            "usize",
-            "bool",
-            "Box",
-            "Option",
-            "Result",
-          ];
-        return {
-          name: "Cairo",
-          aliases: ["cairo"],
-          keywords: {
-            $pattern: e.IDENT_RE + "!?",
-            type: s,
-            keyword: [
-              "as",
-              "break",
-              "const",
-              "continue",
-              "else",
-              "enum",
-              "extern",
-              "false",
-              "fn",
-              "if",
-              "impl",
-              "implicits",
-              "let",
-              "loop",
-              "match",
-              "mod",
-              "mut",
-              "nopanic",
-              "of",
-              "pub",
-              "ref",
-              "return",
-              "self",
-              "struct",
-              "super",
-              "trait",
-              "true",
-              "type",
-              "use",
-              "while",
-            ],
-            literal: ["true", "false"],
-            built_in: t,
-          },
-          illegal: "</",
-          contains: [
-            e.C_LINE_COMMENT_MODE,
-            e.COMMENT("/\\*", "\\*/", { contains: ["self"] }),
-            e.inherit(e.QUOTE_STRING_MODE, { begin: /b?"/, illegal: null }),
-            {
-              className: "string",
-              variants: [
-                { begin: /b?r(#*)"(.|\n)*?"\1(?!#)/ },
-                {
-                  begin: /b?'\\?(x\w{2}|u\w{4}|U\w{8}|.)'/,
-                },
-              ],
-            },
-            { className: "symbol", begin: /'[a-zA-Z_][a-zA-Z0-9_]*/ },
-            {
-              className: "number",
-              variants: [
-                {
-                  begin: "\\b0b([01_]+)",
-                },
-                { begin: "\\b0o([0-7_]+)" },
-                { begin: "\\b0x([A-Fa-f0-9_]+)" },
-                {
-                  begin: "\\b(\\d[\\d_]*(\\.[0-9_]+)?([eE][+-]?[0-9_]+)?)",
-                },
-              ],
-              relevance: 0,
-            },
-            {
-              begin: [/fn/, /\s+/, n],
-              className: { 1: "keyword", 3: "title.function" },
-            },
-            {
-              className: "meta",
-              begin: "#!?\\[",
-              end: "\\]",
-              contains: [
-                {
-                  className: "string",
-                  begin: /"/,
-                  end: /"/,
-                  contains: [e.BACKSLASH_ESCAPE],
-                },
-              ],
-            },
-            {
-              begin: [/let/, /\s+/, /(?:mut\s+)?/, n],
-              className: { 1: "keyword", 3: "keyword", 4: "variable" },
-            },
-            {
-              begin: [/for/, /\s+/, n, /\s+/, /in/],
-              className: { 1: "keyword", 3: "variable", 5: "keyword" },
-            },
-            {
-              begin: [/type/, /\s+/, n],
-              className: { 1: "keyword", 3: "title.class" },
-            },
-            {
-              begin: [/(?:trait|enum|struct|union|impl|for)/, /\s+/, n],
-              className: { 1: "keyword", 3: "title.class" },
-            },
-            {
-              begin: e.IDENT_RE + "::",
-              keywords: {
-                keyword: "Self",
-                built_in: t,
-                type: s,
-              },
-            },
-            { className: "punctuation", begin: "->" },
-          ],
-        };
-      },
-      grmr_coffeescript: (e) => {
-        const n = {
-          keyword: ve
+        [
+          "arguments",
+          "this",
+          "super",
+          "console",
+          "window",
+          "document",
+          "localStorage",
+          "module",
+          "global",
+        ],
+        [
+          "Intl",
+          "DataView",
+          "Number",
+          "Math",
+          "Date",
+          "String",
+          "RegExp",
+          "Object",
+          "Function",
+          "Boolean",
+          "Error",
+          "Symbol",
+          "Set",
+          "Map",
+          "WeakSet",
+          "WeakMap",
+          "Proxy",
+          "Reflect",
+          "JSON",
+          "Promise",
+          "Float64Array",
+          "Int16Array",
+          "Int32Array",
+          "Int8Array",
+          "Uint16Array",
+          "Uint32Array",
+          "Float32Array",
+          "Array",
+          "Uint8Array",
+          "Uint8ClampedArray",
+          "ArrayBuffer",
+        ],
+        [
+          "EvalError",
+          "InternalError",
+          "RangeError",
+          "ReferenceError",
+          "SyntaxError",
+          "TypeError",
+          "URIError",
+        ]
+      );
+    return function (r) {
+      var t = {
+          keyword: e
             .concat([
               "then",
               "unless",
@@ -3698,3168 +1464,3814 @@
               "not",
             ])
             .filter(
-              ((t = ["var", "const", "let", "function", "static"]),
-              (e) => !t.includes(e))
-            ),
-          literal: _e.concat(["yes", "no", "on", "off"]),
-          built_in: ye.concat(["npm", "print"]),
-        };
-        var t;
-        const s = "[A-Za-z$_][0-9A-Za-z$_]*",
-          a = { className: "subst", begin: /#\{/, end: /\}/, keywords: n },
-          i = [
-            e.BINARY_NUMBER_MODE,
-            e.inherit(e.C_NUMBER_MODE, {
-              starts: {
-                end: "(\\s*/)?",
-                relevance: 0,
-              },
-            }),
-            {
-              className: "string",
-              variants: [
-                { begin: /'''/, end: /'''/, contains: [e.BACKSLASH_ESCAPE] },
-                { begin: /'/, end: /'/, contains: [e.BACKSLASH_ESCAPE] },
-                { begin: /"""/, end: /"""/, contains: [e.BACKSLASH_ESCAPE, a] },
-                { begin: /"/, end: /"/, contains: [e.BACKSLASH_ESCAPE, a] },
-              ],
-            },
-            {
-              className: "regexp",
-              variants: [
-                { begin: "///", end: "///", contains: [a, e.HASH_COMMENT_MODE] },
-                { begin: "//[gim]{0,3}(?=\\W)", relevance: 0 },
-                { begin: /\/(?![ *]).*?(?![\\]).\/[gim]{0,3}(?=\W)/ },
-              ],
-            },
-            { begin: "@" + s },
-            {
-              subLanguage: "javascript",
-              excludeBegin: !0,
-              excludeEnd: !0,
-              variants: [
-                {
-                  begin: "```",
-                  end: "```",
-                },
-                { begin: "`", end: "`" },
-              ],
-            },
-          ];
-        a.contains = i;
-        const r = e.inherit(e.TITLE_MODE, { begin: s }),
-          o = "(\\(.*\\)\\s*)?\\B[-=]>",
-          c = {
-            className: "params",
-            begin: "\\([^\\(]",
-            returnBegin: !0,
-            contains: [
-              {
-                begin: /\(/,
-                end: /\)/,
-                keywords: n,
-                contains: ["self"].concat(i),
-              },
+              (
+                (e) => (n) =>
+                  !e.includes(n)
+              )(["var", "const", "let", "function", "static"])
+            )
+            .join(" "),
+          literal: n.concat(["yes", "no", "on", "off"]).join(" "),
+          built_in: a.concat(["npm", "print"]).join(" "),
+        },
+        i = "[A-Za-z$_][0-9A-Za-z$_]*",
+        s = { className: "subst", begin: /#\{/, end: /}/, keywords: t },
+        o = [
+          r.BINARY_NUMBER_MODE,
+          r.inherit(r.C_NUMBER_MODE, {
+            starts: { end: "(\\s*/)?", relevance: 0 },
+          }),
+          {
+            className: "string",
+            variants: [
+              { begin: /'''/, end: /'''/, contains: [r.BACKSLASH_ESCAPE] },
+              { begin: /'/, end: /'/, contains: [r.BACKSLASH_ESCAPE] },
+              { begin: /"""/, end: /"""/, contains: [r.BACKSLASH_ESCAPE, s] },
+              { begin: /"/, end: /"/, contains: [r.BACKSLASH_ESCAPE, s] },
             ],
           },
-          l = {
+          {
+            className: "regexp",
             variants: [
-              {
-                match: [/class\s+/, s, /\s+extends\s+/, s],
-              },
-              { match: [/class\s+/, s] },
+              { begin: "///", end: "///", contains: [s, r.HASH_COMMENT_MODE] },
+              { begin: "//[gim]{0,3}(?=\\W)", relevance: 0 },
+              { begin: /\/(?![ *]).*?(?![\\]).\/[gim]{0,3}(?=\W)/ },
             ],
-            scope: {
-              2: "title.class",
-              4: "title.class.inherited",
-            },
-            keywords: n,
-          };
-        return {
-          name: "CoffeeScript",
-          aliases: ["coffee", "cson", "iced"],
-          keywords: n,
-          illegal: /\/\*/,
+          },
+          { begin: "@" + i },
+          {
+            subLanguage: "javascript",
+            excludeBegin: !0,
+            excludeEnd: !0,
+            variants: [
+              { begin: "```", end: "```" },
+              { begin: "`", end: "`" },
+            ],
+          },
+        ];
+      s.contains = o;
+      var c = r.inherit(r.TITLE_MODE, { begin: i }),
+        l = {
+          className: "params",
+          begin: "\\([^\\(]",
+          returnBegin: !0,
           contains: [
-            ...i,
-            e.COMMENT("###", "###"),
-            e.HASH_COMMENT_MODE,
             {
-              className: "function",
-              begin: "^\\s*" + s + "\\s*=\\s*" + o,
-              end: "[-=]>",
-              returnBegin: !0,
-              contains: [r, c],
-            },
-            {
-              begin: /[:\(,=]\s*/,
-              relevance: 0,
-              contains: [
-                {
-                  className: "function",
-                  begin: o,
-                  end: "[-=]>",
-                  returnBegin: !0,
-                  contains: [c],
-                },
-              ],
-            },
-            l,
-            {
-              begin: s + ":",
-              end: ":",
-              returnBegin: !0,
-              returnEnd: !0,
-              relevance: 0,
+              begin: /\(/,
+              end: /\)/,
+              keywords: t,
+              contains: ["self"].concat(o),
             },
           ],
         };
-      },
-      grmr_cpp: (e) => {
-        const n = e.regex,
-          t = e.COMMENT("//", "$", { contains: [{ begin: /\\\n/ }] }),
-          s = "decltype\\(auto\\)",
-          a = "[a-zA-Z_]\\w*::",
-          i =
-            "(?!struct)(" +
-            s +
-            "|" +
-            n.optional(a) +
-            "[a-zA-Z_]\\w*" +
-            n.optional("<[^<>]+>") +
-            ")",
-          r = {
-            className: "type",
-            begin: "\\b[a-z\\d_]*_t\\b",
+      return {
+        name: "CoffeeScript",
+        aliases: ["coffee", "cson", "iced"],
+        keywords: t,
+        illegal: /\/\*/,
+        contains: o.concat([
+          r.COMMENT("###", "###"),
+          r.HASH_COMMENT_MODE,
+          {
+            className: "function",
+            begin: "^\\s*" + i + "\\s*=\\s*(\\(.*\\))?\\s*\\B[-=]>",
+            end: "[-=]>",
+            returnBegin: !0,
+            contains: [c, l],
           },
-          o = {
-            className: "string",
-            variants: [
+          {
+            begin: /[:\(,=]\s*/,
+            relevance: 0,
+            contains: [
               {
-                begin: '(u8?|U|L)?"',
-                end: '"',
-                illegal: "\\n",
-                contains: [e.BACKSLASH_ESCAPE],
+                className: "function",
+                begin: "(\\(.*\\))?\\s*\\B[-=]>",
+                end: "[-=]>",
+                returnBegin: !0,
+                contains: [l],
               },
-              {
-                begin:
-                  "(u8?|U|L)?'(\\\\(x[0-9A-Fa-f]{2}|u[0-9A-Fa-f]{4,8}|[0-7]{3}|\\S)|.)",
-                end: "'",
-                illegal: ".",
-              },
-              e.END_SAME_AS_BEGIN({
-                begin: /(?:u8?|U|L)?R"([^()\\ ]{0,16})\(/,
-                end: /\)([^()\\ ]{0,16})"/,
-              }),
             ],
           },
-          c = {
-            className: "number",
-            variants: [
+          {
+            className: "class",
+            beginKeywords: "class",
+            end: "$",
+            illegal: /[:="\[\]]/,
+            contains: [
               {
-                begin:
-                  "[+-]?(?:(?:[0-9](?:'?[0-9])*\\.(?:[0-9](?:'?[0-9])*)?|\\.[0-9](?:'?[0-9])*)(?:[Ee][+-]?[0-9](?:'?[0-9])*)?|[0-9](?:'?[0-9])*[Ee][+-]?[0-9](?:'?[0-9])*|0[Xx](?:[0-9A-Fa-f](?:'?[0-9A-Fa-f])*(?:\\.(?:[0-9A-Fa-f](?:'?[0-9A-Fa-f])*)?)?|\\.[0-9A-Fa-f](?:'?[0-9A-Fa-f])*)[Pp][+-]?[0-9](?:'?[0-9])*)(?:[Ff](?:16|32|64|128)?|(BF|bf)16|[Ll]|)",
+                beginKeywords: "extends",
+                endsWithParent: !0,
+                illegal: /[:="\[\]]/,
+                contains: [c],
               },
-              {
-                begin:
-                  "[+-]?\\b(?:0[Bb][01](?:'?[01])*|0[Xx][0-9A-Fa-f](?:'?[0-9A-Fa-f])*|0(?:'?[0-7])*|[1-9](?:'?[0-9])*)(?:[Uu](?:LL?|ll?)|[Uu][Zz]?|(?:LL?|ll?)[Uu]?|[Zz][Uu]|)",
-              },
+              c,
             ],
+          },
+          {
+            begin: i + ":",
+            end: ":",
+            returnBegin: !0,
+            returnEnd: !0,
             relevance: 0,
           },
-          l = {
-            className: "meta",
-            begin: /#\s*[a-z]+\b/,
-            end: /$/,
-            keywords: {
-              keyword:
-                "if else elif endif define undef warning error line pragma _Pragma ifdef ifndef include",
+        ]),
+      };
+    };
+  })()
+);
+hljs.registerLanguage(
+  "cpp",
+  (function () {
+    "use strict";
+    return function (e) {
+      var t = e.getLanguage("c-like").rawDefinition();
+      return (
+        (t.disableAutodetect = !1),
+        (t.name = "C++"),
+        (t.aliases = ["cc", "c++", "h++", "hpp", "hh", "hxx", "cxx"]),
+        t
+      );
+    };
+  })()
+);
+hljs.registerLanguage(
+  "csharp",
+  (function () {
+    "use strict";
+    return function (e) {
+      var n = {
+          keyword:
+            "abstract as base bool break byte case catch char checked const continue decimal default delegate do double enum event explicit extern finally fixed float for foreach goto if implicit in int interface internal is lock long object operator out override params private protected public readonly ref sbyte sealed short sizeof stackalloc static string struct switch this try typeof uint ulong unchecked unsafe ushort using virtual void volatile while add alias ascending async await by descending dynamic equals from get global group into join let nameof on orderby partial remove select set value var when where yield",
+          literal: "null false true",
+        },
+        i = e.inherit(e.TITLE_MODE, { begin: "[a-zA-Z](\\.?\\w)*" }),
+        a = {
+          className: "number",
+          variants: [
+            { begin: "\\b(0b[01']+)" },
+            {
+              begin:
+                "(-?)\\b([\\d']+(\\.[\\d']*)?|\\.[\\d']+)(u|U|l|L|ul|UL|f|F|b|B)",
             },
+            {
+              begin:
+                "(-?)(\\b0[xX][a-fA-F0-9']+|(\\b[\\d']+(\\.[\\d']*)?|\\.[\\d']+)([eE][-+]?[\\d']+)?)",
+            },
+          ],
+          relevance: 0,
+        },
+        s = {
+          className: "string",
+          begin: '@"',
+          end: '"',
+          contains: [{ begin: '""' }],
+        },
+        t = e.inherit(s, { illegal: /\n/ }),
+        l = { className: "subst", begin: "{", end: "}", keywords: n },
+        r = e.inherit(l, { illegal: /\n/ }),
+        c = {
+          className: "string",
+          begin: /\$"/,
+          end: '"',
+          illegal: /\n/,
+          contains: [{ begin: "{{" }, { begin: "}}" }, e.BACKSLASH_ESCAPE, r],
+        },
+        o = {
+          className: "string",
+          begin: /\$@"/,
+          end: '"',
+          contains: [{ begin: "{{" }, { begin: "}}" }, { begin: '""' }, l],
+        },
+        g = e.inherit(o, {
+          illegal: /\n/,
+          contains: [{ begin: "{{" }, { begin: "}}" }, { begin: '""' }, r],
+        });
+      (l.contains = [
+        o,
+        c,
+        s,
+        e.APOS_STRING_MODE,
+        e.QUOTE_STRING_MODE,
+        a,
+        e.C_BLOCK_COMMENT_MODE,
+      ]),
+        (r.contains = [
+          g,
+          c,
+          t,
+          e.APOS_STRING_MODE,
+          e.QUOTE_STRING_MODE,
+          a,
+          e.inherit(e.C_BLOCK_COMMENT_MODE, { illegal: /\n/ }),
+        ]);
+      var d = { variants: [o, c, s, e.APOS_STRING_MODE, e.QUOTE_STRING_MODE] },
+        E = {
+          begin: "<",
+          end: ">",
+          contains: [{ beginKeywords: "in out" }, i],
+        },
+        _ =
+          e.IDENT_RE +
+          "(<" +
+          e.IDENT_RE +
+          "(\\s*,\\s*" +
+          e.IDENT_RE +
+          ")*>)?(\\[\\])?",
+        b = { begin: "@" + e.IDENT_RE, relevance: 0 };
+      return {
+        name: "C#",
+        aliases: ["cs", "c#"],
+        keywords: n,
+        illegal: /::/,
+        contains: [
+          e.COMMENT("///", "$", {
+            returnBegin: !0,
             contains: [
-              { begin: /\\\n/, relevance: 0 },
-              e.inherit(o, { className: "string" }),
               {
-                className: "string",
-                begin: /<.*?>/,
+                className: "doctag",
+                variants: [
+                  { begin: "///", relevance: 0 },
+                  { begin: "\x3c!--|--\x3e" },
+                  { begin: "</?", end: ">" },
+                ],
               },
-              t,
+            ],
+          }),
+          e.C_LINE_COMMENT_MODE,
+          e.C_BLOCK_COMMENT_MODE,
+          {
+            className: "meta",
+            begin: "#",
+            end: "$",
+            keywords: {
+              "meta-keyword":
+                "if else elif endif define undef warning error line region endregion pragma checksum",
+            },
+          },
+          d,
+          a,
+          {
+            beginKeywords: "class interface",
+            end: /[{;=]/,
+            illegal: /[^\s:,]/,
+            contains: [
+              { beginKeywords: "where class" },
+              i,
+              E,
+              e.C_LINE_COMMENT_MODE,
               e.C_BLOCK_COMMENT_MODE,
             ],
           },
-          d = {
-            className: "title",
-            begin: n.optional(a) + e.IDENT_RE,
-            relevance: 0,
-          },
-          p = n.optional(a) + e.IDENT_RE + "\\s*\\(",
-          m = {
-            type: [
-              "bool",
-              "char",
-              "char16_t",
-              "char32_t",
-              "char8_t",
-              "double",
-              "float",
-              "int",
-              "long",
-              "short",
-              "void",
-              "wchar_t",
-              "unsigned",
-              "signed",
-              "const",
-              "static",
-            ],
-            keyword: [
-              "alignas",
-              "alignof",
-              "and",
-              "and_eq",
-              "asm",
-              "atomic_cancel",
-              "atomic_commit",
-              "atomic_noexcept",
-              "auto",
-              "bitand",
-              "bitor",
-              "break",
-              "case",
-              "catch",
-              "class",
-              "co_await",
-              "co_return",
-              "co_yield",
-              "compl",
-              "concept",
-              "const_cast|10",
-              "consteval",
-              "constexpr",
-              "constinit",
-              "continue",
-              "decltype",
-              "default",
-              "delete",
-              "do",
-              "dynamic_cast|10",
-              "else",
-              "enum",
-              "explicit",
-              "export",
-              "extern",
-              "false",
-              "final",
-              "for",
-              "friend",
-              "goto",
-              "if",
-              "import",
-              "inline",
-              "module",
-              "mutable",
-              "namespace",
-              "new",
-              "noexcept",
-              "not",
-              "not_eq",
-              "nullptr",
-              "operator",
-              "or",
-              "or_eq",
-              "override",
-              "private",
-              "protected",
-              "public",
-              "reflexpr",
-              "register",
-              "reinterpret_cast|10",
-              "requires",
-              "return",
-              "sizeof",
-              "static_assert",
-              "static_cast|10",
-              "struct",
-              "switch",
-              "synchronized",
-              "template",
-              "this",
-              "thread_local",
-              "throw",
-              "transaction_safe",
-              "transaction_safe_dynamic",
-              "true",
-              "try",
-              "typedef",
-              "typeid",
-              "typename",
-              "union",
-              "using",
-              "virtual",
-              "volatile",
-              "while",
-              "xor",
-              "xor_eq",
-            ],
-            literal: ["NULL", "false", "nullopt", "nullptr", "true"],
-            built_in: ["_Pragma"],
-            _type_hints: [
-              "any",
-              "auto_ptr",
-              "barrier",
-              "binary_semaphore",
-              "bitset",
-              "complex",
-              "condition_variable",
-              "condition_variable_any",
-              "counting_semaphore",
-              "deque",
-              "false_type",
-              "future",
-              "imaginary",
-              "initializer_list",
-              "istringstream",
-              "jthread",
-              "latch",
-              "lock_guard",
-              "multimap",
-              "multiset",
-              "mutex",
-              "optional",
-              "ostringstream",
-              "packaged_task",
-              "pair",
-              "promise",
-              "priority_queue",
-              "queue",
-              "recursive_mutex",
-              "recursive_timed_mutex",
-              "scoped_lock",
-              "set",
-              "shared_future",
-              "shared_lock",
-              "shared_mutex",
-              "shared_timed_mutex",
-              "shared_ptr",
-              "stack",
-              "string_view",
-              "stringstream",
-              "timed_mutex",
-              "thread",
-              "true_type",
-              "tuple",
-              "unique_lock",
-              "unique_ptr",
-              "unordered_map",
-              "unordered_multimap",
-              "unordered_multiset",
-              "unordered_set",
-              "variant",
-              "vector",
-              "weak_ptr",
-              "wstring",
-              "wstring_view",
-            ],
-          },
-          u = {
-            className: "function.dispatch",
-            relevance: 0,
-            keywords: {
-              _hint: [
-                "abort",
-                "abs",
-                "acos",
-                "apply",
-                "as_const",
-                "asin",
-                "atan",
-                "atan2",
-                "calloc",
-                "ceil",
-                "cerr",
-                "cin",
-                "clog",
-                "cos",
-                "cosh",
-                "cout",
-                "declval",
-                "endl",
-                "exchange",
-                "exit",
-                "exp",
-                "fabs",
-                "floor",
-                "fmod",
-                "forward",
-                "fprintf",
-                "fputs",
-                "free",
-                "frexp",
-                "fscanf",
-                "future",
-                "invoke",
-                "isalnum",
-                "isalpha",
-                "iscntrl",
-                "isdigit",
-                "isgraph",
-                "islower",
-                "isprint",
-                "ispunct",
-                "isspace",
-                "isupper",
-                "isxdigit",
-                "labs",
-                "launder",
-                "ldexp",
-                "log",
-                "log10",
-                "make_pair",
-                "make_shared",
-                "make_shared_for_overwrite",
-                "make_tuple",
-                "make_unique",
-                "malloc",
-                "memchr",
-                "memcmp",
-                "memcpy",
-                "memset",
-                "modf",
-                "move",
-                "pow",
-                "printf",
-                "putchar",
-                "puts",
-                "realloc",
-                "scanf",
-                "sin",
-                "sinh",
-                "snprintf",
-                "sprintf",
-                "sqrt",
-                "sscanf",
-                "std",
-                "stderr",
-                "stdin",
-                "stdout",
-                "strcat",
-                "strchr",
-                "strcmp",
-                "strcpy",
-                "strcspn",
-                "strlen",
-                "strncat",
-                "strncmp",
-                "strncpy",
-                "strpbrk",
-                "strrchr",
-                "strspn",
-                "strstr",
-                "swap",
-                "tan",
-                "tanh",
-                "terminate",
-                "to_underlying",
-                "tolower",
-                "toupper",
-                "vfprintf",
-                "visit",
-                "vprintf",
-                "vsprintf",
-              ],
-            },
-            begin: n.concat(
-              /\b/,
-              /(?!decltype)/,
-              /(?!if)/,
-              /(?!for)/,
-              /(?!switch)/,
-              /(?!while)/,
-              e.IDENT_RE,
-              n.lookahead(/(<[^<>]+>|)\s*\(/)
-            ),
-          },
-          b = [u, l, r, t, e.C_BLOCK_COMMENT_MODE, c, o],
-          g = {
-            variants: [
-              { begin: /=/, end: /;/ },
-              {
-                begin: /\(/,
-                end: /\)/,
-              },
-              { beginKeywords: "new throw return else", end: /;/ },
-            ],
-            keywords: m,
-            contains: b.concat([
-              {
-                begin: /\(/,
-                end: /\)/,
-                keywords: m,
-                contains: b.concat(["self"]),
-                relevance: 0,
-              },
-            ]),
-            relevance: 0,
-          },
-          v = {
-            className: "function",
-            begin: "(" + i + "[\\*&\\s]+)+" + p,
-            returnBegin: !0,
+          {
+            beginKeywords: "namespace",
             end: /[{;=]/,
+            illegal: /[^\s:]/,
+            contains: [i, e.C_LINE_COMMENT_MODE, e.C_BLOCK_COMMENT_MODE],
+          },
+          {
+            className: "meta",
+            begin: "^\\s*\\[",
+            excludeBegin: !0,
+            end: "\\]",
             excludeEnd: !0,
-            keywords: m,
-            illegal: /[^\w\s\*&:<>.]/,
+            contains: [{ className: "meta-string", begin: /"/, end: /"/ }],
+          },
+          { beginKeywords: "new return throw await else", relevance: 0 },
+          {
+            className: "function",
+            begin: "(" + _ + "\\s+)+" + e.IDENT_RE + "\\s*(\\<.+\\>)?\\s*\\(",
+            returnBegin: !0,
+            end: /\s*[{;=]/,
+            excludeEnd: !0,
+            keywords: n,
             contains: [
-              { begin: s, keywords: m, relevance: 0 },
               {
-                begin: p,
+                begin: e.IDENT_RE + "\\s*(\\<.+\\>)?\\s*\\(",
                 returnBegin: !0,
-                contains: [d],
+                contains: [e.TITLE_MODE, E],
                 relevance: 0,
               },
-              { begin: /::/, relevance: 0 },
-              {
-                begin: /:/,
-                endsWithParent: !0,
-                contains: [o, c],
-              },
-              { relevance: 0, match: /,/ },
               {
                 className: "params",
                 begin: /\(/,
                 end: /\)/,
-                keywords: m,
+                excludeBegin: !0,
+                excludeEnd: !0,
+                keywords: n,
                 relevance: 0,
+                contains: [d, a, e.C_BLOCK_COMMENT_MODE],
+              },
+              e.C_LINE_COMMENT_MODE,
+              e.C_BLOCK_COMMENT_MODE,
+            ],
+          },
+          b,
+        ],
+      };
+    };
+  })()
+);
+hljs.registerLanguage(
+  "css",
+  (function () {
+    "use strict";
+    return function (e) {
+      var n = {
+        begin: /(?:[A-Z\_\.\-]+|--[a-zA-Z0-9_-]+)\s*:/,
+        returnBegin: !0,
+        end: ";",
+        endsWithParent: !0,
+        contains: [
+          {
+            className: "attribute",
+            begin: /\S/,
+            end: ":",
+            excludeEnd: !0,
+            starts: {
+              endsWithParent: !0,
+              excludeEnd: !0,
+              contains: [
+                {
+                  begin: /[\w-]+\(/,
+                  returnBegin: !0,
+                  contains: [
+                    { className: "built_in", begin: /[\w-]+/ },
+                    {
+                      begin: /\(/,
+                      end: /\)/,
+                      contains: [
+                        e.APOS_STRING_MODE,
+                        e.QUOTE_STRING_MODE,
+                        e.CSS_NUMBER_MODE,
+                      ],
+                    },
+                  ],
+                },
+                e.CSS_NUMBER_MODE,
+                e.QUOTE_STRING_MODE,
+                e.APOS_STRING_MODE,
+                e.C_BLOCK_COMMENT_MODE,
+                { className: "number", begin: "#[0-9A-Fa-f]+" },
+                { className: "meta", begin: "!important" },
+              ],
+            },
+          },
+        ],
+      };
+      return {
+        name: "CSS",
+        case_insensitive: !0,
+        illegal: /[=\/|'\$]/,
+        contains: [
+          e.C_BLOCK_COMMENT_MODE,
+          { className: "selector-id", begin: /#[A-Za-z0-9_-]+/ },
+          { className: "selector-class", begin: /\.[A-Za-z0-9_-]+/ },
+          {
+            className: "selector-attr",
+            begin: /\[/,
+            end: /\]/,
+            illegal: "$",
+            contains: [e.APOS_STRING_MODE, e.QUOTE_STRING_MODE],
+          },
+          {
+            className: "selector-pseudo",
+            begin: /:(:)?[a-zA-Z0-9\_\-\+\(\)"'.]+/,
+          },
+          {
+            begin: "@(page|font-face)",
+            lexemes: "@[a-z-]+",
+            keywords: "@page @font-face",
+          },
+          {
+            begin: "@",
+            end: "[{;]",
+            illegal: /:/,
+            returnBegin: !0,
+            contains: [
+              { className: "keyword", begin: /@\-?\w[\w]*(\-\w+)*/ },
+              {
+                begin: /\s/,
+                endsWithParent: !0,
+                excludeEnd: !0,
+                relevance: 0,
+                keywords: "and or not only",
                 contains: [
-                  t,
-                  e.C_BLOCK_COMMENT_MODE,
-                  o,
-                  c,
-                  r,
-                  {
-                    begin: /\(/,
-                    end: /\)/,
-                    keywords: m,
-                    relevance: 0,
-                    contains: ["self", t, e.C_BLOCK_COMMENT_MODE, o, c, r],
-                  },
+                  { begin: /[a-z-]+:/, className: "attribute" },
+                  e.APOS_STRING_MODE,
+                  e.QUOTE_STRING_MODE,
+                  e.CSS_NUMBER_MODE,
                 ],
               },
-              r,
-              t,
-              e.C_BLOCK_COMMENT_MODE,
-              l,
             ],
-          };
-        return {
-          name: "C++",
-          aliases: ["cc", "c++", "h++", "hpp", "hh", "hxx", "cxx"],
-          keywords: m,
-          illegal: "</",
-          classNameAliases: { "function.dispatch": "built_in" },
-          contains: [].concat(g, v, u, b, [
-            l,
-            {
-              begin:
-                "\\b(deque|list|queue|priority_queue|pair|stack|vector|map|set|bitset|multiset|multimap|unordered_map|unordered_set|unordered_multiset|unordered_multimap|array|tuple|optional|variant|function)\\s*<(?!<)",
-              end: ">",
-              keywords: m,
-              contains: ["self", r],
-            },
-            { begin: e.IDENT_RE + "::", keywords: m },
-            {
-              match: [
-                /\b(?:enum(?:\s+(?:class|struct))?|class|struct|union)/,
-                /\s+/,
-                /\w+/,
-              ],
-              className: { 1: "keyword", 3: "title.class" },
-            },
-          ]),
-        };
-      },
-      grmr_csharp: (e) => {
-        const n = {
-            keyword: [
-              "abstract",
-              "as",
-              "base",
-              "break",
-              "case",
-              "catch",
-              "class",
-              "const",
-              "continue",
-              "do",
-              "else",
-              "event",
-              "explicit",
-              "extern",
-              "finally",
-              "fixed",
-              "for",
-              "foreach",
-              "goto",
-              "if",
-              "implicit",
-              "in",
-              "interface",
-              "internal",
-              "is",
-              "lock",
-              "namespace",
-              "new",
-              "operator",
-              "out",
-              "override",
-              "params",
-              "private",
-              "protected",
-              "public",
-              "readonly",
-              "record",
-              "ref",
-              "return",
-              "scoped",
-              "sealed",
-              "sizeof",
-              "stackalloc",
-              "static",
-              "struct",
-              "switch",
-              "this",
-              "throw",
-              "try",
-              "typeof",
-              "unchecked",
-              "unsafe",
-              "using",
-              "virtual",
-              "void",
-              "volatile",
-              "while",
-            ].concat([
-              "add",
-              "alias",
-              "and",
-              "ascending",
-              "async",
-              "await",
-              "by",
-              "descending",
-              "equals",
-              "from",
-              "get",
-              "global",
-              "group",
-              "init",
-              "into",
-              "join",
-              "let",
-              "nameof",
-              "not",
-              "notnull",
-              "on",
-              "or",
-              "orderby",
-              "partial",
-              "remove",
-              "select",
-              "set",
-              "unmanaged",
-              "value|0",
-              "var",
-              "when",
-              "where",
-              "with",
-              "yield",
-            ]),
-            built_in: [
-              "bool",
-              "byte",
-              "char",
-              "decimal",
-              "delegate",
-              "double",
-              "dynamic",
-              "enum",
-              "float",
-              "int",
-              "long",
-              "nint",
-              "nuint",
-              "object",
-              "sbyte",
-              "short",
-              "string",
-              "ulong",
-              "uint",
-              "ushort",
-            ],
-            literal: ["default", "false", "null", "true"],
           },
-          t = e.inherit(e.TITLE_MODE, {
-            begin: "[a-zA-Z](\\.?\\w)*",
-          }),
-          s = {
-            className: "number",
-            variants: [
-              {
-                begin: "\\b(0b[01']+)",
-              },
-              {
-                begin:
-                  "(-?)\\b([\\d']+(\\.[\\d']*)?|\\.[\\d']+)(u|U|l|L|ul|UL|f|F|b|B)",
-              },
-              {
-                begin:
-                  "(-?)(\\b0[xX][a-fA-F0-9']+|(\\b[\\d']+(\\.[\\d']*)?|\\.[\\d']+)([eE][-+]?[\\d']+)?)",
-              },
-            ],
+          {
+            className: "selector-tag",
+            begin: "[a-zA-Z-][a-zA-Z0-9_-]*",
             relevance: 0,
           },
-          a = {
-            className: "string",
-            begin: '@"',
-            end: '"',
-            contains: [{ begin: '""' }],
+          {
+            begin: "{",
+            end: "}",
+            illegal: /\S/,
+            contains: [e.C_BLOCK_COMMENT_MODE, n],
           },
-          i = e.inherit(a, { illegal: /\n/ }),
-          r = { className: "subst", begin: /\{/, end: /\}/, keywords: n },
-          o = e.inherit(r, { illegal: /\n/ }),
-          c = {
-            className: "string",
-            begin: /\$"/,
-            end: '"',
-            illegal: /\n/,
-            contains: [
-              { begin: /\{\{/ },
-              { begin: /\}\}/ },
-              e.BACKSLASH_ESCAPE,
-              o,
-            ],
-          },
-          l = {
-            className: "string",
-            begin: /\$@"/,
-            end: '"',
-            contains: [
-              {
-                begin: /\{\{/,
-              },
-              { begin: /\}\}/ },
-              { begin: '""' },
-              r,
-            ],
-          },
-          d = e.inherit(l, {
-            illegal: /\n/,
-            contains: [{ begin: /\{\{/ }, { begin: /\}\}/ }, { begin: '""' }, o],
-          });
-        (r.contains = [
-          l,
-          c,
-          a,
-          e.APOS_STRING_MODE,
-          e.QUOTE_STRING_MODE,
-          s,
-          e.C_BLOCK_COMMENT_MODE,
-        ]),
-          (o.contains = [
-            d,
-            c,
-            i,
-            e.APOS_STRING_MODE,
-            e.QUOTE_STRING_MODE,
-            s,
-            e.inherit(e.C_BLOCK_COMMENT_MODE, {
-              illegal: /\n/,
-            }),
-          ]);
-        const p = {
+        ],
+      };
+    };
+  })()
+);
+hljs.registerLanguage(
+  "diff",
+  (function () {
+    "use strict";
+    return function (e) {
+      return {
+        name: "Diff",
+        aliases: ["patch"],
+        contains: [
+          {
+            className: "meta",
+            relevance: 10,
             variants: [
+              { begin: /^@@ +\-\d+,\d+ +\+\d+,\d+ +@@$/ },
+              { begin: /^\*\*\* +\d+,\d+ +\*\*\*\*$/ },
+              { begin: /^\-\-\- +\d+,\d+ +\-\-\-\-$/ },
+            ],
+          },
+          {
+            className: "comment",
+            variants: [
+              { begin: /Index: /, end: /$/ },
+              { begin: /={3,}/, end: /$/ },
+              { begin: /^\-{3}/, end: /$/ },
+              { begin: /^\*{3} /, end: /$/ },
+              { begin: /^\+{3}/, end: /$/ },
+              { begin: /^\*{15}$/ },
+            ],
+          },
+          { className: "addition", begin: "^\\+", end: "$" },
+          { className: "deletion", begin: "^\\-", end: "$" },
+          { className: "addition", begin: "^\\!", end: "$" },
+        ],
+      };
+    };
+  })()
+);
+hljs.registerLanguage(
+  "go",
+  (function () {
+    "use strict";
+    return function (e) {
+      var n = {
+        keyword:
+          "break default func interface select case map struct chan else goto package switch const fallthrough if range type continue for import return var go defer bool byte complex64 complex128 float32 float64 int8 int16 int32 int64 string uint8 uint16 uint32 uint64 int uint uintptr rune",
+        literal: "true false iota nil",
+        built_in:
+          "append cap close complex copy imag len make new panic print println real recover delete",
+      };
+      return {
+        name: "Go",
+        aliases: ["golang"],
+        keywords: n,
+        illegal: "</",
+        contains: [
+          e.C_LINE_COMMENT_MODE,
+          e.C_BLOCK_COMMENT_MODE,
+          {
+            className: "string",
+            variants: [
+              e.QUOTE_STRING_MODE,
+              e.APOS_STRING_MODE,
+              { begin: "`", end: "`" },
+            ],
+          },
+          {
+            className: "number",
+            variants: [
+              { begin: e.C_NUMBER_RE + "[i]", relevance: 1 },
+              e.C_NUMBER_MODE,
+            ],
+          },
+          { begin: /:=/ },
+          {
+            className: "function",
+            beginKeywords: "func",
+            end: "\\s*(\\{|$)",
+            excludeEnd: !0,
+            contains: [
+              e.TITLE_MODE,
+              {
+                className: "params",
+                begin: /\(/,
+                end: /\)/,
+                keywords: n,
+                illegal: /["']/,
+              },
+            ],
+          },
+        ],
+      };
+    };
+  })()
+);
+hljs.registerLanguage(
+  "http",
+  (function () {
+    "use strict";
+    return function (e) {
+      var n = "HTTP/[0-9\\.]+";
+      return {
+        name: "HTTP",
+        aliases: ["https"],
+        illegal: "\\S",
+        contains: [
+          {
+            begin: "^" + n,
+            end: "$",
+            contains: [{ className: "number", begin: "\\b\\d{3}\\b" }],
+          },
+          {
+            begin: "^[A-Z]+ (.*?) " + n + "$",
+            returnBegin: !0,
+            end: "$",
+            contains: [
               {
                 className: "string",
-                begin: /"""("*)(?!")(.|\n)*?"""\1/,
-                relevance: 1,
+                begin: " ",
+                end: " ",
+                excludeBegin: !0,
+                excludeEnd: !0,
               },
-              l,
-              c,
-              a,
-              e.APOS_STRING_MODE,
-              e.QUOTE_STRING_MODE,
+              { begin: n },
+              { className: "keyword", begin: "[A-Z]+" },
             ],
           },
-          m = {
-            begin: "<",
-            end: ">",
-            contains: [{ beginKeywords: "in out" }, t],
+          {
+            className: "attribute",
+            begin: "^\\w",
+            end: ": ",
+            excludeEnd: !0,
+            illegal: "\\n|\\s|=",
+            starts: { end: "$", relevance: 0 },
           },
-          u =
-            e.IDENT_RE +
-            "(<" +
-            e.IDENT_RE +
-            "(\\s*,\\s*" +
-            e.IDENT_RE +
-            ")*>)?(\\[\\])?",
-          b = {
-            begin: "@" + e.IDENT_RE,
-            relevance: 0,
-          };
-        return {
-          name: "C#",
-          aliases: ["cs", "c#"],
-          keywords: n,
-          illegal: /::/,
-          contains: [
-            e.COMMENT("///", "$", {
-              returnBegin: !0,
-              contains: [
-                {
-                  className: "doctag",
-                  variants: [
-                    { begin: "///", relevance: 0 },
-                    {
-                      begin: "\x3c!--|--\x3e",
-                    },
-                    { begin: "</?", end: ">" },
-                  ],
-                },
-              ],
-            }),
-            e.C_LINE_COMMENT_MODE,
-            e.C_BLOCK_COMMENT_MODE,
-            {
-              className: "meta",
-              begin: "#",
-              end: "$",
-              keywords: {
-                keyword:
-                  "if else elif endif define undef warning error line region endregion pragma checksum",
-              },
-            },
-            p,
-            s,
-            {
-              beginKeywords: "class interface",
-              relevance: 0,
-              end: /[{;=]/,
-              illegal: /[^\s:,]/,
-              contains: [
-                { beginKeywords: "where class" },
-                t,
-                m,
-                e.C_LINE_COMMENT_MODE,
-                e.C_BLOCK_COMMENT_MODE,
-              ],
-            },
-            {
-              beginKeywords: "namespace",
-              relevance: 0,
-              end: /[{;=]/,
-              illegal: /[^\s:]/,
-              contains: [t, e.C_LINE_COMMENT_MODE, e.C_BLOCK_COMMENT_MODE],
-            },
-            {
-              beginKeywords: "record",
-              relevance: 0,
-              end: /[{;=]/,
-              illegal: /[^\s:]/,
-              contains: [t, m, e.C_LINE_COMMENT_MODE, e.C_BLOCK_COMMENT_MODE],
-            },
-            {
-              className: "meta",
-              begin: "^\\s*\\[(?=[\\w])",
-              excludeBegin: !0,
-              end: "\\]",
-              excludeEnd: !0,
-              contains: [
-                {
-                  className: "string",
-                  begin: /"/,
-                  end: /"/,
-                },
-              ],
-            },
-            {
-              beginKeywords: "new return throw await else",
-              relevance: 0,
-            },
-            {
-              className: "function",
-              begin: "(" + u + "\\s+)+" + e.IDENT_RE + "\\s*(<[^=]+>\\s*)?\\(",
-              returnBegin: !0,
-              end: /\s*[{;=]/,
-              excludeEnd: !0,
-              keywords: n,
-              contains: [
-                {
-                  beginKeywords:
-                    "public private protected static internal protected abstract async extern override unsafe virtual new sealed partial",
-                  relevance: 0,
-                },
-                {
-                  begin: e.IDENT_RE + "\\s*(<[^=]+>\\s*)?\\(",
-                  returnBegin: !0,
-                  contains: [e.TITLE_MODE, m],
-                  relevance: 0,
-                },
-                { match: /\(\)/ },
-                {
-                  className: "params",
-                  begin: /\(/,
-                  end: /\)/,
-                  excludeBegin: !0,
-                  excludeEnd: !0,
-                  keywords: n,
-                  relevance: 0,
-                  contains: [p, s, e.C_BLOCK_COMMENT_MODE],
-                },
-                e.C_LINE_COMMENT_MODE,
-                e.C_BLOCK_COMMENT_MODE,
-              ],
-            },
-            b,
+          { begin: "\\n\\n", starts: { subLanguage: [], endsWithParent: !0 } },
+        ],
+      };
+    };
+  })()
+);
+hljs.registerLanguage(
+  "ini",
+  (function () {
+    "use strict";
+    function e(e) {
+      return e ? ("string" == typeof e ? e : e.source) : null;
+    }
+    function n(...n) {
+      return n.map((n) => e(n)).join("");
+    }
+    return function (a) {
+      var s = {
+          className: "number",
+          relevance: 0,
+          variants: [
+            { begin: /([\+\-]+)?[\d]+_[\d_]+/ },
+            { begin: a.NUMBER_RE },
           ],
-        };
-      },
-      grmr_css: (e) => {
-        const n = e.regex,
-          t = se(e),
-          s = [e.APOS_STRING_MODE, e.QUOTE_STRING_MODE];
-        return {
-          name: "CSS",
-          case_insensitive: !0,
-          illegal: /[=|'\$]/,
-          keywords: {
-            keyframePosition: "from to",
-          },
-          classNameAliases: { keyframePosition: "selector-tag" },
-          contains: [
-            t.BLOCK_COMMENT,
-            { begin: /-(webkit|moz|ms|o)-(?=[a-z])/ },
-            t.CSS_NUMBER_MODE,
-            { className: "selector-id", begin: /#[A-Za-z0-9_-]+/, relevance: 0 },
-            {
-              className: "selector-class",
-              begin: "\\.[a-zA-Z-][a-zA-Z0-9_-]*",
-              relevance: 0,
-            },
-            t.ATTRIBUTE_SELECTOR_MODE,
-            {
-              className: "selector-pseudo",
-              variants: [
-                {
-                  begin: ":(" + re.join("|") + ")",
-                },
-                { begin: ":(:)?(" + oe.join("|") + ")" },
-              ],
-            },
-            t.CSS_VARIABLE,
-            { className: "attribute", begin: "\\b(" + ce.join("|") + ")\\b" },
-            {
-              begin: /:/,
-              end: /[;}{]/,
-              contains: [
-                t.BLOCK_COMMENT,
-                t.HEXCOLOR,
-                t.IMPORTANT,
-                t.CSS_NUMBER_MODE,
-                ...s,
-                {
-                  begin: /(url|data-uri)\(/,
-                  end: /\)/,
-                  relevance: 0,
-                  keywords: { built_in: "url data-uri" },
-                  contains: [
-                    ...s,
-                    {
-                      className: "string",
-                      begin: /[^)]/,
-                      endsWithParent: !0,
-                      excludeEnd: !0,
-                    },
-                  ],
-                },
-                t.FUNCTION_DISPATCH,
-              ],
-            },
-            {
-              begin: n.lookahead(/@/),
-              end: "[{;]",
-              relevance: 0,
-              illegal: /:/,
-              contains: [
-                { className: "keyword", begin: /@-?\w[\w]*(-\w+)*/ },
-                {
-                  begin: /\s/,
-                  endsWithParent: !0,
-                  excludeEnd: !0,
-                  relevance: 0,
-                  keywords: {
-                    $pattern: /[a-z-]+/,
-                    keyword: "and or not only",
-                    attribute: ie.join(" "),
-                  },
-                  contains: [
-                    {
-                      begin: /[a-z-]+(?=:)/,
-                      className: "attribute",
-                    },
-                    ...s,
-                    t.CSS_NUMBER_MODE,
-                  ],
-                },
-              ],
-            },
-            {
-              className: "selector-tag",
-              begin: "\\b(" + ae.join("|") + ")\\b",
-            },
+        },
+        i = a.COMMENT();
+      i.variants = [
+        { begin: /;/, end: /$/ },
+        { begin: /#/, end: /$/ },
+      ];
+      var t = {
+          className: "variable",
+          variants: [{ begin: /\$[\w\d"][\w\d_]*/ }, { begin: /\$\{(.*?)}/ }],
+        },
+        r = { className: "literal", begin: /\bon|off|true|false|yes|no\b/ },
+        l = {
+          className: "string",
+          contains: [a.BACKSLASH_ESCAPE],
+          variants: [
+            { begin: "'''", end: "'''", relevance: 10 },
+            { begin: '"""', end: '"""', relevance: 10 },
+            { begin: '"', end: '"' },
+            { begin: "'", end: "'" },
           ],
-        };
-      },
-      grmr_d: (e) => {
-        const n = {
-            $pattern: e.UNDERSCORE_IDENT_RE,
-            keyword:
-              "abstract alias align asm assert auto body break byte case cast catch class const continue debug default delete deprecated do else enum export extern final finally for foreach foreach_reverse|10 goto if immutable import in inout int interface invariant is lazy macro mixin module new nothrow out override package pragma private protected public pure ref return scope shared static struct super switch synchronized template this throw try typedef typeid typeof union unittest version void volatile while with __FILE__ __LINE__ __gshared|10 __thread __traits __DATE__ __EOF__ __TIME__ __TIMESTAMP__ __VENDOR__ __VERSION__",
-            built_in:
-              "bool cdouble cent cfloat char creal dchar delegate double dstring float function idouble ifloat ireal long real short string ubyte ucent uint ulong ushort wchar wstring",
-            literal: "false null true",
+        },
+        c = {
+          begin: /\[/,
+          end: /\]/,
+          contains: [i, r, t, l, s, "self"],
+          relevance: 0,
+        },
+        g =
+          "(" +
+          [/[A-Za-z0-9_-]+/, /"(\\"|[^"])*"/, /'[^']*'/]
+            .map((n) => e(n))
+            .join("|") +
+          ")";
+      return {
+        name: "TOML, also INI",
+        aliases: ["toml"],
+        case_insensitive: !0,
+        illegal: /\S/,
+        contains: [
+          i,
+          { className: "section", begin: /\[+/, end: /\]+/ },
+          {
+            begin: n(
+              g,
+              "(\\s*\\.\\s*",
+              g,
+              ")*",
+              n("(?=", /\s*=\s*[^#\s]/, ")")
+            ),
+            className: "attr",
+            starts: { end: /$/, contains: [i, c, r, t, l, s] },
           },
-          t = "(0|[1-9][\\d_]*)",
-          s = "(0|[1-9][\\d_]*|\\d[\\d_]*|[\\d_]+?\\d)",
-          a = "([\\da-fA-F][\\da-fA-F_]*|_[\\da-fA-F][\\da-fA-F_]*)",
-          i = "([eE][+-]?" + s + ")",
-          r = "(" + t + "|0[bB][01_]+|0[xX]" + a + ")",
-          o =
-            "\\\\(['\"\\?\\\\abfnrtv]|u[\\dA-Fa-f]{4}|[0-7]{1,3}|x[\\dA-Fa-f]{2}|U[\\dA-Fa-f]{8})|&[a-zA-Z\\d]{2,};",
-          c = {
-            className: "number",
-            begin: "\\b" + r + "(L|u|U|Lu|LU|uL|UL)?",
-            relevance: 0,
-          },
-          l = {
-            className: "number",
-            begin:
-              "\\b(((0[xX](" +
-              a +
-              "\\." +
-              a +
-              "|\\.?" +
-              a +
-              ")[pP][+-]?" +
-              s +
-              ")|(" +
-              s +
-              "(\\.\\d*|" +
-              i +
-              ")|\\d+\\." +
-              s +
-              "|\\." +
-              t +
-              i +
-              "?))([fF]|L|i|[fF]i|Li)?|" +
-              r +
-              "(i|[fF]i|Li))",
-            relevance: 0,
-          },
-          d = {
-            className: "string",
-            begin: "'(" + o + "|.)",
-            end: "'",
-            illegal: ".",
-          },
-          p = {
-            className: "string",
-            begin: '"',
-            contains: [{ begin: o, relevance: 0 }],
-            end: '"[cwd]?',
-          },
-          m = e.COMMENT("\\/\\+", "\\+\\/", {
-            contains: ["self"],
-            relevance: 10,
-          });
-        return {
-          name: "D",
-          keywords: n,
-          contains: [
-            e.C_LINE_COMMENT_MODE,
-            e.C_BLOCK_COMMENT_MODE,
-            m,
+        ],
+      };
+    };
+  })()
+);
+hljs.registerLanguage(
+  "java",
+  (function () {
+    "use strict";
+    function e(e) {
+      return e ? ("string" == typeof e ? e : e.source) : null;
+    }
+    function n(e) {
+      return a("(", e, ")?");
+    }
+    function a(...n) {
+      return n.map((n) => e(n)).join("");
+    }
+    function s(...n) {
+      return "(" + n.map((n) => e(n)).join("|") + ")";
+    }
+    return function (e) {
+      var t =
+          "false synchronized int abstract float private char boolean var static null if const for true while long strictfp finally protected import native final void enum else break transient catch instanceof byte super volatile case assert short package default double public try this switch continue throws protected public private module requires exports do",
+        i = {
+          className: "meta",
+          begin: "@[À-ʸa-zA-Z_$][À-ʸa-zA-Z_$0-9]*",
+          contains: [{ begin: /\(/, end: /\)/, contains: ["self"] }],
+        },
+        r = (e) => a("[", e, "]+([", e, "_]*[", e, "]+)?"),
+        c = {
+          className: "number",
+          variants: [
+            { begin: `\\b(0[bB]${r("01")})[lL]?` },
+            { begin: `\\b(0${r("0-7")})[dDfFlL]?` },
             {
-              className: "string",
-              begin: 'x"[\\da-fA-F\\s\\n\\r]*"[cwd]?',
-              relevance: 10,
-            },
-            p,
-            {
-              className: "string",
-              begin: '[rq]"',
-              end: '"[cwd]?',
-              relevance: 5,
-            },
-            { className: "string", begin: "`", end: "`[cwd]?" },
-            { className: "string", begin: 'q"\\{', end: '\\}"' },
-            l,
-            c,
-            d,
-            {
-              className: "meta",
-              begin: "^#!",
-              end: "$",
-              relevance: 5,
-            },
-            { className: "meta", begin: "#(line)", end: "$", relevance: 5 },
-            { className: "keyword", begin: "@[a-zA-Z_][a-zA-Z_\\d]*" },
-          ],
-        };
-      },
-      grmr_diff: (e) => {
-        const n = e.regex;
-        return {
-          name: "Diff",
-          aliases: ["patch"],
-          contains: [
-            {
-              className: "meta",
-              relevance: 10,
-              match: n.either(
-                /^@@ +-\d+,\d+ +\+\d+,\d+ +@@/,
-                /^\*\*\* +\d+,\d+ +\*\*\*\*$/,
-                /^--- +\d+,\d+ +----$/
+              begin: a(
+                /\b0[xX]/,
+                s(
+                  a(r("a-fA-F0-9"), /\./, r("a-fA-F0-9")),
+                  a(r("a-fA-F0-9"), /\.?/),
+                  a(/\./, r("a-fA-F0-9"))
+                ),
+                /([pP][+-]?(\d+))?/,
+                /[fFdDlL]?/
               ),
             },
             {
-              className: "comment",
-              variants: [
-                {
-                  begin: n.either(
-                    /Index: /,
-                    /^index/,
-                    /={3,}/,
-                    /^-{3}/,
-                    /^\*{3} /,
-                    /^\+{3}/,
-                    /^diff --git/
-                  ),
-                  end: /$/,
-                },
-                { match: /^\*{15}$/ },
-              ],
+              begin: a(
+                /\b/,
+                s(a(/\d*\./, r("\\d")), r("\\d")),
+                /[eE][+-]?[\d]+[dDfF]?/
+              ),
             },
-            { className: "addition", begin: /^\+/, end: /$/ },
-            {
-              className: "deletion",
-              begin: /^-/,
-              end: /$/,
-            },
-            { className: "addition", begin: /^!/, end: /$/ },
+            { begin: a(/\b/, r(/\d/), n(/\.?/), n(r(/\d/)), /[dDfFlL]?/) },
           ],
+          relevance: 0,
         };
-      },
-      grmr_go: (e) => {
-        const n = {
-          keyword: [
-            "break",
-            "case",
-            "chan",
-            "const",
-            "continue",
-            "default",
-            "defer",
-            "else",
-            "fallthrough",
-            "for",
-            "func",
-            "go",
-            "goto",
-            "if",
-            "import",
-            "interface",
-            "map",
-            "package",
-            "range",
-            "return",
-            "select",
-            "struct",
-            "switch",
-            "type",
-            "var",
+      return {
+        name: "Java",
+        aliases: ["jsp"],
+        keywords: t,
+        illegal: /<\/|#/,
+        contains: [
+          e.COMMENT("/\\*\\*", "\\*/", {
+            relevance: 0,
+            contains: [
+              { begin: /\w+@/, relevance: 0 },
+              { className: "doctag", begin: "@[A-Za-z]+" },
+            ],
+          }),
+          e.C_LINE_COMMENT_MODE,
+          e.C_BLOCK_COMMENT_MODE,
+          e.APOS_STRING_MODE,
+          e.QUOTE_STRING_MODE,
+          {
+            className: "class",
+            beginKeywords: "class interface",
+            end: /[{;=]/,
+            excludeEnd: !0,
+            keywords: "class interface",
+            illegal: /[:"\[\]]/,
+            contains: [
+              { beginKeywords: "extends implements" },
+              e.UNDERSCORE_TITLE_MODE,
+            ],
+          },
+          { beginKeywords: "new throw return else", relevance: 0 },
+          {
+            className: "function",
+            begin:
+              "([À-ʸa-zA-Z_$][À-ʸa-zA-Z_$0-9]*(<[À-ʸa-zA-Z_$][À-ʸa-zA-Z_$0-9]*(\\s*,\\s*[À-ʸa-zA-Z_$][À-ʸa-zA-Z_$0-9]*)*>)?\\s+)+" +
+              e.UNDERSCORE_IDENT_RE +
+              "\\s*\\(",
+            returnBegin: !0,
+            end: /[{;=]/,
+            excludeEnd: !0,
+            keywords: t,
+            contains: [
+              {
+                begin: e.UNDERSCORE_IDENT_RE + "\\s*\\(",
+                returnBegin: !0,
+                relevance: 0,
+                contains: [e.UNDERSCORE_TITLE_MODE],
+              },
+              {
+                className: "params",
+                begin: /\(/,
+                end: /\)/,
+                keywords: t,
+                relevance: 0,
+                contains: [
+                  i,
+                  e.APOS_STRING_MODE,
+                  e.QUOTE_STRING_MODE,
+                  e.C_NUMBER_MODE,
+                  e.C_BLOCK_COMMENT_MODE,
+                ],
+              },
+              e.C_LINE_COMMENT_MODE,
+              e.C_BLOCK_COMMENT_MODE,
+            ],
+          },
+          c,
+          i,
+        ],
+      };
+    };
+  })()
+);
+hljs.registerLanguage(
+  "javascript",
+  (function () {
+    "use strict";
+    const e = [
+        "as",
+        "in",
+        "of",
+        "if",
+        "for",
+        "while",
+        "finally",
+        "var",
+        "new",
+        "function",
+        "do",
+        "return",
+        "void",
+        "else",
+        "break",
+        "catch",
+        "instanceof",
+        "with",
+        "throw",
+        "case",
+        "default",
+        "try",
+        "switch",
+        "continue",
+        "typeof",
+        "delete",
+        "let",
+        "yield",
+        "const",
+        "class",
+        "debugger",
+        "async",
+        "await",
+        "static",
+        "import",
+        "from",
+        "export",
+        "extends",
+      ],
+      n = ["true", "false", "null", "undefined", "NaN", "Infinity"],
+      a = [].concat(
+        [
+          "setInterval",
+          "setTimeout",
+          "clearInterval",
+          "clearTimeout",
+          "require",
+          "exports",
+          "eval",
+          "isFinite",
+          "isNaN",
+          "parseFloat",
+          "parseInt",
+          "decodeURI",
+          "decodeURIComponent",
+          "encodeURI",
+          "encodeURIComponent",
+          "escape",
+          "unescape",
+        ],
+        [
+          "arguments",
+          "this",
+          "super",
+          "console",
+          "window",
+          "document",
+          "localStorage",
+          "module",
+          "global",
+        ],
+        [
+          "Intl",
+          "DataView",
+          "Number",
+          "Math",
+          "Date",
+          "String",
+          "RegExp",
+          "Object",
+          "Function",
+          "Boolean",
+          "Error",
+          "Symbol",
+          "Set",
+          "Map",
+          "WeakSet",
+          "WeakMap",
+          "Proxy",
+          "Reflect",
+          "JSON",
+          "Promise",
+          "Float64Array",
+          "Int16Array",
+          "Int32Array",
+          "Int8Array",
+          "Uint16Array",
+          "Uint32Array",
+          "Float32Array",
+          "Array",
+          "Uint8Array",
+          "Uint8ClampedArray",
+          "ArrayBuffer",
+        ],
+        [
+          "EvalError",
+          "InternalError",
+          "RangeError",
+          "ReferenceError",
+          "SyntaxError",
+          "TypeError",
+          "URIError",
+        ]
+      );
+    function s(e) {
+      return r("(?=", e, ")");
+    }
+    function r(...e) {
+      return e
+        .map((e) =>
+          (function (e) {
+            return e ? ("string" == typeof e ? e : e.source) : null;
+          })(e)
+        )
+        .join("");
+    }
+    return function (t) {
+      var i = "[A-Za-z$_][0-9A-Za-z$_]*",
+        c = { begin: /<[A-Za-z0-9\\._:-]+/, end: /\/[A-Za-z0-9\\._:-]+>|\/>/ },
+        o = {
+          $pattern: "[A-Za-z$_][0-9A-Za-z$_]*",
+          keyword: e.join(" "),
+          literal: n.join(" "),
+          built_in: a.join(" "),
+        },
+        l = {
+          className: "number",
+          variants: [
+            { begin: "\\b(0[bB][01]+)n?" },
+            { begin: "\\b(0[oO][0-7]+)n?" },
+            { begin: t.C_NUMBER_RE + "n?" },
           ],
-          type: [
-            "bool",
-            "byte",
-            "complex64",
-            "complex128",
-            "error",
-            "float32",
-            "float64",
-            "int8",
-            "int16",
-            "int32",
-            "int64",
-            "string",
-            "uint8",
-            "uint16",
-            "uint32",
-            "uint64",
-            "int",
-            "uint",
-            "uintptr",
-            "rune",
-          ],
-          literal: ["true", "false", "iota", "nil"],
-          built_in: [
-            "append",
-            "cap",
-            "close",
-            "complex",
-            "copy",
-            "imag",
-            "len",
-            "make",
-            "new",
-            "panic",
-            "print",
-            "println",
-            "real",
-            "recover",
-            "delete",
-          ],
+          relevance: 0,
+        },
+        E = {
+          className: "subst",
+          begin: "\\$\\{",
+          end: "\\}",
+          keywords: o,
+          contains: [],
+        },
+        d = {
+          begin: "html`",
+          end: "",
+          starts: {
+            end: "`",
+            returnEnd: !1,
+            contains: [t.BACKSLASH_ESCAPE, E],
+            subLanguage: "xml",
+          },
+        },
+        g = {
+          begin: "css`",
+          end: "",
+          starts: {
+            end: "`",
+            returnEnd: !1,
+            contains: [t.BACKSLASH_ESCAPE, E],
+            subLanguage: "css",
+          },
+        },
+        u = {
+          className: "string",
+          begin: "`",
+          end: "`",
+          contains: [t.BACKSLASH_ESCAPE, E],
         };
-        return {
-          name: "Go",
-          aliases: ["golang"],
-          keywords: n,
-          illegal: "</",
+      E.contains = [
+        t.APOS_STRING_MODE,
+        t.QUOTE_STRING_MODE,
+        d,
+        g,
+        u,
+        l,
+        t.REGEXP_MODE,
+      ];
+      var b = E.contains.concat([
+          {
+            begin: /\(/,
+            end: /\)/,
+            contains: ["self"].concat(E.contains, [
+              t.C_BLOCK_COMMENT_MODE,
+              t.C_LINE_COMMENT_MODE,
+            ]),
+          },
+          t.C_BLOCK_COMMENT_MODE,
+          t.C_LINE_COMMENT_MODE,
+        ]),
+        _ = {
+          className: "params",
+          begin: /\(/,
+          end: /\)/,
+          excludeBegin: !0,
+          excludeEnd: !0,
+          contains: b,
+        };
+      return {
+        name: "JavaScript",
+        aliases: ["js", "jsx", "mjs", "cjs"],
+        keywords: o,
+        contains: [
+          t.SHEBANG({ binary: "node", relevance: 5 }),
+          {
+            className: "meta",
+            relevance: 10,
+            begin: /^\s*['"]use (strict|asm)['"]/,
+          },
+          t.APOS_STRING_MODE,
+          t.QUOTE_STRING_MODE,
+          d,
+          g,
+          u,
+          t.C_LINE_COMMENT_MODE,
+          t.COMMENT("/\\*\\*", "\\*/", {
+            relevance: 0,
+            contains: [
+              {
+                className: "doctag",
+                begin: "@[A-Za-z]+",
+                contains: [
+                  { className: "type", begin: "\\{", end: "\\}", relevance: 0 },
+                  {
+                    className: "variable",
+                    begin: i + "(?=\\s*(-)|$)",
+                    endsParent: !0,
+                    relevance: 0,
+                  },
+                  { begin: /(?=[^\n])\s/, relevance: 0 },
+                ],
+              },
+            ],
+          }),
+          t.C_BLOCK_COMMENT_MODE,
+          l,
+          {
+            begin: r(
+              /[{,\n]\s*/,
+              s(r(/(((\/\/.*)|(\/\*(.|\n)*\*\/))\s*)*/, i + "\\s*:"))
+            ),
+            relevance: 0,
+            contains: [
+              { className: "attr", begin: i + s("\\s*:"), relevance: 0 },
+            ],
+          },
+          {
+            begin: "(" + t.RE_STARTERS_RE + "|\\b(case|return|throw)\\b)\\s*",
+            keywords: "return throw case",
+            contains: [
+              t.C_LINE_COMMENT_MODE,
+              t.C_BLOCK_COMMENT_MODE,
+              t.REGEXP_MODE,
+              {
+                className: "function",
+                begin:
+                  "(\\([^(]*(\\([^(]*(\\([^(]*\\))?\\))?\\)|" +
+                  t.UNDERSCORE_IDENT_RE +
+                  ")\\s*=>",
+                returnBegin: !0,
+                end: "\\s*=>",
+                contains: [
+                  {
+                    className: "params",
+                    variants: [
+                      { begin: t.UNDERSCORE_IDENT_RE },
+                      { className: null, begin: /\(\s*\)/, skip: !0 },
+                      {
+                        begin: /\(/,
+                        end: /\)/,
+                        excludeBegin: !0,
+                        excludeEnd: !0,
+                        keywords: o,
+                        contains: b,
+                      },
+                    ],
+                  },
+                ],
+              },
+              { begin: /,/, relevance: 0 },
+              { className: "", begin: /\s/, end: /\s*/, skip: !0 },
+              {
+                variants: [
+                  { begin: "<>", end: "</>" },
+                  { begin: c.begin, end: c.end },
+                ],
+                subLanguage: "xml",
+                contains: [
+                  { begin: c.begin, end: c.end, skip: !0, contains: ["self"] },
+                ],
+              },
+            ],
+            relevance: 0,
+          },
+          {
+            className: "function",
+            beginKeywords: "function",
+            end: /\{/,
+            excludeEnd: !0,
+            contains: [t.inherit(t.TITLE_MODE, { begin: i }), _],
+            illegal: /\[|%/,
+          },
+          { begin: /\$[(.]/ },
+          t.METHOD_GUARD,
+          {
+            className: "class",
+            beginKeywords: "class",
+            end: /[{;=]/,
+            excludeEnd: !0,
+            illegal: /[:"\[\]]/,
+            contains: [{ beginKeywords: "extends" }, t.UNDERSCORE_TITLE_MODE],
+          },
+          { beginKeywords: "constructor", end: /\{/, excludeEnd: !0 },
+          {
+            begin: "(get|set)\\s+(?=" + i + "\\()",
+            end: /{/,
+            keywords: "get set",
+            contains: [
+              t.inherit(t.TITLE_MODE, { begin: i }),
+              { begin: /\(\)/ },
+              _,
+            ],
+          },
+        ],
+        illegal: /#(?!!)/,
+      };
+    };
+  })()
+);
+hljs.registerLanguage(
+  "json",
+  (function () {
+    "use strict";
+    return function (n) {
+      var e = { literal: "true false null" },
+        i = [n.C_LINE_COMMENT_MODE, n.C_BLOCK_COMMENT_MODE],
+        t = [n.QUOTE_STRING_MODE, n.C_NUMBER_MODE],
+        a = {
+          end: ",",
+          endsWithParent: !0,
+          excludeEnd: !0,
+          contains: t,
+          keywords: e,
+        },
+        l = {
+          begin: "{",
+          end: "}",
           contains: [
+            {
+              className: "attr",
+              begin: /"/,
+              end: /"/,
+              contains: [n.BACKSLASH_ESCAPE],
+              illegal: "\\n",
+            },
+            n.inherit(a, { begin: /:/ }),
+          ].concat(i),
+          illegal: "\\S",
+        },
+        s = {
+          begin: "\\[",
+          end: "\\]",
+          contains: [n.inherit(a)],
+          illegal: "\\S",
+        };
+      return (
+        t.push(l, s),
+        i.forEach(function (n) {
+          t.push(n);
+        }),
+        { name: "JSON", contains: t, keywords: e, illegal: "\\S" }
+      );
+    };
+  })()
+);
+hljs.registerLanguage(
+  "kotlin",
+  (function () {
+    "use strict";
+    return function (e) {
+      var n = {
+          keyword:
+            "abstract as val var vararg get set class object open private protected public noinline crossinline dynamic final enum if else do while for when throw try catch finally import package is in fun override companion reified inline lateinit init interface annotation data sealed internal infix operator out by constructor super tailrec where const inner suspend typealias external expect actual trait volatile transient native default",
+          built_in:
+            "Byte Short Char Int Long Boolean Float Double Void Unit Nothing",
+          literal: "true false null",
+        },
+        a = { className: "symbol", begin: e.UNDERSCORE_IDENT_RE + "@" },
+        i = {
+          className: "subst",
+          begin: "\\${",
+          end: "}",
+          contains: [e.C_NUMBER_MODE],
+        },
+        s = { className: "variable", begin: "\\$" + e.UNDERSCORE_IDENT_RE },
+        t = {
+          className: "string",
+          variants: [
+            { begin: '"""', end: '"""(?=[^"])', contains: [s, i] },
+            {
+              begin: "'",
+              end: "'",
+              illegal: /\n/,
+              contains: [e.BACKSLASH_ESCAPE],
+            },
+            {
+              begin: '"',
+              end: '"',
+              illegal: /\n/,
+              contains: [e.BACKSLASH_ESCAPE, s, i],
+            },
+          ],
+        };
+      i.contains.push(t);
+      var r = {
+          className: "meta",
+          begin:
+            "@(?:file|property|field|get|set|receiver|param|setparam|delegate)\\s*:(?:\\s*" +
+            e.UNDERSCORE_IDENT_RE +
+            ")?",
+        },
+        l = {
+          className: "meta",
+          begin: "@" + e.UNDERSCORE_IDENT_RE,
+          contains: [
+            {
+              begin: /\(/,
+              end: /\)/,
+              contains: [e.inherit(t, { className: "meta-string" })],
+            },
+          ],
+        },
+        c = e.COMMENT("/\\*", "\\*/", { contains: [e.C_BLOCK_COMMENT_MODE] }),
+        o = {
+          variants: [
+            { className: "type", begin: e.UNDERSCORE_IDENT_RE },
+            { begin: /\(/, end: /\)/, contains: [] },
+          ],
+        },
+        d = o;
+      return (
+        (d.variants[1].contains = [o]),
+        (o.variants[1].contains = [d]),
+        {
+          name: "Kotlin",
+          aliases: ["kt"],
+          keywords: n,
+          contains: [
+            e.COMMENT("/\\*\\*", "\\*/", {
+              relevance: 0,
+              contains: [{ className: "doctag", begin: "@[A-Za-z]+" }],
+            }),
             e.C_LINE_COMMENT_MODE,
-            e.C_BLOCK_COMMENT_MODE,
+            c,
             {
-              className: "string",
-              variants: [
-                e.QUOTE_STRING_MODE,
-                e.APOS_STRING_MODE,
-                { begin: "`", end: "`" },
-              ],
+              className: "keyword",
+              begin: /\b(break|continue|return|this)\b/,
+              starts: { contains: [{ className: "symbol", begin: /@\w+/ }] },
             },
-            {
-              className: "number",
-              variants: [
-                {
-                  match:
-                    /-?\b0[xX]\.[a-fA-F0-9](_?[a-fA-F0-9])*[pP][+-]?\d(_?\d)*i?/,
-                  relevance: 0,
-                },
-                {
-                  match:
-                    /-?\b0[xX](_?[a-fA-F0-9])+((\.([a-fA-F0-9](_?[a-fA-F0-9])*)?)?[pP][+-]?\d(_?\d)*)?i?/,
-                  relevance: 0,
-                },
-                { match: /-?\b0[oO](_?[0-7])*i?/, relevance: 0 },
-                {
-                  match: /-?\.\d(_?\d)*([eE][+-]?\d(_?\d)*)?i?/,
-                  relevance: 0,
-                },
-                {
-                  match: /-?\b\d(_?\d)*(\.(\d(_?\d)*)?)?([eE][+-]?\d(_?\d)*)?i?/,
-                  relevance: 0,
-                },
-              ],
-            },
-            {
-              begin: /:=/,
-            },
+            a,
+            r,
+            l,
             {
               className: "function",
-              beginKeywords: "func",
-              end: "\\s*(\\{|$)",
+              beginKeywords: "fun",
+              end: "[(]|$",
+              returnBegin: !0,
               excludeEnd: !0,
+              keywords: n,
+              illegal: /fun\s+(<.*>)?[^\s\(]+(\s+[^\s\(]+)\s*=/,
+              relevance: 5,
               contains: [
-                e.TITLE_MODE,
+                {
+                  begin: e.UNDERSCORE_IDENT_RE + "\\s*\\(",
+                  returnBegin: !0,
+                  relevance: 0,
+                  contains: [e.UNDERSCORE_TITLE_MODE],
+                },
+                {
+                  className: "type",
+                  begin: /</,
+                  end: />/,
+                  keywords: "reified",
+                  relevance: 0,
+                },
                 {
                   className: "params",
                   begin: /\(/,
                   end: /\)/,
                   endsParent: !0,
                   keywords: n,
-                  illegal: /["']/,
+                  relevance: 0,
+                  contains: [
+                    {
+                      begin: /:/,
+                      end: /[=,\/]/,
+                      endsWithParent: !0,
+                      contains: [o, e.C_LINE_COMMENT_MODE, c],
+                      relevance: 0,
+                    },
+                    e.C_LINE_COMMENT_MODE,
+                    c,
+                    r,
+                    l,
+                    t,
+                    e.C_NUMBER_MODE,
+                  ],
                 },
-              ],
-            },
-          ],
-        };
-      },
-      grmr_graphql: (e) => {
-        const n = e.regex;
-        return {
-          name: "GraphQL",
-          aliases: ["gql"],
-          case_insensitive: !0,
-          disableAutodetect: !1,
-          keywords: {
-            keyword: [
-              "query",
-              "mutation",
-              "subscription",
-              "type",
-              "input",
-              "schema",
-              "directive",
-              "interface",
-              "union",
-              "scalar",
-              "fragment",
-              "enum",
-              "on",
-            ],
-            literal: ["true", "false", "null"],
-          },
-          contains: [
-            e.HASH_COMMENT_MODE,
-            e.QUOTE_STRING_MODE,
-            e.NUMBER_MODE,
-            {
-              scope: "punctuation",
-              match: /[.]{3}/,
-              relevance: 0,
-            },
-            {
-              scope: "punctuation",
-              begin: /[\!\(\)\:\=\[\]\{\|\}]{1}/,
-              relevance: 0,
-            },
-            {
-              scope: "variable",
-              begin: /\$/,
-              end: /\W/,
-              excludeEnd: !0,
-              relevance: 0,
-            },
-            { scope: "meta", match: /@\w+/, excludeEnd: !0 },
-            {
-              scope: "symbol",
-              begin: n.concat(/[_A-Za-z][_0-9A-Za-z]*/, n.lookahead(/\s*:/)),
-              relevance: 0,
-            },
-          ],
-          illegal: [/[;<']/, /BEGIN/],
-        };
-      },
-      grmr_handlebars: (e) => {
-        const n = e.regex,
-          t = {
-            $pattern: /[\w.\/]+/,
-            built_in: [
-              "action",
-              "bindattr",
-              "collection",
-              "component",
-              "concat",
-              "debugger",
-              "each",
-              "each-in",
-              "get",
-              "hash",
-              "if",
-              "in",
-              "input",
-              "link-to",
-              "loc",
-              "log",
-              "lookup",
-              "mut",
-              "outlet",
-              "partial",
-              "query-params",
-              "render",
-              "template",
-              "textarea",
-              "unbound",
-              "unless",
-              "view",
-              "with",
-              "yield",
-            ],
-          },
-          s = /\[\]|\[[^\]]+\]/,
-          a = /[^\s!"#%&'()*+,.\/;<=>@\[\\\]^`{|}~]+/,
-          i = n.either(/""|"[^"]+"/, /''|'[^']+'/, s, a),
-          r = n.concat(
-            n.optional(/\.|\.\/|\//),
-            i,
-            n.anyNumberOfTimes(n.concat(/(\.|\/)/, i))
-          ),
-          o = n.concat("(", s, "|", a, ")(?==)"),
-          c = {
-            begin: r,
-          },
-          l = e.inherit(c, {
-            keywords: {
-              $pattern: /[\w.\/]+/,
-              literal: ["true", "false", "undefined", "null"],
-            },
-          }),
-          d = { begin: /\(/, end: /\)/ },
-          p = {
-            className: "attr",
-            begin: o,
-            relevance: 0,
-            starts: {
-              begin: /=/,
-              end: /=/,
-              starts: {
-                contains: [
-                  e.NUMBER_MODE,
-                  e.QUOTE_STRING_MODE,
-                  e.APOS_STRING_MODE,
-                  l,
-                  d,
-                ],
-              },
-            },
-          },
-          m = {
-            contains: [
-              e.NUMBER_MODE,
-              e.QUOTE_STRING_MODE,
-              e.APOS_STRING_MODE,
-              {
-                begin: /as\s+\|/,
-                keywords: { keyword: "as" },
-                end: /\|/,
-                contains: [{ begin: /\w+/ }],
-              },
-              p,
-              l,
-              d,
-            ],
-            returnEnd: !0,
-          },
-          u = e.inherit(c, {
-            className: "name",
-            keywords: t,
-            starts: e.inherit(m, { end: /\)/ }),
-          });
-        d.contains = [u];
-        const b = e.inherit(c, {
-            keywords: t,
-            className: "name",
-            starts: e.inherit(m, { end: /\}\}/ }),
-          }),
-          g = e.inherit(c, { keywords: t, className: "name" }),
-          v = e.inherit(c, {
-            className: "name",
-            keywords: t,
-            starts: e.inherit(m, { end: /\}\}/ }),
-          });
-        return {
-          name: "Handlebars",
-          aliases: ["hbs", "html.hbs", "html.handlebars", "htmlbars"],
-          case_insensitive: !0,
-          subLanguage: "xml",
-          contains: [
-            { begin: /\\\{\{/, skip: !0 },
-            { begin: /\\\\(?=\{\{)/, skip: !0 },
-            e.COMMENT(/\{\{!--/, /--\}\}/),
-            e.COMMENT(/\{\{!/, /\}\}/),
-            {
-              className: "template-tag",
-              begin: /\{\{\{\{(?!\/)/,
-              end: /\}\}\}\}/,
-              contains: [b],
-              starts: { end: /\{\{\{\{\//, returnEnd: !0, subLanguage: "xml" },
-            },
-            {
-              className: "template-tag",
-              begin: /\{\{\{\{\//,
-              end: /\}\}\}\}/,
-              contains: [g],
-            },
-            {
-              className: "template-tag",
-              begin: /\{\{#/,
-              end: /\}\}/,
-              contains: [b],
-            },
-            {
-              className: "template-tag",
-              begin: /\{\{(?=else\}\})/,
-              end: /\}\}/,
-              keywords: "else",
-            },
-            {
-              className: "template-tag",
-              begin: /\{\{(?=else if)/,
-              end: /\}\}/,
-              keywords: "else if",
-            },
-            {
-              className: "template-tag",
-              begin: /\{\{\//,
-              end: /\}\}/,
-              contains: [g],
-            },
-            {
-              className: "template-variable",
-              begin: /\{\{\{/,
-              end: /\}\}\}/,
-              contains: [v],
-            },
-            {
-              className: "template-variable",
-              begin: /\{\{/,
-              end: /\}\}/,
-              contains: [v],
-            },
-          ],
-        };
-      },
-      grmr_haskell: (e) => {
-        const n = "([0-9]_*)+",
-          t = "([0-9a-fA-F]_*)+",
-          s =
-            "([!#$%&*+.\\/<=>?@\\\\^~-]|(?!([(),;\\[\\]`|{}]|[_:\"']))(\\p{S}|\\p{P}))",
-          a = {
-            variants: [
-              e.COMMENT("--+", "$"),
-              e.COMMENT(/\{-/, /-\}/, { contains: ["self"] }),
-            ],
-          },
-          i = {
-            className: "meta",
-            begin: /\{-#/,
-            end: /#-\}/,
-          },
-          r = { className: "meta", begin: "^#", end: "$" },
-          o = { className: "type", begin: "\\b[A-Z][\\w']*", relevance: 0 },
-          c = {
-            begin: "\\(",
-            end: "\\)",
-            illegal: '"',
-            contains: [
-              i,
-              r,
-              {
-                className: "type",
-                begin: "\\b[A-Z][\\w]*(\\((\\.\\.|,|\\w+)\\))?",
-              },
-              e.inherit(e.TITLE_MODE, {
-                begin: "[_a-z][\\w']*",
-              }),
-              a,
-            ],
-          },
-          l = {
-            className: "number",
-            relevance: 0,
-            variants: [
-              {
-                match: `\\b(${n})(\\.(${n}))?([eE][+-]?(${n}))?\\b`,
-              },
-              {
-                match: `\\b0[xX]_*(${t})(\\.(${t}))?([pP][+-]?(${n}))?\\b`,
-              },
-              {
-                match: "\\b0[oO](([0-7]_*)+)\\b",
-              },
-              { match: "\\b0[bB](([01]_*)+)\\b" },
-            ],
-          };
-        return {
-          name: "Haskell",
-          aliases: ["hs"],
-          keywords:
-            "let in if then else case of where do module import hiding qualified type data newtype deriving class instance as default infix infixl infixr foreign export ccall stdcall cplusplus jvm dotnet safe unsafe family forall mdo proc rec",
-          unicodeRegex: !0,
-          contains: [
-            {
-              beginKeywords: "module",
-              end: "where",
-              keywords: "module where",
-              contains: [c, a],
-              illegal: "\\W\\.|;",
-            },
-            {
-              begin: "\\bimport\\b",
-              end: "$",
-              keywords: "import qualified as hiding",
-              contains: [c, a],
-              illegal: "\\W\\.|;",
-            },
-            {
-              className: "class",
-              begin: "^(\\s*)?(class|instance)\\b",
-              end: "where",
-              keywords: "class family instance where",
-              contains: [o, c, a],
-            },
-            {
-              className: "class",
-              begin: "\\b(data|(new)?type)\\b",
-              end: "$",
-              keywords: "data family type newtype deriving",
-              contains: [
-                i,
-                o,
                 c,
-                { begin: /\{/, end: /\}/, contains: c.contains },
-                a,
               ],
             },
-            { beginKeywords: "default", end: "$", contains: [o, c, a] },
             {
-              beginKeywords: "infix infixl infixr",
-              end: "$",
-              contains: [e.C_NUMBER_MODE, a],
+              className: "class",
+              beginKeywords: "class interface trait",
+              end: /[:\{(]|$/,
+              excludeEnd: !0,
+              illegal: "extends implements",
+              contains: [
+                {
+                  beginKeywords:
+                    "public protected internal private constructor",
+                },
+                e.UNDERSCORE_TITLE_MODE,
+                {
+                  className: "type",
+                  begin: /</,
+                  end: />/,
+                  excludeBegin: !0,
+                  excludeEnd: !0,
+                  relevance: 0,
+                },
+                {
+                  className: "type",
+                  begin: /[,:]\s*/,
+                  end: /[<\(,]|$/,
+                  excludeBegin: !0,
+                  returnEnd: !0,
+                },
+                r,
+                l,
+              ],
             },
-            {
-              begin: "\\bforeign\\b",
-              end: "$",
-              keywords:
-                "foreign import export ccall stdcall cplusplus jvm dotnet safe unsafe",
-              contains: [o, e.QUOTE_STRING_MODE, a],
-            },
+            t,
             {
               className: "meta",
-              begin: "#!\\/usr\\/bin\\/env runhaskell",
+              begin: "^#!/usr/bin/env",
               end: "$",
+              illegal: "\n",
             },
-            i,
-            r,
             {
-              scope: "string",
-              begin: /'(?=\\?.')/,
-              end: /'/,
-              contains: [{ scope: "char.escape", match: /\\./ }],
+              className: "number",
+              begin:
+                "\\b(0[bB]([01]+[01_]+[01]+|[01]+)|0[xX]([a-fA-F0-9]+[a-fA-F0-9_]+[a-fA-F0-9]+|[a-fA-F0-9]+)|(([\\d]+[\\d_]+[\\d]+|[\\d]+)(\\.([\\d]+[\\d_]+[\\d]+|[\\d]+))?|\\.([\\d]+[\\d_]+[\\d]+|[\\d]+))([eE][-+]?\\d+)?)[lLfF]?",
+              relevance: 0,
             },
-            e.QUOTE_STRING_MODE,
-            l,
-            o,
-            e.inherit(e.TITLE_MODE, { begin: "^[_a-z][\\w']*" }),
-            {
-              begin: `(?!-)${s}--+|--+(?!-)${s}`,
-            },
-            a,
-            { begin: "->|<-" },
           ],
-        };
-      },
-      grmr_http: (e) => {
-        const n = "HTTP/([32]|1\\.[01])",
-          t = {
-            className: "attribute",
-            begin: e.regex.concat("^", /[A-Za-z][A-Za-z0-9-]*/, "(?=\\:\\s)"),
-            starts: {
-              contains: [
-                {
-                  className: "punctuation",
-                  begin: /: /,
-                  relevance: 0,
-                  starts: { end: "$", relevance: 0 },
-                },
-              ],
-            },
-          },
-          s = [
-            t,
-            { begin: "\\n\\n", starts: { subLanguage: [], endsWithParent: !0 } },
-          ];
-        return {
-          name: "HTTP",
-          aliases: ["https"],
-          illegal: /\S/,
+        }
+      );
+    };
+  })()
+);
+hljs.registerLanguage(
+  "less",
+  (function () {
+    "use strict";
+    return function (e) {
+      var n = "([\\w-]+|@{[\\w-]+})",
+        a = [],
+        s = [],
+        t = function (e) {
+          return { className: "string", begin: "~?" + e + ".*?" + e };
+        },
+        r = function (e, n, a) {
+          return { className: e, begin: n, relevance: a };
+        },
+        i = { begin: "\\(", end: "\\)", contains: s, relevance: 0 };
+      s.push(
+        e.C_LINE_COMMENT_MODE,
+        e.C_BLOCK_COMMENT_MODE,
+        t("'"),
+        t('"'),
+        e.CSS_NUMBER_MODE,
+        {
+          begin: "(url|data-uri)\\(",
+          starts: { className: "string", end: "[\\)\\n]", excludeEnd: !0 },
+        },
+        r("number", "#[0-9A-Fa-f]+\\b"),
+        i,
+        r("variable", "@@?[\\w-]+", 10),
+        r("variable", "@{[\\w-]+}"),
+        r("built_in", "~?`[^`]*?`"),
+        {
+          className: "attribute",
+          begin: "[\\w-]+\\s*:",
+          end: ":",
+          returnBegin: !0,
+          excludeEnd: !0,
+        },
+        { className: "meta", begin: "!important" }
+      );
+      var c = s.concat({ begin: "{", end: "}", contains: a }),
+        l = {
+          beginKeywords: "when",
+          endsWithParent: !0,
+          contains: [{ beginKeywords: "and not" }].concat(s),
+        },
+        o = {
+          begin: n + "\\s*:",
+          returnBegin: !0,
+          end: "[;}]",
+          relevance: 0,
           contains: [
             {
-              begin: "^(?=" + n + " \\d{3})",
-              end: /$/,
-              contains: [
-                { className: "meta", begin: n },
-                {
-                  className: "number",
-                  begin: "\\b\\d{3}\\b",
-                },
-              ],
-              starts: { end: /\b\B/, illegal: /\S/, contains: s },
+              className: "attribute",
+              begin: n,
+              end: ":",
+              excludeEnd: !0,
+              starts: {
+                endsWithParent: !0,
+                illegal: "[<=$]",
+                relevance: 0,
+                contains: s,
+              },
             },
+          ],
+        },
+        g = {
+          className: "keyword",
+          begin:
+            "@(import|media|charset|font-face|(-[a-z]+-)?keyframes|supports|document|namespace|page|viewport|host)\\b",
+          starts: { end: "[;{}]", returnEnd: !0, contains: s, relevance: 0 },
+        },
+        d = {
+          className: "variable",
+          variants: [
+            { begin: "@[\\w-]+\\s*:", relevance: 15 },
+            { begin: "@[\\w-]+" },
+          ],
+          starts: { end: "[;}]", returnEnd: !0, contains: c },
+        },
+        b = {
+          variants: [
+            { begin: "[\\.#:&\\[>]", end: "[;{}]" },
+            { begin: n, end: "{" },
+          ],
+          returnBegin: !0,
+          returnEnd: !0,
+          illegal: "[<='$\"]",
+          relevance: 0,
+          contains: [
+            e.C_LINE_COMMENT_MODE,
+            e.C_BLOCK_COMMENT_MODE,
+            l,
+            r("keyword", "all\\b"),
+            r("variable", "@{[\\w-]+}"),
+            r("selector-tag", n + "%?", 0),
+            r("selector-id", "#" + n),
+            r("selector-class", "\\." + n, 0),
+            r("selector-tag", "&", 0),
+            { className: "selector-attr", begin: "\\[", end: "\\]" },
             {
-              begin: "(?=^[A-Z]+ (.*?) " + n + "$)",
-              end: /$/,
+              className: "selector-pseudo",
+              begin: /:(:)?[a-zA-Z0-9\_\-\+\(\)"'.]+/,
+            },
+            { begin: "\\(", end: "\\)", contains: c },
+            { begin: "!important" },
+          ],
+        };
+      return (
+        a.push(e.C_LINE_COMMENT_MODE, e.C_BLOCK_COMMENT_MODE, g, d, o, b),
+        {
+          name: "Less",
+          case_insensitive: !0,
+          illegal: "[=>'/<($\"]",
+          contains: a,
+        }
+      );
+    };
+  })()
+);
+hljs.registerLanguage(
+  "lua",
+  (function () {
+    "use strict";
+    return function (e) {
+      var t = { begin: "\\[=*\\[", end: "\\]=*\\]", contains: ["self"] },
+        a = [
+          e.COMMENT("--(?!\\[=*\\[)", "$"),
+          e.COMMENT("--\\[=*\\[", "\\]=*\\]", { contains: [t], relevance: 10 }),
+        ];
+      return {
+        name: "Lua",
+        keywords: {
+          $pattern: e.UNDERSCORE_IDENT_RE,
+          literal: "true false nil",
+          keyword:
+            "and break do else elseif end for goto if in local not or repeat return then until while",
+          built_in:
+            "_G _ENV _VERSION __index __newindex __mode __call __metatable __tostring __len __gc __add __sub __mul __div __mod __pow __concat __unm __eq __lt __le assert collectgarbage dofile error getfenv getmetatable ipairs load loadfile loadstring module next pairs pcall print rawequal rawget rawset require select setfenv setmetatable tonumber tostring type unpack xpcall arg self coroutine resume yield status wrap create running debug getupvalue debug sethook getmetatable gethook setmetatable setlocal traceback setfenv getinfo setupvalue getlocal getregistry getfenv io lines write close flush open output type read stderr stdin input stdout popen tmpfile math log max acos huge ldexp pi cos tanh pow deg tan cosh sinh random randomseed frexp ceil floor rad abs sqrt modf asin min mod fmod log10 atan2 exp sin atan os exit setlocale date getenv difftime remove time clock tmpname rename execute package preload loadlib loaded loaders cpath config path seeall string sub upper len gfind rep find match char dump gmatch reverse byte format gsub lower table setn insert getn foreachi maxn foreach concat sort remove",
+        },
+        contains: a.concat([
+          {
+            className: "function",
+            beginKeywords: "function",
+            end: "\\)",
+            contains: [
+              e.inherit(e.TITLE_MODE, {
+                begin: "([_a-zA-Z]\\w*\\.)*([_a-zA-Z]\\w*:)?[_a-zA-Z]\\w*",
+              }),
+              {
+                className: "params",
+                begin: "\\(",
+                endsWithParent: !0,
+                contains: a,
+              },
+            ].concat(a),
+          },
+          e.C_NUMBER_MODE,
+          e.APOS_STRING_MODE,
+          e.QUOTE_STRING_MODE,
+          {
+            className: "string",
+            begin: "\\[=*\\[",
+            end: "\\]=*\\]",
+            contains: [t],
+            relevance: 5,
+          },
+        ]),
+      };
+    };
+  })()
+);
+hljs.registerLanguage(
+  "makefile",
+  (function () {
+    "use strict";
+    return function (e) {
+      var i = {
+          className: "variable",
+          variants: [
+            {
+              begin: "\\$\\(" + e.UNDERSCORE_IDENT_RE + "\\)",
+              contains: [e.BACKSLASH_ESCAPE],
+            },
+            { begin: /\$[@%<?\^\+\*]/ },
+          ],
+        },
+        n = {
+          className: "string",
+          begin: /"/,
+          end: /"/,
+          contains: [e.BACKSLASH_ESCAPE, i],
+        },
+        a = {
+          className: "variable",
+          begin: /\$\([\w-]+\s/,
+          end: /\)/,
+          keywords: {
+            built_in:
+              "subst patsubst strip findstring filter filter-out sort word wordlist firstword lastword dir notdir suffix basename addsuffix addprefix join wildcard realpath abspath error warning shell origin flavor foreach if or and call eval file value",
+          },
+          contains: [i],
+        },
+        r = { begin: "^" + e.UNDERSCORE_IDENT_RE + "\\s*(?=[:+?]?=)" },
+        s = {
+          className: "section",
+          begin: /^[^\s]+:/,
+          end: /$/,
+          contains: [i],
+        };
+      return {
+        name: "Makefile",
+        aliases: ["mk", "mak"],
+        keywords: {
+          $pattern: /[\w-]+/,
+          keyword:
+            "define endef undefine ifdef ifndef ifeq ifneq else endif include -include sinclude override export unexport private vpath",
+        },
+        contains: [
+          e.HASH_COMMENT_MODE,
+          i,
+          n,
+          a,
+          r,
+          {
+            className: "meta",
+            begin: /^\.PHONY:/,
+            end: /$/,
+            keywords: { $pattern: /[\.\w]+/, "meta-keyword": ".PHONY" },
+          },
+          s,
+        ],
+      };
+    };
+  })()
+);
+hljs.registerLanguage(
+  "xml",
+  (function () {
+    "use strict";
+    return function (e) {
+      var n = {
+          className: "symbol",
+          begin: "&[a-z]+;|&#[0-9]+;|&#x[a-f0-9]+;",
+        },
+        a = {
+          begin: "\\s",
+          contains: [
+            {
+              className: "meta-keyword",
+              begin: "#?[a-z_][a-z1-9_-]+",
+              illegal: "\\n",
+            },
+          ],
+        },
+        s = e.inherit(a, { begin: "\\(", end: "\\)" }),
+        t = e.inherit(e.APOS_STRING_MODE, { className: "meta-string" }),
+        i = e.inherit(e.QUOTE_STRING_MODE, { className: "meta-string" }),
+        c = {
+          endsWithParent: !0,
+          illegal: /</,
+          relevance: 0,
+          contains: [
+            { className: "attr", begin: "[A-Za-z0-9\\._:-]+", relevance: 0 },
+            {
+              begin: /=\s*/,
+              relevance: 0,
               contains: [
                 {
                   className: "string",
-                  begin: " ",
-                  end: " ",
+                  endsParent: !0,
+                  variants: [
+                    { begin: /"/, end: /"/, contains: [n] },
+                    { begin: /'/, end: /'/, contains: [n] },
+                    { begin: /[^\s"'=<>`]+/ },
+                  ],
+                },
+              ],
+            },
+          ],
+        };
+      return {
+        name: "HTML, XML",
+        aliases: [
+          "html",
+          "xhtml",
+          "rss",
+          "atom",
+          "xjb",
+          "xsd",
+          "xsl",
+          "plist",
+          "wsf",
+          "svg",
+        ],
+        case_insensitive: !0,
+        contains: [
+          {
+            className: "meta",
+            begin: "<![a-z]",
+            end: ">",
+            relevance: 10,
+            contains: [
+              a,
+              i,
+              t,
+              s,
+              {
+                begin: "\\[",
+                end: "\\]",
+                contains: [
+                  {
+                    className: "meta",
+                    begin: "<![a-z]",
+                    end: ">",
+                    contains: [a, s, i, t],
+                  },
+                ],
+              },
+            ],
+          },
+          e.COMMENT("\x3c!--", "--\x3e", { relevance: 10 }),
+          { begin: "<\\!\\[CDATA\\[", end: "\\]\\]>", relevance: 10 },
+          n,
+          { className: "meta", begin: /<\?xml/, end: /\?>/, relevance: 10 },
+          {
+            className: "tag",
+            begin: "<style(?=\\s|>)",
+            end: ">",
+            keywords: { name: "style" },
+            contains: [c],
+            starts: {
+              end: "</style>",
+              returnEnd: !0,
+              subLanguage: ["css", "xml"],
+            },
+          },
+          {
+            className: "tag",
+            begin: "<script(?=\\s|>)",
+            end: ">",
+            keywords: { name: "script" },
+            contains: [c],
+            starts: {
+              end: "</script>",
+              returnEnd: !0,
+              subLanguage: ["javascript", "handlebars", "xml"],
+            },
+          },
+          {
+            className: "tag",
+            begin: "</?",
+            end: "/?>",
+            contains: [
+              { className: "name", begin: /[^\/><\s]+/, relevance: 0 },
+              c,
+            ],
+          },
+        ],
+      };
+    };
+  })()
+);
+hljs.registerLanguage(
+  "markdown",
+  (function () {
+    "use strict";
+    return function (n) {
+      const e = { begin: "<", end: ">", subLanguage: "xml", relevance: 0 },
+        a = {
+          begin: "\\[.+?\\][\\(\\[].*?[\\)\\]]",
+          returnBegin: !0,
+          contains: [
+            {
+              className: "string",
+              begin: "\\[",
+              end: "\\]",
+              excludeBegin: !0,
+              returnEnd: !0,
+              relevance: 0,
+            },
+            {
+              className: "link",
+              begin: "\\]\\(",
+              end: "\\)",
+              excludeBegin: !0,
+              excludeEnd: !0,
+            },
+            {
+              className: "symbol",
+              begin: "\\]\\[",
+              end: "\\]",
+              excludeBegin: !0,
+              excludeEnd: !0,
+            },
+          ],
+          relevance: 10,
+        },
+        i = {
+          className: "strong",
+          contains: [],
+          variants: [
+            { begin: /_{2}/, end: /_{2}/ },
+            { begin: /\*{2}/, end: /\*{2}/ },
+          ],
+        },
+        s = {
+          className: "emphasis",
+          contains: [],
+          variants: [
+            { begin: /\*(?!\*)/, end: /\*/ },
+            { begin: /_(?!_)/, end: /_/, relevance: 0 },
+          ],
+        };
+      i.contains.push(s), s.contains.push(i);
+      var c = [e, a];
+      return (
+        (i.contains = i.contains.concat(c)),
+        (s.contains = s.contains.concat(c)),
+        {
+          name: "Markdown",
+          aliases: ["md", "mkdown", "mkd"],
+          contains: [
+            {
+              className: "section",
+              variants: [
+                { begin: "^#{1,6}", end: "$", contains: (c = c.concat(i, s)) },
+                {
+                  begin: "(?=^.+?\\n[=-]{2,}$)",
+                  contains: [
+                    { begin: "^[=-]*$" },
+                    { begin: "^", end: "\\n", contains: c },
+                  ],
+                },
+              ],
+            },
+            e,
+            {
+              className: "bullet",
+              begin: "^[ \t]*([*+-]|(\\d+\\.))(?=\\s+)",
+              end: "\\s+",
+              excludeEnd: !0,
+            },
+            i,
+            s,
+            { className: "quote", begin: "^>\\s+", contains: c, end: "$" },
+            {
+              className: "code",
+              variants: [
+                { begin: "(`{3,})(.|\\n)*?\\1`*[ ]*" },
+                { begin: "(~{3,})(.|\\n)*?\\1~*[ ]*" },
+                { begin: "```", end: "```+[ ]*$" },
+                { begin: "~~~", end: "~~~+[ ]*$" },
+                { begin: "`.+?`" },
+                {
+                  begin: "(?=^( {4}|\\t))",
+                  contains: [{ begin: "^( {4}|\\t)", end: "(\\n)$" }],
+                  relevance: 0,
+                },
+              ],
+            },
+            { begin: "^[-\\*]{3,}", end: "$" },
+            a,
+            {
+              begin: /^\[[^\n]+\]:/,
+              returnBegin: !0,
+              contains: [
+                {
+                  className: "symbol",
+                  begin: /\[/,
+                  end: /\]/,
                   excludeBegin: !0,
                   excludeEnd: !0,
                 },
                 {
-                  className: "meta",
-                  begin: n,
+                  className: "link",
+                  begin: /:\s*/,
+                  end: /$/,
+                  excludeBegin: !0,
                 },
-                { className: "keyword", begin: "[A-Z]+" },
               ],
-              starts: {
-                end: /\b\B/,
-                illegal: /\S/,
-                contains: s,
-              },
             },
-            e.inherit(t, { relevance: 0 }),
           ],
-        };
-      },
-      grmr_ini: (e) => {
-        const n = e.regex,
-          t = {
-            className: "number",
-            relevance: 0,
-            variants: [
-              {
-                begin: /([+-]+)?[\d]+_[\d_]+/,
-              },
-              { begin: e.NUMBER_RE },
-            ],
+        }
+      );
+    };
+  })()
+);
+hljs.registerLanguage(
+  "nginx",
+  (function () {
+    "use strict";
+    return function (e) {
+      var n = {
+          className: "variable",
+          variants: [
+            { begin: /\$\d+/ },
+            { begin: /\$\{/, end: /}/ },
+            { begin: "[\\$\\@]" + e.UNDERSCORE_IDENT_RE },
+          ],
+        },
+        a = {
+          endsWithParent: !0,
+          keywords: {
+            $pattern: "[a-z/_]+",
+            literal:
+              "on off yes no true false none blocked debug info notice warn error crit select break last permanent redirect kqueue rtsig epoll poll /dev/poll",
           },
-          s = e.COMMENT();
-        s.variants = [
-          {
-            begin: /;/,
-            end: /$/,
-          },
-          { begin: /#/, end: /$/ },
-        ];
-        const a = {
-            className: "variable",
-            variants: [{ begin: /\$[\w\d"][\w\d_]*/ }, { begin: /\$\{(.*?)\}/ }],
-          },
-          i = {
-            className: "literal",
-            begin: /\bon|off|true|false|yes|no\b/,
-          },
-          r = {
-            className: "string",
-            contains: [e.BACKSLASH_ESCAPE],
-            variants: [
-              { begin: "'''", end: "'''", relevance: 10 },
-              {
-                begin: '"""',
-                end: '"""',
-                relevance: 10,
-              },
-              { begin: '"', end: '"' },
-              { begin: "'", end: "'" },
-            ],
-          },
-          o = {
-            begin: /\[/,
-            end: /\]/,
-            contains: [s, i, a, r, t, "self"],
-            relevance: 0,
-          },
-          c = n.either(/[A-Za-z0-9_-]+/, /"(\\"|[^"])*"/, /'[^']*'/);
-        return {
-          name: "TOML, also INI",
-          aliases: ["toml"],
-          case_insensitive: !0,
-          illegal: /\S/,
+          relevance: 0,
+          illegal: "=>",
           contains: [
-            s,
-            { className: "section", begin: /\[+/, end: /\]+/ },
+            e.HASH_COMMENT_MODE,
             {
-              begin: n.concat(
-                c,
-                "(\\s*\\.\\s*",
-                c,
-                ")*",
-                n.lookahead(/\s*=\s*[^#\s]/)
-              ),
-              className: "attr",
-              starts: { end: /$/, contains: [s, o, i, a, r, t] },
+              className: "string",
+              contains: [e.BACKSLASH_ESCAPE, n],
+              variants: [
+                { begin: /"/, end: /"/ },
+                { begin: /'/, end: /'/ },
+              ],
             },
+            {
+              begin: "([a-z]+):/",
+              end: "\\s",
+              endsWithParent: !0,
+              excludeEnd: !0,
+              contains: [n],
+            },
+            {
+              className: "regexp",
+              contains: [e.BACKSLASH_ESCAPE, n],
+              variants: [
+                { begin: "\\s\\^", end: "\\s|{|;", returnEnd: !0 },
+                { begin: "~\\*?\\s+", end: "\\s|{|;", returnEnd: !0 },
+                { begin: "\\*(\\.[a-z\\-]+)+" },
+                { begin: "([a-z\\-]+\\.)+\\*" },
+              ],
+            },
+            {
+              className: "number",
+              begin:
+                "\\b\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}(:\\d{1,5})?\\b",
+            },
+            {
+              className: "number",
+              begin: "\\b\\d+[kKmMgGdshdwy]*\\b",
+              relevance: 0,
+            },
+            n,
           ],
         };
-      },
-      grmr_java: (e) => {
-        const n = e.regex,
-          t = "[\xc0-\u02b8a-zA-Z_$][\xc0-\u02b8a-zA-Z_$0-9]*",
-          s = t + be("(?:<" + t + "~~~(?:\\s*,\\s*" + t + "~~~)*>)?", /~~~/g, 2),
-          a = {
-            keyword: [
-              "synchronized",
-              "abstract",
-              "private",
-              "var",
-              "static",
-              "if",
-              "const ",
-              "for",
-              "while",
-              "strictfp",
-              "finally",
-              "protected",
-              "import",
-              "native",
-              "final",
-              "void",
-              "enum",
-              "else",
-              "break",
-              "transient",
-              "catch",
-              "instanceof",
-              "volatile",
-              "case",
-              "assert",
-              "package",
-              "default",
-              "public",
-              "try",
-              "switch",
-              "continue",
-              "throws",
-              "protected",
-              "public",
-              "private",
-              "module",
-              "requires",
-              "exports",
-              "do",
-              "sealed",
-              "yield",
-              "permits",
-              "goto",
-              "when",
-            ],
-            literal: ["false", "true", "null"],
-            type: [
-              "char",
-              "boolean",
-              "long",
-              "float",
-              "int",
-              "byte",
-              "short",
-              "double",
-            ],
-            built_in: ["super", "this"],
+      return {
+        name: "Nginx config",
+        aliases: ["nginxconf"],
+        contains: [
+          e.HASH_COMMENT_MODE,
+          {
+            begin: e.UNDERSCORE_IDENT_RE + "\\s+{",
+            returnBegin: !0,
+            end: "{",
+            contains: [{ className: "section", begin: e.UNDERSCORE_IDENT_RE }],
+            relevance: 0,
           },
-          i = {
-            className: "meta",
-            begin: "@" + t,
+          {
+            begin: e.UNDERSCORE_IDENT_RE + "\\s",
+            end: ";|{",
+            returnBegin: !0,
             contains: [
               {
-                begin: /\(/,
-                end: /\)/,
-                contains: ["self"],
+                className: "attribute",
+                begin: e.UNDERSCORE_IDENT_RE,
+                starts: a,
+              },
+            ],
+            relevance: 0,
+          },
+        ],
+        illegal: "[^\\s\\}]",
+      };
+    };
+  })()
+);
+hljs.registerLanguage(
+  "objectivec",
+  (function () {
+    "use strict";
+    return function (e) {
+      var n = /[a-zA-Z@][a-zA-Z0-9_]*/,
+        _ = {
+          $pattern: n,
+          keyword: "@interface @class @protocol @implementation",
+        };
+      return {
+        name: "Objective-C",
+        aliases: ["mm", "objc", "obj-c"],
+        keywords: {
+          $pattern: n,
+          keyword:
+            "int float while char export sizeof typedef const struct for union unsigned long volatile static bool mutable if do return goto void enum else break extern asm case short default double register explicit signed typename this switch continue wchar_t inline readonly assign readwrite self @synchronized id typeof nonatomic super unichar IBOutlet IBAction strong weak copy in out inout bycopy byref oneway __strong __weak __block __autoreleasing @private @protected @public @try @property @end @throw @catch @finally @autoreleasepool @synthesize @dynamic @selector @optional @required @encode @package @import @defs @compatibility_alias __bridge __bridge_transfer __bridge_retained __bridge_retain __covariant __contravariant __kindof _Nonnull _Nullable _Null_unspecified __FUNCTION__ __PRETTY_FUNCTION__ __attribute__ getter setter retain unsafe_unretained nonnull nullable null_unspecified null_resettable class instancetype NS_DESIGNATED_INITIALIZER NS_UNAVAILABLE NS_REQUIRES_SUPER NS_RETURNS_INNER_POINTER NS_INLINE NS_AVAILABLE NS_DEPRECATED NS_ENUM NS_OPTIONS NS_SWIFT_UNAVAILABLE NS_ASSUME_NONNULL_BEGIN NS_ASSUME_NONNULL_END NS_REFINED_FOR_SWIFT NS_SWIFT_NAME NS_SWIFT_NOTHROW NS_DURING NS_HANDLER NS_ENDHANDLER NS_VALUERETURN NS_VOIDRETURN",
+          literal: "false true FALSE TRUE nil YES NO NULL",
+          built_in:
+            "BOOL dispatch_once_t dispatch_queue_t dispatch_sync dispatch_async dispatch_once",
+        },
+        illegal: "</",
+        contains: [
+          {
+            className: "built_in",
+            begin:
+              "\\b(AV|CA|CF|CG|CI|CL|CM|CN|CT|MK|MP|MTK|MTL|NS|SCN|SK|UI|WK|XC)\\w+",
+          },
+          e.C_LINE_COMMENT_MODE,
+          e.C_BLOCK_COMMENT_MODE,
+          e.C_NUMBER_MODE,
+          e.QUOTE_STRING_MODE,
+          e.APOS_STRING_MODE,
+          {
+            className: "string",
+            variants: [
+              {
+                begin: '@"',
+                end: '"',
+                illegal: "\\n",
+                contains: [e.BACKSLASH_ESCAPE],
               },
             ],
           },
-          r = {
-            className: "params",
-            begin: /\(/,
-            end: /\)/,
-            keywords: a,
-            relevance: 0,
-            contains: [e.C_BLOCK_COMMENT_MODE],
-            endsParent: !0,
-          };
-        return {
-          name: "Java",
-          aliases: ["jsp"],
-          keywords: a,
-          illegal: /<\/|#/,
-          contains: [
-            e.COMMENT("/\\*\\*", "\\*/", {
-              relevance: 0,
-              contains: [
-                { begin: /\w+@/, relevance: 0 },
-                { className: "doctag", begin: "@[A-Za-z]+" },
-              ],
-            }),
-            {
-              begin: /import java\.[a-z]+\./,
-              keywords: "import",
-              relevance: 2,
+          {
+            className: "meta",
+            begin: /#\s*[a-z]+\b/,
+            end: /$/,
+            keywords: {
+              "meta-keyword":
+                "if else elif endif define undef warning error line pragma ifdef ifndef include",
             },
-            e.C_LINE_COMMENT_MODE,
-            e.C_BLOCK_COMMENT_MODE,
+            contains: [
+              { begin: /\\\n/, relevance: 0 },
+              e.inherit(e.QUOTE_STRING_MODE, { className: "meta-string" }),
+              {
+                className: "meta-string",
+                begin: /<.*?>/,
+                end: /$/,
+                illegal: "\\n",
+              },
+              e.C_LINE_COMMENT_MODE,
+              e.C_BLOCK_COMMENT_MODE,
+            ],
+          },
+          {
+            className: "class",
+            begin: "(" + _.keyword.split(" ").join("|") + ")\\b",
+            end: "({|$)",
+            excludeEnd: !0,
+            keywords: _,
+            contains: [e.UNDERSCORE_TITLE_MODE],
+          },
+          { begin: "\\." + e.UNDERSCORE_IDENT_RE, relevance: 0 },
+        ],
+      };
+    };
+  })()
+);
+hljs.registerLanguage(
+  "perl",
+  (function () {
+    "use strict";
+    return function (e) {
+      var n = {
+          $pattern: /[\w.]+/,
+          keyword:
+            "getpwent getservent quotemeta msgrcv scalar kill dbmclose undef lc ma syswrite tr send umask sysopen shmwrite vec qx utime local oct semctl localtime readpipe do return format read sprintf dbmopen pop getpgrp not getpwnam rewinddir qq fileno qw endprotoent wait sethostent bless s|0 opendir continue each sleep endgrent shutdown dump chomp connect getsockname die socketpair close flock exists index shmget sub for endpwent redo lstat msgctl setpgrp abs exit select print ref gethostbyaddr unshift fcntl syscall goto getnetbyaddr join gmtime symlink semget splice x|0 getpeername recv log setsockopt cos last reverse gethostbyname getgrnam study formline endhostent times chop length gethostent getnetent pack getprotoent getservbyname rand mkdir pos chmod y|0 substr endnetent printf next open msgsnd readdir use unlink getsockopt getpriority rindex wantarray hex system getservbyport endservent int chr untie rmdir prototype tell listen fork shmread ucfirst setprotoent else sysseek link getgrgid shmctl waitpid unpack getnetbyname reset chdir grep split require caller lcfirst until warn while values shift telldir getpwuid my getprotobynumber delete and sort uc defined srand accept package seekdir getprotobyname semop our rename seek if q|0 chroot sysread setpwent no crypt getc chown sqrt write setnetent setpriority foreach tie sin msgget map stat getlogin unless elsif truncate exec keys glob tied closedir ioctl socket readlink eval xor readline binmode setservent eof ord bind alarm pipe atan2 getgrent exp time push setgrent gt lt or ne m|0 break given say state when",
+        },
+        t = { className: "subst", begin: "[$@]\\{", end: "\\}", keywords: n },
+        s = { begin: "->{", end: "}" },
+        r = {
+          variants: [
+            { begin: /\$\d/ },
+            { begin: /[\$%@](\^\w\b|#\w+(::\w+)*|{\w+}|\w+(::\w*)*)/ },
+            { begin: /[\$%@][^\s\w{]/, relevance: 0 },
+          ],
+        },
+        i = [e.BACKSLASH_ESCAPE, t, r],
+        a = [
+          r,
+          e.HASH_COMMENT_MODE,
+          e.COMMENT("^\\=\\w", "\\=cut", { endsWithParent: !0 }),
+          s,
+          {
+            className: "string",
+            contains: i,
+            variants: [
+              { begin: "q[qwxr]?\\s*\\(", end: "\\)", relevance: 5 },
+              { begin: "q[qwxr]?\\s*\\[", end: "\\]", relevance: 5 },
+              { begin: "q[qwxr]?\\s*\\{", end: "\\}", relevance: 5 },
+              { begin: "q[qwxr]?\\s*\\|", end: "\\|", relevance: 5 },
+              { begin: "q[qwxr]?\\s*\\<", end: "\\>", relevance: 5 },
+              { begin: "qw\\s+q", end: "q", relevance: 5 },
+              { begin: "'", end: "'", contains: [e.BACKSLASH_ESCAPE] },
+              { begin: '"', end: '"' },
+              { begin: "`", end: "`", contains: [e.BACKSLASH_ESCAPE] },
+              { begin: "{\\w+}", contains: [], relevance: 0 },
+              { begin: "-?\\w+\\s*\\=\\>", contains: [], relevance: 0 },
+            ],
+          },
+          {
+            className: "number",
+            begin:
+              "(\\b0[0-7_]+)|(\\b0x[0-9a-fA-F_]+)|(\\b[1-9][0-9_]*(\\.[0-9_]+)?)|[0_]\\b",
+            relevance: 0,
+          },
+          {
+            begin:
+              "(\\/\\/|" +
+              e.RE_STARTERS_RE +
+              "|\\b(split|return|print|reverse|grep)\\b)\\s*",
+            keywords: "split return print reverse grep",
+            relevance: 0,
+            contains: [
+              e.HASH_COMMENT_MODE,
+              {
+                className: "regexp",
+                begin: "(s|tr|y)/(\\\\.|[^/])*/(\\\\.|[^/])*/[a-z]*",
+                relevance: 10,
+              },
+              {
+                className: "regexp",
+                begin: "(m|qr)?/",
+                end: "/[a-z]*",
+                contains: [e.BACKSLASH_ESCAPE],
+                relevance: 0,
+              },
+            ],
+          },
+          {
+            className: "function",
+            beginKeywords: "sub",
+            end: "(\\s*\\(.*?\\))?[;{]",
+            excludeEnd: !0,
+            relevance: 5,
+            contains: [e.TITLE_MODE],
+          },
+          { begin: "-\\w\\b", relevance: 0 },
+          {
+            begin: "^__DATA__$",
+            end: "^__END__$",
+            subLanguage: "mojolicious",
+            contains: [{ begin: "^@@.*", end: "$", className: "comment" }],
+          },
+        ];
+      return (
+        (t.contains = a),
+        (s.contains = a),
+        { name: "Perl", aliases: ["pl", "pm"], keywords: n, contains: a }
+      );
+    };
+  })()
+);
+hljs.registerLanguage(
+  "php",
+  (function () {
+    "use strict";
+    return function (e) {
+      var r = { begin: "\\$+[a-zA-Z_-ÿ][a-zA-Z0-9_-ÿ]*" },
+        t = {
+          className: "meta",
+          variants: [
+            { begin: /<\?php/, relevance: 10 },
+            { begin: /<\?[=]?/ },
+            { begin: /\?>/ },
+          ],
+        },
+        a = {
+          className: "string",
+          contains: [e.BACKSLASH_ESCAPE, t],
+          variants: [
+            { begin: 'b"', end: '"' },
+            { begin: "b'", end: "'" },
+            e.inherit(e.APOS_STRING_MODE, { illegal: null }),
+            e.inherit(e.QUOTE_STRING_MODE, { illegal: null }),
+          ],
+        },
+        n = { variants: [e.BINARY_NUMBER_MODE, e.C_NUMBER_MODE] },
+        i = {
+          keyword:
+            "__CLASS__ __DIR__ __FILE__ __FUNCTION__ __LINE__ __METHOD__ __NAMESPACE__ __TRAIT__ die echo exit include include_once print require require_once array abstract and as binary bool boolean break callable case catch class clone const continue declare default do double else elseif empty enddeclare endfor endforeach endif endswitch endwhile eval extends final finally float for foreach from global goto if implements instanceof insteadof int integer interface isset iterable list new object or private protected public real return string switch throw trait try unset use var void while xor yield",
+          literal: "false null true",
+          built_in:
+            "Error|0 AppendIterator ArgumentCountError ArithmeticError ArrayIterator ArrayObject AssertionError BadFunctionCallException BadMethodCallException CachingIterator CallbackFilterIterator CompileError Countable DirectoryIterator DivisionByZeroError DomainException EmptyIterator ErrorException Exception FilesystemIterator FilterIterator GlobIterator InfiniteIterator InvalidArgumentException IteratorIterator LengthException LimitIterator LogicException MultipleIterator NoRewindIterator OutOfBoundsException OutOfRangeException OuterIterator OverflowException ParentIterator ParseError RangeException RecursiveArrayIterator RecursiveCachingIterator RecursiveCallbackFilterIterator RecursiveDirectoryIterator RecursiveFilterIterator RecursiveIterator RecursiveIteratorIterator RecursiveRegexIterator RecursiveTreeIterator RegexIterator RuntimeException SeekableIterator SplDoublyLinkedList SplFileInfo SplFileObject SplFixedArray SplHeap SplMaxHeap SplMinHeap SplObjectStorage SplObserver SplObserver SplPriorityQueue SplQueue SplStack SplSubject SplSubject SplTempFileObject TypeError UnderflowException UnexpectedValueException ArrayAccess Closure Generator Iterator IteratorAggregate Serializable Throwable Traversable WeakReference Directory __PHP_Incomplete_Class parent php_user_filter self static stdClass",
+        };
+      return {
+        aliases: ["php", "php3", "php4", "php5", "php6", "php7"],
+        case_insensitive: !0,
+        keywords: i,
+        contains: [
+          e.HASH_COMMENT_MODE,
+          e.COMMENT("//", "$", { contains: [t] }),
+          e.COMMENT("/\\*", "\\*/", {
+            contains: [{ className: "doctag", begin: "@[A-Za-z]+" }],
+          }),
+          e.COMMENT("__halt_compiler.+?;", !1, {
+            endsWithParent: !0,
+            keywords: "__halt_compiler",
+          }),
+          {
+            className: "string",
+            begin: /<<<['"]?\w+['"]?$/,
+            end: /^\w+;?$/,
+            contains: [
+              e.BACKSLASH_ESCAPE,
+              {
+                className: "subst",
+                variants: [{ begin: /\$\w+/ }, { begin: /\{\$/, end: /\}/ }],
+              },
+            ],
+          },
+          t,
+          { className: "keyword", begin: /\$this\b/ },
+          r,
+          { begin: /(::|->)+[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/ },
+          {
+            className: "function",
+            beginKeywords: "fn function",
+            end: /[;{]/,
+            excludeEnd: !0,
+            illegal: "[$%\\[]",
+            contains: [
+              e.UNDERSCORE_TITLE_MODE,
+              {
+                className: "params",
+                begin: "\\(",
+                end: "\\)",
+                excludeBegin: !0,
+                excludeEnd: !0,
+                keywords: i,
+                contains: ["self", r, e.C_BLOCK_COMMENT_MODE, a, n],
+              },
+            ],
+          },
+          {
+            className: "class",
+            beginKeywords: "class interface",
+            end: "{",
+            excludeEnd: !0,
+            illegal: /[:\(\$"]/,
+            contains: [
+              { beginKeywords: "extends implements" },
+              e.UNDERSCORE_TITLE_MODE,
+            ],
+          },
+          {
+            beginKeywords: "namespace",
+            end: ";",
+            illegal: /[\.']/,
+            contains: [e.UNDERSCORE_TITLE_MODE],
+          },
+          {
+            beginKeywords: "use",
+            end: ";",
+            contains: [e.UNDERSCORE_TITLE_MODE],
+          },
+          { begin: "=>" },
+          a,
+          n,
+        ],
+      };
+    };
+  })()
+);
+hljs.registerLanguage(
+  "php-template",
+  (function () {
+    "use strict";
+    return function (n) {
+      return {
+        name: "PHP template",
+        subLanguage: "xml",
+        contains: [
+          {
+            begin: /<\?(php|=)?/,
+            end: /\?>/,
+            subLanguage: "php",
+            contains: [
+              { begin: "/\\*", end: "\\*/", skip: !0 },
+              { begin: 'b"', end: '"', skip: !0 },
+              { begin: "b'", end: "'", skip: !0 },
+              n.inherit(n.APOS_STRING_MODE, {
+                illegal: null,
+                className: null,
+                contains: null,
+                skip: !0,
+              }),
+              n.inherit(n.QUOTE_STRING_MODE, {
+                illegal: null,
+                className: null,
+                contains: null,
+                skip: !0,
+              }),
+            ],
+          },
+        ],
+      };
+    };
+  })()
+);
+hljs.registerLanguage(
+  "plaintext",
+  (function () {
+    "use strict";
+    return function (t) {
+      return {
+        name: "Plain text",
+        aliases: ["text", "txt"],
+        disableAutodetect: !0,
+      };
+    };
+  })()
+);
+hljs.registerLanguage(
+  "properties",
+  (function () {
+    "use strict";
+    return function (e) {
+      var n = "[ \\t\\f]*",
+        t = "(" + n + "[:=]" + n + "|[ \\t\\f]+)",
+        a = "([^\\\\:= \\t\\f\\n]|\\\\.)+",
+        s = {
+          end: t,
+          relevance: 0,
+          starts: {
+            className: "string",
+            end: /$/,
+            relevance: 0,
+            contains: [{ begin: "\\\\\\n" }],
+          },
+        };
+      return {
+        name: ".properties",
+        case_insensitive: !0,
+        illegal: /\S/,
+        contains: [
+          e.COMMENT("^\\s*[!#]", "$"),
+          {
+            begin: "([^\\\\\\W:= \\t\\f\\n]|\\\\.)+" + t,
+            returnBegin: !0,
+            contains: [
+              {
+                className: "attr",
+                begin: "([^\\\\\\W:= \\t\\f\\n]|\\\\.)+",
+                endsParent: !0,
+                relevance: 0,
+              },
+            ],
+            starts: s,
+          },
+          {
+            begin: a + t,
+            returnBegin: !0,
+            relevance: 0,
+            contains: [
+              { className: "meta", begin: a, endsParent: !0, relevance: 0 },
+            ],
+            starts: s,
+          },
+          { className: "attr", relevance: 0, begin: a + n + "$" },
+        ],
+      };
+    };
+  })()
+);
+hljs.registerLanguage(
+  "python",
+  (function () {
+    "use strict";
+    return function (e) {
+      var n = {
+          keyword:
+            "and elif is global as in if from raise for except finally print import pass return exec else break not with class assert yield try while continue del or def lambda async await nonlocal|10",
+          built_in: "Ellipsis NotImplemented",
+          literal: "False None True",
+        },
+        a = { className: "meta", begin: /^(>>>|\.\.\.) / },
+        i = {
+          className: "subst",
+          begin: /\{/,
+          end: /\}/,
+          keywords: n,
+          illegal: /#/,
+        },
+        s = { begin: /\{\{/, relevance: 0 },
+        r = {
+          className: "string",
+          contains: [e.BACKSLASH_ESCAPE],
+          variants: [
             {
-              begin: /"""/,
+              begin: /(u|b)?r?'''/,
+              end: /'''/,
+              contains: [e.BACKSLASH_ESCAPE, a],
+              relevance: 10,
+            },
+            {
+              begin: /(u|b)?r?"""/,
               end: /"""/,
-              className: "string",
-              contains: [e.BACKSLASH_ESCAPE],
+              contains: [e.BACKSLASH_ESCAPE, a],
+              relevance: 10,
+            },
+            {
+              begin: /(fr|rf|f)'''/,
+              end: /'''/,
+              contains: [e.BACKSLASH_ESCAPE, a, s, i],
+            },
+            {
+              begin: /(fr|rf|f)"""/,
+              end: /"""/,
+              contains: [e.BACKSLASH_ESCAPE, a, s, i],
+            },
+            { begin: /(u|r|ur)'/, end: /'/, relevance: 10 },
+            { begin: /(u|r|ur)"/, end: /"/, relevance: 10 },
+            { begin: /(b|br)'/, end: /'/ },
+            { begin: /(b|br)"/, end: /"/ },
+            {
+              begin: /(fr|rf|f)'/,
+              end: /'/,
+              contains: [e.BACKSLASH_ESCAPE, s, i],
+            },
+            {
+              begin: /(fr|rf|f)"/,
+              end: /"/,
+              contains: [e.BACKSLASH_ESCAPE, s, i],
             },
             e.APOS_STRING_MODE,
             e.QUOTE_STRING_MODE,
+          ],
+        },
+        l = {
+          className: "number",
+          relevance: 0,
+          variants: [
+            { begin: e.BINARY_NUMBER_RE + "[lLjJ]?" },
+            { begin: "\\b(0o[0-7]+)[lLjJ]?" },
+            { begin: e.C_NUMBER_RE + "[lLjJ]?" },
+          ],
+        },
+        t = {
+          className: "params",
+          variants: [
+            { begin: /\(\s*\)/, skip: !0, className: null },
             {
-              match: [
-                /\b(?:class|interface|enum|extends|implements|new)/,
-                /\s+/,
-                t,
+              begin: /\(/,
+              end: /\)/,
+              excludeBegin: !0,
+              excludeEnd: !0,
+              contains: ["self", a, l, r, e.HASH_COMMENT_MODE],
+            },
+          ],
+        };
+      return (
+        (i.contains = [r, l, a]),
+        {
+          name: "Python",
+          aliases: ["py", "gyp", "ipython"],
+          keywords: n,
+          illegal: /(<\/|->|\?)|=>/,
+          contains: [
+            a,
+            l,
+            { beginKeywords: "if", relevance: 0 },
+            r,
+            e.HASH_COMMENT_MODE,
+            {
+              variants: [
+                { className: "function", beginKeywords: "def" },
+                { className: "class", beginKeywords: "class" },
               ],
-              className: {
-                1: "keyword",
-                3: "title.class",
+              end: /:/,
+              illegal: /[${=;\n,]/,
+              contains: [
+                e.UNDERSCORE_TITLE_MODE,
+                t,
+                { begin: /->/, endsWithParent: !0, keywords: "None" },
+              ],
+            },
+            { className: "meta", begin: /^[\t ]*@/, end: /$/ },
+            { begin: /\b(print|exec)\(/ },
+          ],
+        }
+      );
+    };
+  })()
+);
+hljs.registerLanguage(
+  "python-repl",
+  (function () {
+    "use strict";
+    return function (n) {
+      return {
+        aliases: ["pycon"],
+        contains: [
+          {
+            className: "meta",
+            starts: { end: / |$/, starts: { end: "$", subLanguage: "python" } },
+            variants: [
+              { begin: /^>>>(?=[ ]|$)/ },
+              { begin: /^\.\.\.(?=[ ]|$)/ },
+            ],
+          },
+        ],
+      };
+    };
+  })()
+);
+hljs.registerLanguage(
+  "ruby",
+  (function () {
+    "use strict";
+    return function (e) {
+      var n =
+          "[a-zA-Z_]\\w*[!?=]?|[-+~]\\@|<<|>>|=~|===?|<=>|[<>]=?|\\*\\*|[-/+%^&*~`|]|\\[\\]=?",
+        a = {
+          keyword:
+            "and then defined module in return redo if BEGIN retry end for self when next until do begin unless END rescue else break undef not super class case require yield alias while ensure elsif or include attr_reader attr_writer attr_accessor",
+          literal: "true false nil",
+        },
+        s = { className: "doctag", begin: "@[A-Za-z]+" },
+        i = { begin: "#<", end: ">" },
+        r = [
+          e.COMMENT("#", "$", { contains: [s] }),
+          e.COMMENT("^\\=begin", "^\\=end", { contains: [s], relevance: 10 }),
+          e.COMMENT("^__END__", "\\n$"),
+        ],
+        c = { className: "subst", begin: "#\\{", end: "}", keywords: a },
+        t = {
+          className: "string",
+          contains: [e.BACKSLASH_ESCAPE, c],
+          variants: [
+            { begin: /'/, end: /'/ },
+            { begin: /"/, end: /"/ },
+            { begin: /`/, end: /`/ },
+            { begin: "%[qQwWx]?\\(", end: "\\)" },
+            { begin: "%[qQwWx]?\\[", end: "\\]" },
+            { begin: "%[qQwWx]?{", end: "}" },
+            { begin: "%[qQwWx]?<", end: ">" },
+            { begin: "%[qQwWx]?/", end: "/" },
+            { begin: "%[qQwWx]?%", end: "%" },
+            { begin: "%[qQwWx]?-", end: "-" },
+            { begin: "%[qQwWx]?\\|", end: "\\|" },
+            {
+              begin:
+                /\B\?(\\\d{1,3}|\\x[A-Fa-f0-9]{1,2}|\\u[A-Fa-f0-9]{4}|\\?\S)\b/,
+            },
+            {
+              begin: /<<[-~]?'?(\w+)(?:.|\n)*?\n\s*\1\b/,
+              returnBegin: !0,
+              contains: [
+                { begin: /<<[-~]?'?/ },
+                e.END_SAME_AS_BEGIN({
+                  begin: /(\w+)/,
+                  end: /(\w+)/,
+                  contains: [e.BACKSLASH_ESCAPE, c],
+                }),
+              ],
+            },
+          ],
+        },
+        b = {
+          className: "params",
+          begin: "\\(",
+          end: "\\)",
+          endsParent: !0,
+          keywords: a,
+        },
+        d = [
+          t,
+          i,
+          {
+            className: "class",
+            beginKeywords: "class module",
+            end: "$|;",
+            illegal: /=/,
+            contains: [
+              e.inherit(e.TITLE_MODE, {
+                begin: "[A-Za-z_]\\w*(::\\w+)*(\\?|\\!)?",
+              }),
+              {
+                begin: "<\\s*",
+                contains: [{ begin: "(" + e.IDENT_RE + "::)?" + e.IDENT_RE }],
               },
-            },
-            { match: /non-sealed/, scope: "keyword" },
+            ].concat(r),
+          },
+          {
+            className: "function",
+            beginKeywords: "def",
+            end: "$|;",
+            contains: [e.inherit(e.TITLE_MODE, { begin: n }), b].concat(r),
+          },
+          { begin: e.IDENT_RE + "::" },
+          {
+            className: "symbol",
+            begin: e.UNDERSCORE_IDENT_RE + "(\\!|\\?)?:",
+            relevance: 0,
+          },
+          {
+            className: "symbol",
+            begin: ":(?!\\s)",
+            contains: [t, { begin: n }],
+            relevance: 0,
+          },
+          {
+            className: "number",
+            begin:
+              "(\\b0[0-7_]+)|(\\b0x[0-9a-fA-F_]+)|(\\b[1-9][0-9_]*(\\.[0-9_]+)?)|[0_]\\b",
+            relevance: 0,
+          },
+          { begin: "(\\$\\W)|((\\$|\\@\\@?)(\\w+))" },
+          { className: "params", begin: /\|/, end: /\|/, keywords: a },
+          {
+            begin: "(" + e.RE_STARTERS_RE + "|unless)\\s*",
+            keywords: "unless",
+            contains: [
+              i,
+              {
+                className: "regexp",
+                contains: [e.BACKSLASH_ESCAPE, c],
+                illegal: /\n/,
+                variants: [
+                  { begin: "/", end: "/[a-z]*" },
+                  { begin: "%r{", end: "}[a-z]*" },
+                  { begin: "%r\\(", end: "\\)[a-z]*" },
+                  { begin: "%r!", end: "![a-z]*" },
+                  { begin: "%r\\[", end: "\\][a-z]*" },
+                ],
+              },
+            ].concat(r),
+            relevance: 0,
+          },
+        ].concat(r);
+      (c.contains = d), (b.contains = d);
+      var g = [
+        { begin: /^\s*=>/, starts: { end: "$", contains: d } },
+        {
+          className: "meta",
+          begin:
+            "^([>?]>|[\\w#]+\\(\\w+\\):\\d+:\\d+>|(\\w+-)?\\d+\\.\\d+\\.\\d(p\\d+)?[^>]+>)",
+          starts: { end: "$", contains: d },
+        },
+      ];
+      return {
+        name: "Ruby",
+        aliases: ["rb", "gemspec", "podspec", "thor", "irb"],
+        keywords: a,
+        illegal: /\/\*/,
+        contains: r.concat(g).concat(d),
+      };
+    };
+  })()
+);
+hljs.registerLanguage(
+  "rust",
+  (function () {
+    "use strict";
+    return function (e) {
+      var n = "([ui](8|16|32|64|128|size)|f(32|64))?",
+        t =
+          "drop i8 i16 i32 i64 i128 isize u8 u16 u32 u64 u128 usize f32 f64 str char bool Box Option Result String Vec Copy Send Sized Sync Drop Fn FnMut FnOnce ToOwned Clone Debug PartialEq PartialOrd Eq Ord AsRef AsMut Into From Default Iterator Extend IntoIterator DoubleEndedIterator ExactSizeIterator SliceConcatExt ToString assert! assert_eq! bitflags! bytes! cfg! col! concat! concat_idents! debug_assert! debug_assert_eq! env! panic! file! format! format_args! include_bin! include_str! line! local_data_key! module_path! option_env! print! println! select! stringify! try! unimplemented! unreachable! vec! write! writeln! macro_rules! assert_ne! debug_assert_ne!";
+      return {
+        name: "Rust",
+        aliases: ["rs"],
+        keywords: {
+          $pattern: e.IDENT_RE + "!?",
+          keyword:
+            "abstract as async await become box break const continue crate do dyn else enum extern false final fn for if impl in let loop macro match mod move mut override priv pub ref return self Self static struct super trait true try type typeof unsafe unsized use virtual where while yield",
+          literal: "true false Some None Ok Err",
+          built_in: t,
+        },
+        illegal: "</",
+        contains: [
+          e.C_LINE_COMMENT_MODE,
+          e.COMMENT("/\\*", "\\*/", { contains: ["self"] }),
+          e.inherit(e.QUOTE_STRING_MODE, { begin: /b?"/, illegal: null }),
+          {
+            className: "string",
+            variants: [
+              { begin: /r(#*)"(.|\n)*?"\1(?!#)/ },
+              { begin: /b?'\\?(x\w{2}|u\w{4}|U\w{8}|.)'/ },
+            ],
+          },
+          { className: "symbol", begin: /'[a-zA-Z_][a-zA-Z0-9_]*/ },
+          {
+            className: "number",
+            variants: [
+              { begin: "\\b0b([01_]+)" + n },
+              { begin: "\\b0o([0-7_]+)" + n },
+              { begin: "\\b0x([A-Fa-f0-9_]+)" + n },
+              { begin: "\\b(\\d[\\d_]*(\\.[0-9_]+)?([eE][+-]?[0-9_]+)?)" + n },
+            ],
+            relevance: 0,
+          },
+          {
+            className: "function",
+            beginKeywords: "fn",
+            end: "(\\(|<)",
+            excludeEnd: !0,
+            contains: [e.UNDERSCORE_TITLE_MODE],
+          },
+          {
+            className: "meta",
+            begin: "#\\!?\\[",
+            end: "\\]",
+            contains: [{ className: "meta-string", begin: /"/, end: /"/ }],
+          },
+          {
+            className: "class",
+            beginKeywords: "type",
+            end: ";",
+            contains: [e.inherit(e.UNDERSCORE_TITLE_MODE, { endsParent: !0 })],
+            illegal: "\\S",
+          },
+          {
+            className: "class",
+            beginKeywords: "trait enum struct union",
+            end: "{",
+            contains: [e.inherit(e.UNDERSCORE_TITLE_MODE, { endsParent: !0 })],
+            illegal: "[\\w\\d]",
+          },
+          { begin: e.IDENT_RE + "::", keywords: { built_in: t } },
+          { begin: "->" },
+        ],
+      };
+    };
+  })()
+);
+hljs.registerLanguage(
+  "scss",
+  (function () {
+    "use strict";
+    return function (e) {
+      var t = {
+          className: "variable",
+          begin: "(\\$[a-zA-Z-][a-zA-Z0-9_-]*)\\b",
+        },
+        i = { className: "number", begin: "#[0-9A-Fa-f]+" };
+      return (
+        e.CSS_NUMBER_MODE,
+        e.QUOTE_STRING_MODE,
+        e.APOS_STRING_MODE,
+        e.C_BLOCK_COMMENT_MODE,
+        {
+          name: "SCSS",
+          case_insensitive: !0,
+          illegal: "[=/|']",
+          contains: [
+            e.C_LINE_COMMENT_MODE,
+            e.C_BLOCK_COMMENT_MODE,
             {
-              begin: [n.concat(/(?!else)/, t), /\s+/, t, /\s+/, /=(?!=)/],
-              className: { 1: "type", 3: "variable", 5: "operator" },
-            },
-            {
-              begin: [/record/, /\s+/, t],
-              className: { 1: "keyword", 3: "title.class" },
-              contains: [r, e.C_LINE_COMMENT_MODE, e.C_BLOCK_COMMENT_MODE],
-            },
-            {
-              beginKeywords: "new throw return else",
+              className: "selector-id",
+              begin: "\\#[A-Za-z0-9_-]+",
               relevance: 0,
             },
             {
-              begin: ["(?:" + s + "\\s+)", e.UNDERSCORE_IDENT_RE, /\s*(?=\()/],
-              className: {
-                2: "title.function",
-              },
-              keywords: a,
+              className: "selector-class",
+              begin: "\\.[A-Za-z0-9_-]+",
+              relevance: 0,
+            },
+            {
+              className: "selector-attr",
+              begin: "\\[",
+              end: "\\]",
+              illegal: "$",
+            },
+            {
+              className: "selector-tag",
+              begin:
+                "\\b(a|abbr|acronym|address|area|article|aside|audio|b|base|big|blockquote|body|br|button|canvas|caption|cite|code|col|colgroup|command|datalist|dd|del|details|dfn|div|dl|dt|em|embed|fieldset|figcaption|figure|footer|form|frame|frameset|(h[1-6])|head|header|hgroup|hr|html|i|iframe|img|input|ins|kbd|keygen|label|legend|li|link|map|mark|meta|meter|nav|noframes|noscript|object|ol|optgroup|option|output|p|param|pre|progress|q|rp|rt|ruby|samp|script|section|select|small|span|strike|strong|style|sub|sup|table|tbody|td|textarea|tfoot|th|thead|time|title|tr|tt|ul|var|video)\\b",
+              relevance: 0,
+            },
+            {
+              className: "selector-pseudo",
+              begin:
+                ":(visited|valid|root|right|required|read-write|read-only|out-range|optional|only-of-type|only-child|nth-of-type|nth-last-of-type|nth-last-child|nth-child|not|link|left|last-of-type|last-child|lang|invalid|indeterminate|in-range|hover|focus|first-of-type|first-line|first-letter|first-child|first|enabled|empty|disabled|default|checked|before|after|active)",
+            },
+            {
+              className: "selector-pseudo",
+              begin:
+                "::(after|before|choices|first-letter|first-line|repeat-index|repeat-item|selection|value)",
+            },
+            t,
+            {
+              className: "attribute",
+              begin:
+                "\\b(src|z-index|word-wrap|word-spacing|word-break|width|widows|white-space|visibility|vertical-align|unicode-bidi|transition-timing-function|transition-property|transition-duration|transition-delay|transition|transform-style|transform-origin|transform|top|text-underline-position|text-transform|text-shadow|text-rendering|text-overflow|text-indent|text-decoration-style|text-decoration-line|text-decoration-color|text-decoration|text-align-last|text-align|tab-size|table-layout|right|resize|quotes|position|pointer-events|perspective-origin|perspective|page-break-inside|page-break-before|page-break-after|padding-top|padding-right|padding-left|padding-bottom|padding|overflow-y|overflow-x|overflow-wrap|overflow|outline-width|outline-style|outline-offset|outline-color|outline|orphans|order|opacity|object-position|object-fit|normal|none|nav-up|nav-right|nav-left|nav-index|nav-down|min-width|min-height|max-width|max-height|mask|marks|margin-top|margin-right|margin-left|margin-bottom|margin|list-style-type|list-style-position|list-style-image|list-style|line-height|letter-spacing|left|justify-content|initial|inherit|ime-mode|image-orientation|image-resolution|image-rendering|icon|hyphens|height|font-weight|font-variant-ligatures|font-variant|font-style|font-stretch|font-size-adjust|font-size|font-language-override|font-kerning|font-feature-settings|font-family|font|float|flex-wrap|flex-shrink|flex-grow|flex-flow|flex-direction|flex-basis|flex|filter|empty-cells|display|direction|cursor|counter-reset|counter-increment|content|column-width|column-span|column-rule-width|column-rule-style|column-rule-color|column-rule|column-gap|column-fill|column-count|columns|color|clip-path|clip|clear|caption-side|break-inside|break-before|break-after|box-sizing|box-shadow|box-decoration-break|bottom|border-width|border-top-width|border-top-style|border-top-right-radius|border-top-left-radius|border-top-color|border-top|border-style|border-spacing|border-right-width|border-right-style|border-right-color|border-right|border-radius|border-left-width|border-left-style|border-left-color|border-left|border-image-width|border-image-source|border-image-slice|border-image-repeat|border-image-outset|border-image|border-color|border-collapse|border-bottom-width|border-bottom-style|border-bottom-right-radius|border-bottom-left-radius|border-bottom-color|border-bottom|border|background-size|background-repeat|background-position|background-origin|background-image|background-color|background-clip|background-attachment|background-blend-mode|background|backface-visibility|auto|animation-timing-function|animation-play-state|animation-name|animation-iteration-count|animation-fill-mode|animation-duration|animation-direction|animation-delay|animation|align-self|align-items|align-content)\\b",
+              illegal: "[^\\s]",
+            },
+            {
+              begin:
+                "\\b(whitespace|wait|w-resize|visible|vertical-text|vertical-ideographic|uppercase|upper-roman|upper-alpha|underline|transparent|top|thin|thick|text|text-top|text-bottom|tb-rl|table-header-group|table-footer-group|sw-resize|super|strict|static|square|solid|small-caps|separate|se-resize|scroll|s-resize|rtl|row-resize|ridge|right|repeat|repeat-y|repeat-x|relative|progress|pointer|overline|outside|outset|oblique|nowrap|not-allowed|normal|none|nw-resize|no-repeat|no-drop|newspaper|ne-resize|n-resize|move|middle|medium|ltr|lr-tb|lowercase|lower-roman|lower-alpha|loose|list-item|line|line-through|line-edge|lighter|left|keep-all|justify|italic|inter-word|inter-ideograph|inside|inset|inline|inline-block|inherit|inactive|ideograph-space|ideograph-parenthesis|ideograph-numeric|ideograph-alpha|horizontal|hidden|help|hand|groove|fixed|ellipsis|e-resize|double|dotted|distribute|distribute-space|distribute-letter|distribute-all-lines|disc|disabled|default|decimal|dashed|crosshair|collapse|col-resize|circle|char|center|capitalize|break-word|break-all|bottom|both|bolder|bold|block|bidi-override|below|baseline|auto|always|all-scroll|absolute|table|table-cell)\\b",
+            },
+            {
+              begin: ":",
+              end: ";",
               contains: [
+                t,
+                i,
+                e.CSS_NUMBER_MODE,
+                e.QUOTE_STRING_MODE,
+                e.APOS_STRING_MODE,
+                { className: "meta", begin: "!important" },
+              ],
+            },
+            {
+              begin: "@(page|font-face)",
+              lexemes: "@[a-z-]+",
+              keywords: "@page @font-face",
+            },
+            {
+              begin: "@",
+              end: "[{;]",
+              returnBegin: !0,
+              keywords: "and or not only",
+              contains: [
+                { begin: "@[a-z-]+", className: "keyword" },
+                t,
+                e.QUOTE_STRING_MODE,
+                e.APOS_STRING_MODE,
+                i,
+                e.CSS_NUMBER_MODE,
+              ],
+            },
+          ],
+        }
+      );
+    };
+  })()
+);
+hljs.registerLanguage(
+  "shell",
+  (function () {
+    "use strict";
+    return function (s) {
+      return {
+        name: "Shell Session",
+        aliases: ["console"],
+        contains: [
+          {
+            className: "meta",
+            begin: "^\\s{0,3}[/\\w\\d\\[\\]()@-]*[>%$#]",
+            starts: { end: "$", subLanguage: "bash" },
+          },
+        ],
+      };
+    };
+  })()
+);
+hljs.registerLanguage(
+  "sql",
+  (function () {
+    "use strict";
+    return function (e) {
+      var t = e.COMMENT("--", "$");
+      return {
+        name: "SQL",
+        case_insensitive: !0,
+        illegal: /[<>{}*]/,
+        contains: [
+          {
+            beginKeywords:
+              "begin end start commit rollback savepoint lock alter create drop rename call delete do handler insert load replace select truncate update set show pragma grant merge describe use explain help declare prepare execute deallocate release unlock purge reset change stop analyze cache flush optimize repair kill install uninstall checksum restore check backup revoke comment values with",
+            end: /;/,
+            endsWithParent: !0,
+            keywords: {
+              $pattern: /[\w\.]+/,
+              keyword:
+                "as abort abs absolute acc acce accep accept access accessed accessible account acos action activate add addtime admin administer advanced advise aes_decrypt aes_encrypt after agent aggregate ali alia alias all allocate allow alter always analyze ancillary and anti any anydata anydataset anyschema anytype apply archive archived archivelog are as asc ascii asin assembly assertion associate asynchronous at atan atn2 attr attri attrib attribu attribut attribute attributes audit authenticated authentication authid authors auto autoallocate autodblink autoextend automatic availability avg backup badfile basicfile before begin beginning benchmark between bfile bfile_base big bigfile bin binary_double binary_float binlog bit_and bit_count bit_length bit_or bit_xor bitmap blob_base block blocksize body both bound bucket buffer_cache buffer_pool build bulk by byte byteordermark bytes cache caching call calling cancel capacity cascade cascaded case cast catalog category ceil ceiling chain change changed char_base char_length character_length characters characterset charindex charset charsetform charsetid check checksum checksum_agg child choose chr chunk class cleanup clear client clob clob_base clone close cluster_id cluster_probability cluster_set clustering coalesce coercibility col collate collation collect colu colum column column_value columns columns_updated comment commit compact compatibility compiled complete composite_limit compound compress compute concat concat_ws concurrent confirm conn connec connect connect_by_iscycle connect_by_isleaf connect_by_root connect_time connection consider consistent constant constraint constraints constructor container content contents context contributors controlfile conv convert convert_tz corr corr_k corr_s corresponding corruption cos cost count count_big counted covar_pop covar_samp cpu_per_call cpu_per_session crc32 create creation critical cross cube cume_dist curdate current current_date current_time current_timestamp current_user cursor curtime customdatum cycle data database databases datafile datafiles datalength date_add date_cache date_format date_sub dateadd datediff datefromparts datename datepart datetime2fromparts day day_to_second dayname dayofmonth dayofweek dayofyear days db_role_change dbtimezone ddl deallocate declare decode decompose decrement decrypt deduplicate def defa defau defaul default defaults deferred defi defin define degrees delayed delegate delete delete_all delimited demand dense_rank depth dequeue des_decrypt des_encrypt des_key_file desc descr descri describ describe descriptor deterministic diagnostics difference dimension direct_load directory disable disable_all disallow disassociate discardfile disconnect diskgroup distinct distinctrow distribute distributed div do document domain dotnet double downgrade drop dumpfile duplicate duration each edition editionable editions element ellipsis else elsif elt empty enable enable_all enclosed encode encoding encrypt end end-exec endian enforced engine engines enqueue enterprise entityescaping eomonth error errors escaped evalname evaluate event eventdata events except exception exceptions exchange exclude excluding execu execut execute exempt exists exit exp expire explain explode export export_set extended extent external external_1 external_2 externally extract failed failed_login_attempts failover failure far fast feature_set feature_value fetch field fields file file_name_convert filesystem_like_logging final finish first first_value fixed flash_cache flashback floor flush following follows for forall force foreign form forma format found found_rows freelist freelists freepools fresh from from_base64 from_days ftp full function general generated get get_format get_lock getdate getutcdate global global_name globally go goto grant grants greatest group group_concat group_id grouping grouping_id groups gtid_subtract guarantee guard handler hash hashkeys having hea head headi headin heading heap help hex hierarchy high high_priority hosts hour hours http id ident_current ident_incr ident_seed identified identity idle_time if ifnull ignore iif ilike ilm immediate import in include including increment index indexes indexing indextype indicator indices inet6_aton inet6_ntoa inet_aton inet_ntoa infile initial initialized initially initrans inmemory inner innodb input insert install instance instantiable instr interface interleaved intersect into invalidate invisible is is_free_lock is_ipv4 is_ipv4_compat is_not is_not_null is_used_lock isdate isnull isolation iterate java join json json_exists keep keep_duplicates key keys kill language large last last_day last_insert_id last_value lateral lax lcase lead leading least leaves left len lenght length less level levels library like like2 like4 likec limit lines link list listagg little ln load load_file lob lobs local localtime localtimestamp locate locator lock locked log log10 log2 logfile logfiles logging logical logical_reads_per_call logoff logon logs long loop low low_priority lower lpad lrtrim ltrim main make_set makedate maketime managed management manual map mapping mask master master_pos_wait match matched materialized max maxextents maximize maxinstances maxlen maxlogfiles maxloghistory maxlogmembers maxsize maxtrans md5 measures median medium member memcompress memory merge microsecond mid migration min minextents minimum mining minus minute minutes minvalue missing mod mode model modification modify module monitoring month months mount move movement multiset mutex name name_const names nan national native natural nav nchar nclob nested never new newline next nextval no no_write_to_binlog noarchivelog noaudit nobadfile nocheck nocompress nocopy nocycle nodelay nodiscardfile noentityescaping noguarantee nokeep nologfile nomapping nomaxvalue nominimize nominvalue nomonitoring none noneditionable nonschema noorder nopr nopro noprom nopromp noprompt norely noresetlogs noreverse normal norowdependencies noschemacheck noswitch not nothing notice notnull notrim novalidate now nowait nth_value nullif nulls num numb numbe nvarchar nvarchar2 object ocicoll ocidate ocidatetime ociduration ociinterval ociloblocator ocinumber ociref ocirefcursor ocirowid ocistring ocitype oct octet_length of off offline offset oid oidindex old on online only opaque open operations operator optimal optimize option optionally or oracle oracle_date oradata ord ordaudio orddicom orddoc order ordimage ordinality ordvideo organization orlany orlvary out outer outfile outline output over overflow overriding package pad parallel parallel_enable parameters parent parse partial partition partitions pascal passing password password_grace_time password_lock_time password_reuse_max password_reuse_time password_verify_function patch path patindex pctincrease pctthreshold pctused pctversion percent percent_rank percentile_cont percentile_disc performance period period_add period_diff permanent physical pi pipe pipelined pivot pluggable plugin policy position post_transaction pow power pragma prebuilt precedes preceding precision prediction prediction_cost prediction_details prediction_probability prediction_set prepare present preserve prior priority private private_sga privileges procedural procedure procedure_analyze processlist profiles project prompt protection public publishingservername purge quarter query quick quiesce quota quotename radians raise rand range rank raw read reads readsize rebuild record records recover recovery recursive recycle redo reduced ref reference referenced references referencing refresh regexp_like register regr_avgx regr_avgy regr_count regr_intercept regr_r2 regr_slope regr_sxx regr_sxy reject rekey relational relative relaylog release release_lock relies_on relocate rely rem remainder rename repair repeat replace replicate replication required reset resetlogs resize resource respect restore restricted result result_cache resumable resume retention return returning returns reuse reverse revoke right rlike role roles rollback rolling rollup round row row_count rowdependencies rowid rownum rows rtrim rules safe salt sample save savepoint sb1 sb2 sb4 scan schema schemacheck scn scope scroll sdo_georaster sdo_topo_geometry search sec_to_time second seconds section securefile security seed segment select self semi sequence sequential serializable server servererror session session_user sessions_per_user set sets settings sha sha1 sha2 share shared shared_pool short show shrink shutdown si_averagecolor si_colorhistogram si_featurelist si_positionalcolor si_stillimage si_texture siblings sid sign sin size size_t sizes skip slave sleep smalldatetimefromparts smallfile snapshot some soname sort soundex source space sparse spfile split sql sql_big_result sql_buffer_result sql_cache sql_calc_found_rows sql_small_result sql_variant_property sqlcode sqldata sqlerror sqlname sqlstate sqrt square standalone standby start starting startup statement static statistics stats_binomial_test stats_crosstab stats_ks_test stats_mode stats_mw_test stats_one_way_anova stats_t_test_ stats_t_test_indep stats_t_test_one stats_t_test_paired stats_wsr_test status std stddev stddev_pop stddev_samp stdev stop storage store stored str str_to_date straight_join strcmp strict string struct stuff style subdate subpartition subpartitions substitutable substr substring subtime subtring_index subtype success sum suspend switch switchoffset switchover sync synchronous synonym sys sys_xmlagg sysasm sysaux sysdate sysdatetimeoffset sysdba sysoper system system_user sysutcdatetime table tables tablespace tablesample tan tdo template temporary terminated tertiary_weights test than then thread through tier ties time time_format time_zone timediff timefromparts timeout timestamp timestampadd timestampdiff timezone_abbr timezone_minute timezone_region to to_base64 to_date to_days to_seconds todatetimeoffset trace tracking transaction transactional translate translation treat trigger trigger_nestlevel triggers trim truncate try_cast try_convert try_parse type ub1 ub2 ub4 ucase unarchived unbounded uncompress under undo unhex unicode uniform uninstall union unique unix_timestamp unknown unlimited unlock unnest unpivot unrecoverable unsafe unsigned until untrusted unusable unused update updated upgrade upped upper upsert url urowid usable usage use use_stored_outlines user user_data user_resources users using utc_date utc_timestamp uuid uuid_short validate validate_password_strength validation valist value values var var_samp varcharc vari varia variab variabl variable variables variance varp varraw varrawc varray verify version versions view virtual visible void wait wallet warning warnings week weekday weekofyear wellformed when whene whenev wheneve whenever where while whitespace window with within without work wrapped xdb xml xmlagg xmlattributes xmlcast xmlcolattval xmlelement xmlexists xmlforest xmlindex xmlnamespaces xmlpi xmlquery xmlroot xmlschema xmlserialize xmltable xmltype xor year year_to_month years yearweek",
+              literal: "true false null unknown",
+              built_in:
+                "array bigint binary bit blob bool boolean char character date dec decimal float int int8 integer interval number numeric real record serial serial8 smallint text time timestamp tinyint varchar varchar2 varying void",
+            },
+            contains: [
+              {
+                className: "string",
+                begin: "'",
+                end: "'",
+                contains: [{ begin: "''" }],
+              },
+              {
+                className: "string",
+                begin: '"',
+                end: '"',
+                contains: [{ begin: '""' }],
+              },
+              { className: "string", begin: "`", end: "`" },
+              e.C_NUMBER_MODE,
+              e.C_BLOCK_COMMENT_MODE,
+              t,
+              e.HASH_COMMENT_MODE,
+            ],
+          },
+          e.C_BLOCK_COMMENT_MODE,
+          t,
+          e.HASH_COMMENT_MODE,
+        ],
+      };
+    };
+  })()
+);
+hljs.registerLanguage(
+  "swift",
+  (function () {
+    "use strict";
+    return function (e) {
+      var i = {
+          keyword:
+            "#available #colorLiteral #column #else #elseif #endif #file #fileLiteral #function #if #imageLiteral #line #selector #sourceLocation _ __COLUMN__ __FILE__ __FUNCTION__ __LINE__ Any as as! as? associatedtype associativity break case catch class continue convenience default defer deinit didSet do dynamic dynamicType else enum extension fallthrough false fileprivate final for func get guard if import in indirect infix init inout internal is lazy left let mutating nil none nonmutating open operator optional override postfix precedence prefix private protocol Protocol public repeat required rethrows return right self Self set static struct subscript super switch throw throws true try try! try? Type typealias unowned var weak where while willSet",
+          literal: "true false nil",
+          built_in:
+            "abs advance alignof alignofValue anyGenerator assert assertionFailure bridgeFromObjectiveC bridgeFromObjectiveCUnconditional bridgeToObjectiveC bridgeToObjectiveCUnconditional c compactMap contains count countElements countLeadingZeros debugPrint debugPrintln distance dropFirst dropLast dump encodeBitsAsWords enumerate equal fatalError filter find getBridgedObjectiveCType getVaList indices insertionSort isBridgedToObjectiveC isBridgedVerbatimToObjectiveC isUniquelyReferenced isUniquelyReferencedNonObjC join lazy lexicographicalCompare map max maxElement min minElement numericCast overlaps partition posix precondition preconditionFailure print println quickSort readLine reduce reflect reinterpretCast reverse roundUpToAlignment sizeof sizeofValue sort split startsWith stride strideof strideofValue swap toString transcode underestimateCount unsafeAddressOf unsafeBitCast unsafeDowncast unsafeUnwrap unsafeReflect withExtendedLifetime withObjectAtPlusZero withUnsafePointer withUnsafePointerToObject withUnsafeMutablePointer withUnsafeMutablePointers withUnsafePointer withUnsafePointers withVaList zip",
+        },
+        n = e.COMMENT("/\\*", "\\*/", { contains: ["self"] }),
+        t = {
+          className: "subst",
+          begin: /\\\(/,
+          end: "\\)",
+          keywords: i,
+          contains: [],
+        },
+        a = {
+          className: "string",
+          contains: [e.BACKSLASH_ESCAPE, t],
+          variants: [
+            { begin: /"""/, end: /"""/ },
+            { begin: /"/, end: /"/ },
+          ],
+        },
+        r = {
+          className: "number",
+          begin:
+            "\\b([\\d_]+(\\.[\\deE_]+)?|0x[a-fA-F0-9_]+(\\.[a-fA-F0-9p_]+)?|0b[01_]+|0o[0-7_]+)\\b",
+          relevance: 0,
+        };
+      return (
+        (t.contains = [r]),
+        {
+          name: "Swift",
+          keywords: i,
+          contains: [
+            a,
+            e.C_LINE_COMMENT_MODE,
+            n,
+            { className: "type", begin: "\\b[A-Z][\\wÀ-ʸ']*[!?]" },
+            { className: "type", begin: "\\b[A-Z][\\wÀ-ʸ']*", relevance: 0 },
+            r,
+            {
+              className: "function",
+              beginKeywords: "func",
+              end: "{",
+              excludeEnd: !0,
+              contains: [
+                e.inherit(e.TITLE_MODE, { begin: /[A-Za-z$_][0-9A-Za-z$_]*/ }),
+                { begin: /</, end: />/ },
                 {
                   className: "params",
                   begin: /\(/,
                   end: /\)/,
-                  keywords: a,
-                  relevance: 0,
+                  endsParent: !0,
+                  keywords: i,
                   contains: [
-                    i,
-                    e.APOS_STRING_MODE,
-                    e.QUOTE_STRING_MODE,
-                    ue,
+                    "self",
+                    r,
+                    a,
                     e.C_BLOCK_COMMENT_MODE,
+                    { begin: ":" },
                   ],
+                  illegal: /["']/,
                 },
-                e.C_LINE_COMMENT_MODE,
-                e.C_BLOCK_COMMENT_MODE,
               ],
+              illegal: /\[|%/,
             },
-            ue,
-            i,
-          ],
-        };
-      },
-      grmr_javascript: Ne,
-      grmr_json: (e) => {
-        const n = ["true", "false", "null"],
-          t = { scope: "literal", beginKeywords: n.join(" ") };
-        return {
-          name: "JSON",
-          aliases: ["jsonc"],
-          keywords: {
-            literal: n,
-          },
-          contains: [
             {
-              className: "attr",
-              begin: /"(\\.|[^\\"\r\n])*"(?=\s*:)/,
-              relevance: 1.01,
-            },
-            { match: /[{}[\],:]/, className: "punctuation", relevance: 0 },
-            e.QUOTE_STRING_MODE,
-            t,
-            e.C_NUMBER_MODE,
-            e.C_LINE_COMMENT_MODE,
-            e.C_BLOCK_COMMENT_MODE,
-          ],
-          illegal: "\\S",
-        };
-      },
-      grmr_julia: (e) => {
-        const n = "[A-Za-z_\\u00A1-\\uFFFF][A-Za-z_0-9\\u00A1-\\uFFFF]*",
-          t = {
-            $pattern: n,
-            keyword: [
-              "baremodule",
-              "begin",
-              "break",
-              "catch",
-              "ccall",
-              "const",
-              "continue",
-              "do",
-              "else",
-              "elseif",
-              "end",
-              "export",
-              "false",
-              "finally",
-              "for",
-              "function",
-              "global",
-              "if",
-              "import",
-              "in",
-              "isa",
-              "let",
-              "local",
-              "macro",
-              "module",
-              "quote",
-              "return",
-              "true",
-              "try",
-              "using",
-              "where",
-              "while",
-            ],
-            literal: [
-              "ARGS",
-              "C_NULL",
-              "DEPOT_PATH",
-              "ENDIAN_BOM",
-              "ENV",
-              "Inf",
-              "Inf16",
-              "Inf32",
-              "Inf64",
-              "InsertionSort",
-              "LOAD_PATH",
-              "MergeSort",
-              "NaN",
-              "NaN16",
-              "NaN32",
-              "NaN64",
-              "PROGRAM_FILE",
-              "QuickSort",
-              "RoundDown",
-              "RoundFromZero",
-              "RoundNearest",
-              "RoundNearestTiesAway",
-              "RoundNearestTiesUp",
-              "RoundToZero",
-              "RoundUp",
-              "VERSION|0",
-              "devnull",
-              "false",
-              "im",
-              "missing",
-              "nothing",
-              "pi",
-              "stderr",
-              "stdin",
-              "stdout",
-              "true",
-              "undef",
-              "\u03c0",
-              "\u212f",
-            ],
-            built_in: [
-              "AbstractArray",
-              "AbstractChannel",
-              "AbstractChar",
-              "AbstractDict",
-              "AbstractDisplay",
-              "AbstractFloat",
-              "AbstractIrrational",
-              "AbstractMatrix",
-              "AbstractRange",
-              "AbstractSet",
-              "AbstractString",
-              "AbstractUnitRange",
-              "AbstractVecOrMat",
-              "AbstractVector",
-              "Any",
-              "ArgumentError",
-              "Array",
-              "AssertionError",
-              "BigFloat",
-              "BigInt",
-              "BitArray",
-              "BitMatrix",
-              "BitSet",
-              "BitVector",
-              "Bool",
-              "BoundsError",
-              "CapturedException",
-              "CartesianIndex",
-              "CartesianIndices",
-              "Cchar",
-              "Cdouble",
-              "Cfloat",
-              "Channel",
-              "Char",
-              "Cint",
-              "Cintmax_t",
-              "Clong",
-              "Clonglong",
-              "Cmd",
-              "Colon",
-              "Complex",
-              "ComplexF16",
-              "ComplexF32",
-              "ComplexF64",
-              "CompositeException",
-              "Condition",
-              "Cptrdiff_t",
-              "Cshort",
-              "Csize_t",
-              "Cssize_t",
-              "Cstring",
-              "Cuchar",
-              "Cuint",
-              "Cuintmax_t",
-              "Culong",
-              "Culonglong",
-              "Cushort",
-              "Cvoid",
-              "Cwchar_t",
-              "Cwstring",
-              "DataType",
-              "DenseArray",
-              "DenseMatrix",
-              "DenseVecOrMat",
-              "DenseVector",
-              "Dict",
-              "DimensionMismatch",
-              "Dims",
-              "DivideError",
-              "DomainError",
-              "EOFError",
-              "Enum",
-              "ErrorException",
-              "Exception",
-              "ExponentialBackOff",
-              "Expr",
-              "Float16",
-              "Float32",
-              "Float64",
-              "Function",
-              "GlobalRef",
-              "HTML",
-              "IO",
-              "IOBuffer",
-              "IOContext",
-              "IOStream",
-              "IdDict",
-              "IndexCartesian",
-              "IndexLinear",
-              "IndexStyle",
-              "InexactError",
-              "InitError",
-              "Int",
-              "Int128",
-              "Int16",
-              "Int32",
-              "Int64",
-              "Int8",
-              "Integer",
-              "InterruptException",
-              "InvalidStateException",
-              "Irrational",
-              "KeyError",
-              "LinRange",
-              "LineNumberNode",
-              "LinearIndices",
-              "LoadError",
-              "MIME",
-              "Matrix",
-              "Method",
-              "MethodError",
-              "Missing",
-              "MissingException",
-              "Module",
-              "NTuple",
-              "NamedTuple",
-              "Nothing",
-              "Number",
-              "OrdinalRange",
-              "OutOfMemoryError",
-              "OverflowError",
-              "Pair",
-              "PartialQuickSort",
-              "PermutedDimsArray",
-              "Pipe",
-              "ProcessFailedException",
-              "Ptr",
-              "QuoteNode",
-              "Rational",
-              "RawFD",
-              "ReadOnlyMemoryError",
-              "Real",
-              "ReentrantLock",
-              "Ref",
-              "Regex",
-              "RegexMatch",
-              "RoundingMode",
-              "SegmentationFault",
-              "Set",
-              "Signed",
-              "Some",
-              "StackOverflowError",
-              "StepRange",
-              "StepRangeLen",
-              "StridedArray",
-              "StridedMatrix",
-              "StridedVecOrMat",
-              "StridedVector",
-              "String",
-              "StringIndexError",
-              "SubArray",
-              "SubString",
-              "SubstitutionString",
-              "Symbol",
-              "SystemError",
-              "Task",
-              "TaskFailedException",
-              "Text",
-              "TextDisplay",
-              "Timer",
-              "Tuple",
-              "Type",
-              "TypeError",
-              "TypeVar",
-              "UInt",
-              "UInt128",
-              "UInt16",
-              "UInt32",
-              "UInt64",
-              "UInt8",
-              "UndefInitializer",
-              "UndefKeywordError",
-              "UndefRefError",
-              "UndefVarError",
-              "Union",
-              "UnionAll",
-              "UnitRange",
-              "Unsigned",
-              "Val",
-              "Vararg",
-              "VecElement",
-              "VecOrMat",
-              "Vector",
-              "VersionNumber",
-              "WeakKeyDict",
-              "WeakRef",
-            ],
-          },
-          s = { keywords: t, illegal: /<\// },
-          a = { className: "subst", begin: /\$\(/, end: /\)/, keywords: t },
-          i = { className: "variable", begin: "\\$" + n },
-          r = {
-            className: "string",
-            contains: [e.BACKSLASH_ESCAPE, a, i],
-            variants: [
-              { begin: /\w*"""/, end: /"""\w*/, relevance: 10 },
-              { begin: /\w*"/, end: /"\w*/ },
-            ],
-          },
-          o = {
-            className: "string",
-            contains: [e.BACKSLASH_ESCAPE, a, i],
-            begin: "`",
-            end: "`",
-          },
-          c = { className: "meta", begin: "@" + n };
-        return (
-          (s.name = "Julia"),
-          (s.contains = [
-            {
-              className: "number",
-              begin:
-                /(\b0x[\d_]*(\.[\d_]*)?|0x\.\d[\d_]*)p[-+]?\d+|\b0[box][a-fA-F0-9][a-fA-F0-9_]*|(\b\d[\d_]*(\.[\d_]*)?|\.\d[\d_]*)([eEfF][-+]?\d+)?/,
-              relevance: 0,
-            },
-            { className: "string", begin: /'(.|\\[xXuU][a-zA-Z0-9]+)'/ },
-            r,
-            o,
-            c,
-            {
-              className: "comment",
-              variants: [
-                { begin: "#=", end: "=#", relevance: 10 },
-                { begin: "#", end: "$" },
-              ],
-            },
-            e.HASH_COMMENT_MODE,
-            {
-              className: "keyword",
-              begin:
-                "\\b(((abstract|primitive)\\s+)type|(mutable\\s+)?struct)\\b",
-            },
-            { begin: /<:/ },
-          ]),
-          (a.contains = s.contains),
-          s
-        );
-      },
-      grmr_kotlin: (e) => {
-        const n = {
-            keyword:
-              "abstract as val var vararg get set class object open private protected public noinline crossinline dynamic final enum if else do while for when throw try catch finally import package is in fun override companion reified inline lateinit init interface annotation data sealed internal infix operator out by constructor super tailrec where const inner suspend typealias external expect actual",
-            built_in:
-              "Byte Short Char Int Long Boolean Float Double Void Unit Nothing",
-            literal: "true false null",
-          },
-          t = { className: "symbol", begin: e.UNDERSCORE_IDENT_RE + "@" },
-          s = {
-            className: "subst",
-            begin: /\$\{/,
-            end: /\}/,
-            contains: [e.C_NUMBER_MODE],
-          },
-          a = {
-            className: "variable",
-            begin: "\\$" + e.UNDERSCORE_IDENT_RE,
-          },
-          i = {
-            className: "string",
-            variants: [
-              { begin: '"""', end: '"""(?=[^"])', contains: [a, s] },
-              {
-                begin: "'",
-                end: "'",
-                illegal: /\n/,
-                contains: [e.BACKSLASH_ESCAPE],
-              },
-              {
-                begin: '"',
-                end: '"',
-                illegal: /\n/,
-                contains: [e.BACKSLASH_ESCAPE, a, s],
-              },
-            ],
-          };
-        s.contains.push(i);
-        const r = {
-            className: "meta",
-            begin:
-              "@(?:file|property|field|get|set|receiver|param|setparam|delegate)\\s*:(?:\\s*" +
-              e.UNDERSCORE_IDENT_RE +
-              ")?",
-          },
-          o = {
-            className: "meta",
-            begin: "@" + e.UNDERSCORE_IDENT_RE,
-            contains: [
-              {
-                begin: /\(/,
-                end: /\)/,
-                contains: [e.inherit(i, { className: "string" }), "self"],
-              },
-            ],
-          },
-          c = ue,
-          l = e.COMMENT("/\\*", "\\*/", { contains: [e.C_BLOCK_COMMENT_MODE] }),
-          d = {
-            variants: [
-              { className: "type", begin: e.UNDERSCORE_IDENT_RE },
-              { begin: /\(/, end: /\)/, contains: [] },
-            ],
-          },
-          p = d;
-        return (
-          (p.variants[1].contains = [d]),
-          (d.variants[1].contains = [p]),
-          {
-            name: "Kotlin",
-            aliases: ["kt", "kts"],
-            keywords: n,
-            contains: [
-              e.COMMENT("/\\*\\*", "\\*/", {
-                relevance: 0,
-                contains: [{ className: "doctag", begin: "@[A-Za-z]+" }],
-              }),
-              e.C_LINE_COMMENT_MODE,
-              l,
-              {
-                className: "keyword",
-                begin: /\b(break|continue|return|this)\b/,
-                starts: { contains: [{ className: "symbol", begin: /@\w+/ }] },
-              },
-              t,
-              r,
-              o,
-              {
-                className: "function",
-                beginKeywords: "fun",
-                end: "[(]|$",
-                returnBegin: !0,
-                excludeEnd: !0,
-                keywords: n,
-                relevance: 5,
-                contains: [
-                  {
-                    begin: e.UNDERSCORE_IDENT_RE + "\\s*\\(",
-                    returnBegin: !0,
-                    relevance: 0,
-                    contains: [e.UNDERSCORE_TITLE_MODE],
-                  },
-                  {
-                    className: "type",
-                    begin: /</,
-                    end: />/,
-                    keywords: "reified",
-                    relevance: 0,
-                  },
-                  {
-                    className: "params",
-                    begin: /\(/,
-                    end: /\)/,
-                    endsParent: !0,
-                    keywords: n,
-                    relevance: 0,
-                    contains: [
-                      {
-                        begin: /:/,
-                        end: /[=,\/]/,
-                        endsWithParent: !0,
-                        contains: [d, e.C_LINE_COMMENT_MODE, l],
-                        relevance: 0,
-                      },
-                      e.C_LINE_COMMENT_MODE,
-                      l,
-                      r,
-                      o,
-                      i,
-                      e.C_NUMBER_MODE,
-                    ],
-                  },
-                  l,
-                ],
-              },
-              {
-                begin: [/class|interface|trait/, /\s+/, e.UNDERSCORE_IDENT_RE],
-                beginScope: {
-                  3: "title.class",
-                },
-                keywords: "class interface trait",
-                end: /[:\{(]|$/,
-                excludeEnd: !0,
-                illegal: "extends implements",
-                contains: [
-                  {
-                    beginKeywords:
-                      "public protected internal private constructor",
-                  },
-                  e.UNDERSCORE_TITLE_MODE,
-                  {
-                    className: "type",
-                    begin: /</,
-                    end: />/,
-                    excludeBegin: !0,
-                    excludeEnd: !0,
-                    relevance: 0,
-                  },
-                  {
-                    className: "type",
-                    begin: /[,:]\s*/,
-                    end: /[<\(,){\s]|$/,
-                    excludeBegin: !0,
-                    returnEnd: !0,
-                  },
-                  r,
-                  o,
-                ],
-              },
-              i,
-              {
-                className: "meta",
-                begin: "^#!/usr/bin/env",
-                end: "$",
-                illegal: "\n",
-              },
-              c,
-            ],
-          }
-        );
-      },
-      grmr_less: (e) => {
-        const n = se(e),
-          t = le,
-          s = "[\\w-]+",
-          a = "(" + s + "|@\\{" + s + "\\})",
-          i = [],
-          r = [],
-          o = (e) => ({
-            className: "string",
-            begin: "~?" + e + ".*?" + e,
-          }),
-          c = (e, n, t) => ({ className: e, begin: n, relevance: t }),
-          l = {
-            $pattern: /[a-z-]+/,
-            keyword: "and or not only",
-            attribute: ie.join(" "),
-          },
-          d = {
-            begin: "\\(",
-            end: "\\)",
-            contains: r,
-            keywords: l,
-            relevance: 0,
-          };
-        r.push(
-          e.C_LINE_COMMENT_MODE,
-          e.C_BLOCK_COMMENT_MODE,
-          o("'"),
-          o('"'),
-          n.CSS_NUMBER_MODE,
-          {
-            begin: "(url|data-uri)\\(",
-            starts: { className: "string", end: "[\\)\\n]", excludeEnd: !0 },
-          },
-          n.HEXCOLOR,
-          d,
-          c("variable", "@@?" + s, 10),
-          c("variable", "@\\{" + s + "\\}"),
-          c("built_in", "~?`[^`]*?`"),
-          {
-            className: "attribute",
-            begin: s + "\\s*:",
-            end: ":",
-            returnBegin: !0,
-            excludeEnd: !0,
-          },
-          n.IMPORTANT,
-          { beginKeywords: "and not" },
-          n.FUNCTION_DISPATCH
-        );
-        const p = r.concat({
-            begin: /\{/,
-            end: /\}/,
-            contains: i,
-          }),
-          m = {
-            beginKeywords: "when",
-            endsWithParent: !0,
-            contains: [{ beginKeywords: "and not" }].concat(r),
-          },
-          u = {
-            begin: a + "\\s*:",
-            returnBegin: !0,
-            end: /[;}]/,
-            relevance: 0,
-            contains: [
-              { begin: /-(webkit|moz|ms|o)-/ },
-              n.CSS_VARIABLE,
-              {
-                className: "attribute",
-                begin: "\\b(" + ce.join("|") + ")\\b",
-                end: /(?=:)/,
-                starts: {
-                  endsWithParent: !0,
-                  illegal: "[<=$]",
-                  relevance: 0,
-                  contains: r,
-                },
-              },
-            ],
-          },
-          b = {
-            className: "keyword",
-            begin:
-              "@(import|media|charset|font-face|(-[a-z]+-)?keyframes|supports|document|namespace|page|viewport|host)\\b",
-            starts: {
-              end: "[;{}]",
-              keywords: l,
-              returnEnd: !0,
-              contains: r,
-              relevance: 0,
-            },
-          },
-          g = {
-            className: "variable",
-            variants: [
-              { begin: "@" + s + "\\s*:", relevance: 15 },
-              { begin: "@" + s },
-            ],
-            starts: { end: "[;}]", returnEnd: !0, contains: p },
-          },
-          v = {
-            variants: [
-              {
-                begin: "[\\.#:&\\[>]",
-                end: "[;{}]",
-              },
-              { begin: a, end: /\{/ },
-            ],
-            returnBegin: !0,
-            returnEnd: !0,
-            illegal: "[<='$\"]",
-            relevance: 0,
-            contains: [
-              e.C_LINE_COMMENT_MODE,
-              e.C_BLOCK_COMMENT_MODE,
-              m,
-              c("keyword", "all\\b"),
-              c("variable", "@\\{" + s + "\\}"),
-              {
-                begin: "\\b(" + ae.join("|") + ")\\b",
-                className: "selector-tag",
-              },
-              n.CSS_NUMBER_MODE,
-              c("selector-tag", a, 0),
-              c("selector-id", "#" + a),
-              c("selector-class", "\\." + a, 0),
-              c("selector-tag", "&", 0),
-              n.ATTRIBUTE_SELECTOR_MODE,
-              {
-                className: "selector-pseudo",
-                begin: ":(" + re.join("|") + ")",
-              },
-              {
-                className: "selector-pseudo",
-                begin: ":(:)?(" + oe.join("|") + ")",
-              },
-              { begin: /\(/, end: /\)/, relevance: 0, contains: p },
-              { begin: "!important" },
-              n.FUNCTION_DISPATCH,
-            ],
-          },
-          _ = {
-            begin: s + ":(:)?" + `(${t.join("|")})`,
-            returnBegin: !0,
-            contains: [v],
-          };
-        return (
-          i.push(
-            e.C_LINE_COMMENT_MODE,
-            e.C_BLOCK_COMMENT_MODE,
-            b,
-            g,
-            _,
-            u,
-            v,
-            m,
-            n.FUNCTION_DISPATCH
-          ),
-          {
-            name: "Less",
-            case_insensitive: !0,
-            illegal: "[=>'/<($\"]",
-            contains: i,
-          }
-        );
-      },
-      grmr_lua: (e) => {
-        const n = "\\[=*\\[",
-          t = "\\]=*\\]",
-          s = { begin: n, end: t, contains: ["self"] },
-          a = [
-            e.COMMENT("--(?!" + n + ")", "$"),
-            e.COMMENT("--" + n, t, { contains: [s], relevance: 10 }),
-          ];
-        return {
-          name: "Lua",
-          keywords: {
-            $pattern: e.UNDERSCORE_IDENT_RE,
-            literal: "true false nil",
-            keyword:
-              "and break do else elseif end for goto if in local not or repeat return then until while",
-            built_in:
-              "_G _ENV _VERSION __index __newindex __mode __call __metatable __tostring __len __gc __add __sub __mul __div __mod __pow __concat __unm __eq __lt __le assert collectgarbage dofile error getfenv getmetatable ipairs load loadfile loadstring module next pairs pcall print rawequal rawget rawset require select setfenv setmetatable tonumber tostring type unpack xpcall arg self coroutine resume yield status wrap create running debug getupvalue debug sethook getmetatable gethook setmetatable setlocal traceback setfenv getinfo setupvalue getlocal getregistry getfenv io lines write close flush open output type read stderr stdin input stdout popen tmpfile math log max acos huge ldexp pi cos tanh pow deg tan cosh sinh random randomseed frexp ceil floor rad abs sqrt modf asin min mod fmod log10 atan2 exp sin atan os exit setlocale date getenv difftime remove time clock tmpname rename execute package preload loadlib loaded loaders cpath config path seeall string sub upper len gfind rep find match char dump gmatch reverse byte format gsub lower table setn insert getn foreachi maxn foreach concat sort remove",
-          },
-          contains: a.concat([
-            {
-              className: "function",
-              beginKeywords: "function",
-              end: "\\)",
+              className: "class",
+              beginKeywords: "struct protocol class extension enum",
+              keywords: i,
+              end: "\\{",
+              excludeEnd: !0,
               contains: [
                 e.inherit(e.TITLE_MODE, {
-                  begin: "([_a-zA-Z]\\w*\\.)*([_a-zA-Z]\\w*:)?[_a-zA-Z]\\w*",
+                  begin: /[A-Za-z$_][\u00C0-\u02B80-9A-Za-z$_]*/,
                 }),
-                {
-                  className: "params",
-                  begin: "\\(",
-                  endsWithParent: !0,
-                  contains: a,
-                },
-              ].concat(a),
+              ],
             },
-            e.C_NUMBER_MODE,
-            e.APOS_STRING_MODE,
-            e.QUOTE_STRING_MODE,
-            {
-              className: "string",
-              begin: n,
-              end: t,
-              contains: [s],
-              relevance: 5,
-            },
-          ]),
-        };
-      },
-      grmr_makefile: (e) => {
-        const n = {
-            className: "variable",
-            variants: [
-              {
-                begin: "\\$\\(" + e.UNDERSCORE_IDENT_RE + "\\)",
-                contains: [e.BACKSLASH_ESCAPE],
-              },
-              { begin: /\$[@%<?\^\+\*]/ },
-            ],
-          },
-          t = {
-            className: "string",
-            begin: /"/,
-            end: /"/,
-            contains: [e.BACKSLASH_ESCAPE, n],
-          },
-          s = {
-            className: "variable",
-            begin: /\$\([\w-]+\s/,
-            end: /\)/,
-            keywords: {
-              built_in:
-                "subst patsubst strip findstring filter filter-out sort word wordlist firstword lastword dir notdir suffix basename addsuffix addprefix join wildcard realpath abspath error warning shell origin flavor foreach if or and call eval file value",
-            },
-            contains: [n, t],
-          },
-          a = { begin: "^" + e.UNDERSCORE_IDENT_RE + "\\s*(?=[:+?]?=)" },
-          i = {
-            className: "section",
-            begin: /^[^\s]+:/,
-            end: /$/,
-            contains: [n],
-          };
-        return {
-          name: "Makefile",
-          aliases: ["mk", "mak", "make"],
-          keywords: {
-            $pattern: /[\w-]+/,
-            keyword:
-              "define endef undefine ifdef ifndef ifeq ifneq else endif include -include sinclude override export unexport private vpath",
-          },
-          contains: [
-            e.HASH_COMMENT_MODE,
-            n,
-            t,
-            s,
-            a,
             {
               className: "meta",
-              begin: /^\.PHONY:/,
-              end: /$/,
-              keywords: { $pattern: /[\.\w]+/, keyword: ".PHONY" },
+              begin:
+                "(@discardableResult|@warn_unused_result|@exported|@lazy|@noescape|@NSCopying|@NSManaged|@objc|@objcMembers|@convention|@required|@noreturn|@IBAction|@IBDesignable|@IBInspectable|@IBOutlet|@infix|@prefix|@postfix|@autoclosure|@testable|@available|@nonobjc|@NSApplicationMain|@UIApplicationMain|@dynamicMemberLookup|@propertyWrapper)\\b",
             },
-            i,
+            {
+              beginKeywords: "import",
+              end: /$/,
+              contains: [e.C_LINE_COMMENT_MODE, n],
+            },
           ],
-        };
-      },
-      grmr_markdown: (e) => {
-        const n = {
-            begin: /<\/?[A-Za-z_]/,
-            end: ">",
+        }
+      );
+    };
+  })()
+);
+hljs.registerLanguage(
+  "typescript",
+  (function () {
+    "use strict";
+    const e = [
+        "as",
+        "in",
+        "of",
+        "if",
+        "for",
+        "while",
+        "finally",
+        "var",
+        "new",
+        "function",
+        "do",
+        "return",
+        "void",
+        "else",
+        "break",
+        "catch",
+        "instanceof",
+        "with",
+        "throw",
+        "case",
+        "default",
+        "try",
+        "switch",
+        "continue",
+        "typeof",
+        "delete",
+        "let",
+        "yield",
+        "const",
+        "class",
+        "debugger",
+        "async",
+        "await",
+        "static",
+        "import",
+        "from",
+        "export",
+        "extends",
+      ],
+      n = ["true", "false", "null", "undefined", "NaN", "Infinity"],
+      a = [].concat(
+        [
+          "setInterval",
+          "setTimeout",
+          "clearInterval",
+          "clearTimeout",
+          "require",
+          "exports",
+          "eval",
+          "isFinite",
+          "isNaN",
+          "parseFloat",
+          "parseInt",
+          "decodeURI",
+          "decodeURIComponent",
+          "encodeURI",
+          "encodeURIComponent",
+          "escape",
+          "unescape",
+        ],
+        [
+          "arguments",
+          "this",
+          "super",
+          "console",
+          "window",
+          "document",
+          "localStorage",
+          "module",
+          "global",
+        ],
+        [
+          "Intl",
+          "DataView",
+          "Number",
+          "Math",
+          "Date",
+          "String",
+          "RegExp",
+          "Object",
+          "Function",
+          "Boolean",
+          "Error",
+          "Symbol",
+          "Set",
+          "Map",
+          "WeakSet",
+          "WeakMap",
+          "Proxy",
+          "Reflect",
+          "JSON",
+          "Promise",
+          "Float64Array",
+          "Int16Array",
+          "Int32Array",
+          "Int8Array",
+          "Uint16Array",
+          "Uint32Array",
+          "Float32Array",
+          "Array",
+          "Uint8Array",
+          "Uint8ClampedArray",
+          "ArrayBuffer",
+        ],
+        [
+          "EvalError",
+          "InternalError",
+          "RangeError",
+          "ReferenceError",
+          "SyntaxError",
+          "TypeError",
+          "URIError",
+        ]
+      );
+    return function (r) {
+      var t = {
+          $pattern: "[A-Za-z$_][0-9A-Za-z$_]*",
+          keyword: e
+            .concat([
+              "type",
+              "namespace",
+              "typedef",
+              "interface",
+              "public",
+              "private",
+              "protected",
+              "implements",
+              "declare",
+              "abstract",
+              "readonly",
+            ])
+            .join(" "),
+          literal: n.join(" "),
+          built_in: a
+            .concat([
+              "any",
+              "void",
+              "number",
+              "boolean",
+              "string",
+              "object",
+              "never",
+              "enum",
+            ])
+            .join(" "),
+        },
+        s = { className: "meta", begin: "@[A-Za-z$_][0-9A-Za-z$_]*" },
+        i = {
+          className: "number",
+          variants: [
+            { begin: "\\b(0[bB][01]+)n?" },
+            { begin: "\\b(0[oO][0-7]+)n?" },
+            { begin: r.C_NUMBER_RE + "n?" },
+          ],
+          relevance: 0,
+        },
+        o = {
+          className: "subst",
+          begin: "\\$\\{",
+          end: "\\}",
+          keywords: t,
+          contains: [],
+        },
+        c = {
+          begin: "html`",
+          end: "",
+          starts: {
+            end: "`",
+            returnEnd: !1,
+            contains: [r.BACKSLASH_ESCAPE, o],
             subLanguage: "xml",
-            relevance: 0,
           },
-          t = {
-            variants: [
-              { begin: /\[.+?\]\[.*?\]/, relevance: 0 },
-              {
-                begin:
-                  /\[.+?\]\(((data|javascript|mailto):|(?:http|ftp)s?:\/\/).*?\)/,
-                relevance: 2,
-              },
-              {
-                begin: e.regex.concat(
-                  /\[.+?\]\(/,
-                  /[A-Za-z][A-Za-z0-9+.-]*/,
-                  /:\/\/.*?\)/
-                ),
-                relevance: 2,
-              },
-              { begin: /\[.+?\]\([./?&#].*?\)/, relevance: 1 },
-              {
-                begin: /\[.*?\]\(.*?\)/,
-                relevance: 0,
-              },
-            ],
-            returnBegin: !0,
-            contains: [
-              { match: /\[(?=\])/ },
-              {
-                className: "string",
-                relevance: 0,
-                begin: "\\[",
-                end: "\\]",
-                excludeBegin: !0,
-                returnEnd: !0,
-              },
-              {
-                className: "link",
-                relevance: 0,
-                begin: "\\]\\(",
-                end: "\\)",
-                excludeBegin: !0,
-                excludeEnd: !0,
-              },
-              {
-                className: "symbol",
-                relevance: 0,
-                begin: "\\]\\[",
-                end: "\\]",
-                excludeBegin: !0,
-                excludeEnd: !0,
-              },
-            ],
+        },
+        l = {
+          begin: "css`",
+          end: "",
+          starts: {
+            end: "`",
+            returnEnd: !1,
+            contains: [r.BACKSLASH_ESCAPE, o],
+            subLanguage: "css",
           },
-          s = {
-            className: "strong",
-            contains: [],
-            variants: [
-              { begin: /_{2}(?!\s)/, end: /_{2}/ },
-              { begin: /\*{2}(?!\s)/, end: /\*{2}/ },
-            ],
-          },
-          a = {
-            className: "emphasis",
-            contains: [],
-            variants: [
-              { begin: /\*(?![*\s])/, end: /\*/ },
-              {
-                begin: /_(?![_\s])/,
-                end: /_/,
-                relevance: 0,
-              },
-            ],
-          },
-          i = e.inherit(s, { contains: [] }),
-          r = e.inherit(a, { contains: [] });
-        s.contains.push(r), a.contains.push(i);
-        let o = [n, t];
-        return (
-          [s, a, i, r].forEach((e) => {
-            e.contains = e.contains.concat(o);
-          }),
-          (o = o.concat(s, a)),
+        },
+        E = {
+          className: "string",
+          begin: "`",
+          end: "`",
+          contains: [r.BACKSLASH_ESCAPE, o],
+        };
+      o.contains = [
+        r.APOS_STRING_MODE,
+        r.QUOTE_STRING_MODE,
+        c,
+        l,
+        E,
+        i,
+        r.REGEXP_MODE,
+      ];
+      var d = {
+          begin: "\\(",
+          end: /\)/,
+          keywords: t,
+          contains: [
+            "self",
+            r.QUOTE_STRING_MODE,
+            r.APOS_STRING_MODE,
+            r.NUMBER_MODE,
+          ],
+        },
+        u = {
+          className: "params",
+          begin: /\(/,
+          end: /\)/,
+          excludeBegin: !0,
+          excludeEnd: !0,
+          keywords: t,
+          contains: [r.C_LINE_COMMENT_MODE, r.C_BLOCK_COMMENT_MODE, s, d],
+        };
+      return {
+        name: "TypeScript",
+        aliases: ["ts"],
+        keywords: t,
+        contains: [
+          r.SHEBANG(),
+          { className: "meta", begin: /^\s*['"]use strict['"]/ },
+          r.APOS_STRING_MODE,
+          r.QUOTE_STRING_MODE,
+          c,
+          l,
+          E,
+          r.C_LINE_COMMENT_MODE,
+          r.C_BLOCK_COMMENT_MODE,
+          i,
           {
-            name: "Markdown",
-            aliases: ["md", "mkdown", "mkd"],
+            begin: "(" + r.RE_STARTERS_RE + "|\\b(case|return|throw)\\b)\\s*",
+            keywords: "return throw case",
             contains: [
+              r.C_LINE_COMMENT_MODE,
+              r.C_BLOCK_COMMENT_MODE,
+              r.REGEXP_MODE,
               {
-                className: "section",
-                variants: [
-                  { begin: "^#{1,6}", end: "$", contains: o },
+                className: "function",
+                begin:
+                  "(\\([^(]*(\\([^(]*(\\([^(]*\\))?\\))?\\)|" +
+                  r.UNDERSCORE_IDENT_RE +
+                  ")\\s*=>",
+                returnBegin: !0,
+                end: "\\s*=>",
+                contains: [
                   {
-                    begin: "(?=^.+?\\n[=-]{2,}$)",
-                    contains: [
-                      { begin: "^[=-]*$" },
-                      { begin: "^", end: "\\n", contains: o },
+                    className: "params",
+                    variants: [
+                      { begin: r.UNDERSCORE_IDENT_RE },
+                      { className: null, begin: /\(\s*\)/, skip: !0 },
+                      {
+                        begin: /\(/,
+                        end: /\)/,
+                        excludeBegin: !0,
+                        excludeEnd: !0,
+                        keywords: t,
+                        contains: d.contains,
+                      },
                     ],
                   },
                 ],
               },
-              n,
-              {
-                className: "bullet",
-                begin: "^[ \t]*([*+-]|(\\d+\\.))(?=\\s+)",
-                end: "\\s+",
-                excludeEnd: !0,
-              },
-              s,
-              a,
-              { className: "quote", begin: "^>\\s+", contains: o, end: "$" },
-              {
-                className: "code",
-                variants: [
-                  { begin: "(`{3,})[^`](.|\\n)*?\\1`*[ ]*" },
-                  {
-                    begin: "(~{3,})[^~](.|\\n)*?\\1~*[ ]*",
-                  },
-                  { begin: "```", end: "```+[ ]*$" },
-                  {
-                    begin: "~~~",
-                    end: "~~~+[ ]*$",
-                  },
-                  { begin: "`.+?`" },
-                  {
-                    begin: "(?=^( {4}|\\t))",
-                    contains: [{ begin: "^( {4}|\\t)", end: "(\\n)$" }],
-                    relevance: 0,
-                  },
-                ],
-              },
-              {
-                begin: "^[-\\*]{3,}",
-                end: "$",
-              },
-              t,
-              {
-                begin: /^\[[^\n]+\]:/,
-                returnBegin: !0,
-                contains: [
-                  {
-                    className: "symbol",
-                    begin: /\[/,
-                    end: /\]/,
-                    excludeBegin: !0,
-                    excludeEnd: !0,
-                  },
-                  {
-                    className: "link",
-                    begin: /:\s*/,
-                    end: /$/,
-                    excludeBegin: !0,
-                  },
-                ],
-              },
-              {
-                scope: "literal",
-                match: /&([a-zA-Z0-9]+|#[0-9]{1,7}|#[Xx][0-9a-fA-F]{1,6});/,
-              },
             ],
-          }
-        );
-      },
-      grmr_nginx: (e) => {
-        const n = e.regex,
-          t = {
-            className: "variable",
+            relevance: 0,
+          },
+          {
+            className: "function",
+            beginKeywords: "function",
+            end: /[\{;]/,
+            excludeEnd: !0,
+            keywords: t,
+            contains: [
+              "self",
+              r.inherit(r.TITLE_MODE, { begin: "[A-Za-z$_][0-9A-Za-z$_]*" }),
+              u,
+            ],
+            illegal: /%/,
+            relevance: 0,
+          },
+          {
+            beginKeywords: "constructor",
+            end: /[\{;]/,
+            excludeEnd: !0,
+            contains: ["self", u],
+          },
+          { begin: /module\./, keywords: { built_in: "module" }, relevance: 0 },
+          { beginKeywords: "module", end: /\{/, excludeEnd: !0 },
+          {
+            beginKeywords: "interface",
+            end: /\{/,
+            excludeEnd: !0,
+            keywords: "interface extends",
+          },
+          { begin: /\$[(.]/ },
+          { begin: "\\." + r.IDENT_RE, relevance: 0 },
+          s,
+          d,
+        ],
+      };
+    };
+  })()
+);
+hljs.registerLanguage(
+  "yaml",
+  (function () {
+    "use strict";
+    return function (e) {
+      var n = "true false yes no null",
+        a = "[\\w#;/?:@&=+$,.~*\\'()[\\]]+",
+        s = {
+          className: "string",
+          relevance: 0,
+          variants: [
+            { begin: /'/, end: /'/ },
+            { begin: /"/, end: /"/ },
+            { begin: /\S+/ },
+          ],
+          contains: [
+            e.BACKSLASH_ESCAPE,
+            {
+              className: "template-variable",
+              variants: [
+                { begin: "{{", end: "}}" },
+                { begin: "%{", end: "}" },
+              ],
+            },
+          ],
+        },
+        i = e.inherit(s, {
+          variants: [
+            { begin: /'/, end: /'/ },
+            { begin: /"/, end: /"/ },
+            { begin: /[^\s,{}[\]]+/ },
+          ],
+        }),
+        l = {
+          end: ",",
+          endsWithParent: !0,
+          excludeEnd: !0,
+          contains: [],
+          keywords: n,
+          relevance: 0,
+        },
+        t = {
+          begin: "{",
+          end: "}",
+          contains: [l],
+          illegal: "\\n",
+          relevance: 0,
+        },
+        g = {
+          begin: "\\[",
+          end: "\\]",
+          contains: [l],
+          illegal: "\\n",
+          relevance: 0,
+        },
+        b = [
+          {
+            className: "attr",
             variants: [
-              { begin: /\$\d+/ },
-              {
-                begin: /\$\{\w+\}/,
-              },
-              { begin: n.concat(/[$@]/, e.UNDERSCORE_IDENT_RE) },
+              { begin: "\\w[\\w :\\/.-]*:(?=[ \t]|$)" },
+              { begin: '"\\w[\\w :\\/.-]*":(?=[ \t]|$)' },
+              { begin: "'\\w[\\w :\\/.-]*':(?=[ \t]|$)" },
             ],
           },
-          s = {
-            endsWithParent: !0,
-            keywords: {
-              $pattern: /[a-z_]{2,}|\/dev\/poll/,
-              literal: [
-                "on",
-                "off",
-                "yes",
-                "no",
-                "true",
-                "false",
-                "none",
-                "blocked",
-                "debug",
-                "info",
-                "notice",
-                "warn",
-                "error",
-                "crit",
-                "select",
-                "break",
-                "last",
-                "permanent",
-                "redirect",
-                "kqueue",
-                "rtsig",
-                "epoll",
-                "poll",
-                "/dev/poll",
-              ],
-            },
+          { className: "meta", begin: "^---s*$", relevance: 10 },
+          {
+            className: "string",
+            begin: "[\\|>]([0-9]?[+-])?[ ]*\\n( *)[\\S ]+\\n(\\2[\\S ]+\\n?)*",
+          },
+          {
+            begin: "<%[%=-]?",
+            end: "[%-]?%>",
+            subLanguage: "ruby",
+            excludeBegin: !0,
+            excludeEnd: !0,
             relevance: 0,
-            illegal: "=>",
-            contains: [
-              e.HASH_COMMENT_MODE,
-              {
-                className: "string",
-                contains: [e.BACKSLASH_ESCAPE, t],
-                variants: [
-                  { begin: /"/, end: /"/ },
-                  { begin: /'/, end: /'/ },
-                ],
-              },
-              {
-                begin: "([a-z]+):/",
-                end: "\\s",
-                endsWithParent: !0,
-                excludeEnd: !0,
-                contains: [t],
-              },
-              {
-                className: "regexp",
-                contains: [e.BACKSLASH_ESCAPE, t],
-                variants: [
-                  { begin: "\\s\\^", end: "\\s|\\{|;", returnEnd: !0 },
-                  { begin: "~\\*?\\s+", end: "\\s|\\{|;", returnEnd: !0 },
-                  {
-                    begin: "\\*(\\.[a-z\\-]+)+",
-                  },
-                  { begin: "([a-z\\-]+\\.)+\\*" },
-                ],
-              },
-              {
-                className: "number",
-                begin:
-                  "\\b\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}(:\\d{1,5})?\\b",
-              },
-              {
-                className: "number",
-                begin: "\\b\\d+[kKmMgGdshdwy]?\\b",
-                relevance: 0,
-              },
-              t,
-            ],
-          };
-        return {
-          name: "Nginx config",
-          aliases: ["nginxconf"],
-          contains: [
-            e.HASH_COMMENT_MODE,
-            {
-              beginKeywords: "upstream location",
-              end: /;|\{/,
-              contains: s.contains,
-              keywords: {
-                section: "upstream location",
-              },
-            },
-            {
-              className: "section",
-              begin: n.concat(e.UNDERSCORE_IDENT_RE + n.lookahead(/\s+\{/)),
-              relevance: 0,
-            },
-            {
-              begin: n.lookahead(e.UNDERSCORE_IDENT_RE + "\\s"),
-              end: ";|\\{",
-              contains: [
-                {
-                  className: "attribute",
-                  begin: e.UNDERSCORE_IDENT_RE,
-                  starts: s,
-                },
-              ],
-              relevance: 0,
-            },
-          ],
-          illegal: "[^\\s\\}\\{]",
-        };
-      },
-      grmr_nim: (e) => ({
-        name: "Nim",
+          },
+          { className: "type", begin: "!\\w+!" + a },
+          { className: "type", begin: "!<" + a + ">" },
+          { className: "type", begin: "!" + a },
+          { className: "type", begin: "!!" + a },
+          { className: "meta", begin: "&" + e.UNDERSCORE_IDENT_RE + "$" },
+          { className: "meta", begin: "\\*" + e.UNDERSCORE_IDENT_RE + "$" },
+          { className: "bullet", begin: "\\-(?=[ ]|$)", relevance: 0 },
+          e.HASH_COMMENT_MODE,
+          { beginKeywords: n, keywords: { literal: n } },
+          {
+            className: "number",
+            begin:
+              "\\b[0-9]{4}(-[0-9][0-9]){0,2}([Tt \\t][0-9][0-9]?(:[0-9][0-9]){2})?(\\.[0-9]*)?([ \\t])*(Z|[-+][0-9][0-9]?(:[0-9][0-9])?)?\\b",
+          },
+          { className: "number", begin: e.C_NUMBER_RE + "\\b" },
+          t,
+          g,
+          s,
+        ],
+        c = [...b];
+      return (
+        c.pop(),
+        c.push(i),
+        (l.contains = c),
+        {
+          name: "YAML",
+          case_insensitive: !0,
+          aliases: ["yml", "YAML"],
+          contains: b,
+        }
+      );
+    };
+  })()
+);
+hljs.registerLanguage(
+  "armasm",
+  (function () {
+    "use strict";
+    return function (s) {
+      const e = {
+        variants: [
+          s.COMMENT("^[ \\t]*(?=#)", "$", { relevance: 0, excludeBegin: !0 }),
+          s.COMMENT("[;@]", "$", { relevance: 0 }),
+          s.C_LINE_COMMENT_MODE,
+          s.C_BLOCK_COMMENT_MODE,
+        ],
+      };
+      return {
+        name: "ARM Assembly",
+        case_insensitive: !0,
+        aliases: ["arm"],
         keywords: {
-          keyword: [
-            "addr",
-            "and",
-            "as",
-            "asm",
-            "bind",
-            "block",
-            "break",
-            "case",
-            "cast",
-            "const",
-            "continue",
-            "converter",
-            "discard",
-            "distinct",
-            "div",
-            "do",
-            "elif",
-            "else",
-            "end",
-            "enum",
-            "except",
-            "export",
-            "finally",
-            "for",
-            "from",
-            "func",
-            "generic",
-            "guarded",
-            "if",
-            "import",
-            "in",
-            "include",
-            "interface",
-            "is",
-            "isnot",
-            "iterator",
-            "let",
-            "macro",
-            "method",
-            "mixin",
-            "mod",
-            "nil",
-            "not",
-            "notin",
-            "object",
-            "of",
-            "or",
-            "out",
-            "proc",
-            "ptr",
-            "raise",
-            "ref",
-            "return",
-            "shared",
-            "shl",
-            "shr",
-            "static",
-            "template",
-            "try",
-            "tuple",
-            "type",
-            "using",
-            "var",
-            "when",
-            "while",
-            "with",
-            "without",
-            "xor",
-            "yield",
-          ],
-          literal: ["true", "false"],
-          type: [
-            "int",
-            "int8",
-            "int16",
-            "int32",
-            "int64",
-            "uint",
-            "uint8",
-            "uint16",
-            "uint32",
-            "uint64",
-            "float",
-            "float32",
-            "float64",
-            "bool",
-            "char",
-            "string",
-            "cstring",
-            "pointer",
-            "expr",
-            "stmt",
-            "void",
-            "auto",
-            "any",
-            "range",
-            "array",
-            "openarray",
-            "varargs",
-            "seq",
-            "set",
-            "clong",
-            "culong",
-            "cchar",
-            "cschar",
-            "cshort",
-            "cint",
-            "csize",
-            "clonglong",
-            "cfloat",
-            "cdouble",
-            "clongdouble",
-            "cuchar",
-            "cushort",
-            "cuint",
-            "culonglong",
-            "cstringarray",
-            "semistatic",
-          ],
-          built_in: ["stdin", "stdout", "stderr", "result"],
+          $pattern: "\\.?" + s.IDENT_RE,
+          meta: ".2byte .4byte .align .ascii .asciz .balign .byte .code .data .else .end .endif .endm .endr .equ .err .exitm .extern .global .hword .if .ifdef .ifndef .include .irp .long .macro .rept .req .section .set .skip .space .text .word .arm .thumb .code16 .code32 .force_thumb .thumb_func .ltorg ALIAS ALIGN ARM AREA ASSERT ATTR CN CODE CODE16 CODE32 COMMON CP DATA DCB DCD DCDU DCDO DCFD DCFDU DCI DCQ DCQU DCW DCWU DN ELIF ELSE END ENDFUNC ENDIF ENDP ENTRY EQU EXPORT EXPORTAS EXTERN FIELD FILL FUNCTION GBLA GBLL GBLS GET GLOBAL IF IMPORT INCBIN INCLUDE INFO KEEP LCLA LCLL LCLS LTORG MACRO MAP MEND MEXIT NOFP OPT PRESERVE8 PROC QN READONLY RELOC REQUIRE REQUIRE8 RLIST FN ROUT SETA SETL SETS SN SPACE SUBT THUMB THUMBX TTL WHILE WEND ",
+          built_in:
+            "r0 r1 r2 r3 r4 r5 r6 r7 r8 r9 r10 r11 r12 r13 r14 r15 pc lr sp ip sl sb fp a1 a2 a3 a4 v1 v2 v3 v4 v5 v6 v7 v8 f0 f1 f2 f3 f4 f5 f6 f7 p0 p1 p2 p3 p4 p5 p6 p7 p8 p9 p10 p11 p12 p13 p14 p15 c0 c1 c2 c3 c4 c5 c6 c7 c8 c9 c10 c11 c12 c13 c14 c15 q0 q1 q2 q3 q4 q5 q6 q7 q8 q9 q10 q11 q12 q13 q14 q15 cpsr_c cpsr_x cpsr_s cpsr_f cpsr_cx cpsr_cxs cpsr_xs cpsr_xsf cpsr_sf cpsr_cxsf spsr_c spsr_x spsr_s spsr_f spsr_cx spsr_cxs spsr_xs spsr_xsf spsr_sf spsr_cxsf s0 s1 s2 s3 s4 s5 s6 s7 s8 s9 s10 s11 s12 s13 s14 s15 s16 s17 s18 s19 s20 s21 s22 s23 s24 s25 s26 s27 s28 s29 s30 s31 d0 d1 d2 d3 d4 d5 d6 d7 d8 d9 d10 d11 d12 d13 d14 d15 d16 d17 d18 d19 d20 d21 d22 d23 d24 d25 d26 d27 d28 d29 d30 d31 {PC} {VAR} {TRUE} {FALSE} {OPT} {CONFIG} {ENDIAN} {CODESIZE} {CPU} {FPU} {ARCHITECTURE} {PCSTOREOFFSET} {ARMASM_VERSION} {INTER} {ROPI} {RWPI} {SWST} {NOSWST} . @",
         },
         contains: [
-          { className: "meta", begin: /\{\./, end: /\.\}/, relevance: 10 },
+          {
+            className: "keyword",
+            begin:
+              "\\b(adc|(qd?|sh?|u[qh]?)?add(8|16)?|usada?8|(q|sh?|u[qh]?)?(as|sa)x|and|adrl?|sbc|rs[bc]|asr|b[lx]?|blx|bxj|cbn?z|tb[bh]|bic|bfc|bfi|[su]bfx|bkpt|cdp2?|clz|clrex|cmp|cmn|cpsi[ed]|cps|setend|dbg|dmb|dsb|eor|isb|it[te]{0,3}|lsl|lsr|ror|rrx|ldm(([id][ab])|f[ds])?|ldr((s|ex)?[bhd])?|movt?|mvn|mra|mar|mul|[us]mull|smul[bwt][bt]|smu[as]d|smmul|smmla|mla|umlaal|smlal?([wbt][bt]|d)|mls|smlsl?[ds]|smc|svc|sev|mia([bt]{2}|ph)?|mrr?c2?|mcrr2?|mrs|msr|orr|orn|pkh(tb|bt)|rbit|rev(16|sh)?|sel|[su]sat(16)?|nop|pop|push|rfe([id][ab])?|stm([id][ab])?|str(ex)?[bhd]?|(qd?)?sub|(sh?|q|u[qh]?)?sub(8|16)|[su]xt(a?h|a?b(16)?)|srs([id][ab])?|swpb?|swi|smi|tst|teq|wfe|wfi|yield)(eq|ne|cs|cc|mi|pl|vs|vc|hi|ls|ge|lt|gt|le|al|hs|lo)?[sptrx]?(?=\\s)",
+          },
+          e,
+          s.QUOTE_STRING_MODE,
+          { className: "string", begin: "'", end: "[^\\\\]'", relevance: 0 },
+          {
+            className: "title",
+            begin: "\\|",
+            end: "\\|",
+            illegal: "\\n",
+            relevance: 0,
+          },
+          {
+            className: "number",
+            variants: [
+              { begin: "[#$=]?0x[0-9a-f]+" },
+              { begin: "[#$=]?0b[01]+" },
+              { begin: "[#$=]\\d+" },
+              { begin: "\\b\\d+" },
+            ],
+            relevance: 0,
+          },
+          {
+            className: "symbol",
+            variants: [
+              { begin: "^[ \\t]*[a-z_\\.\\$][a-z0-9_\\.\\$]+:" },
+              { begin: "^[a-z_\\.\\$][a-z0-9_\\.\\$]+" },
+              { begin: "[=#]\\w+" },
+            ],
+            relevance: 0,
+          },
+        ],
+      };
+    };
+  })()
+);
+hljs.registerLanguage(
+  "d",
+  (function () {
+    "use strict";
+    return function (e) {
+      var a = {
+          $pattern: e.UNDERSCORE_IDENT_RE,
+          keyword:
+            "abstract alias align asm assert auto body break byte case cast catch class const continue debug default delete deprecated do else enum export extern final finally for foreach foreach_reverse|10 goto if immutable import in inout int interface invariant is lazy macro mixin module new nothrow out override package pragma private protected public pure ref return scope shared static struct super switch synchronized template this throw try typedef typeid typeof union unittest version void volatile while with __FILE__ __LINE__ __gshared|10 __thread __traits __DATE__ __EOF__ __TIME__ __TIMESTAMP__ __VENDOR__ __VERSION__",
+          built_in:
+            "bool cdouble cent cfloat char creal dchar delegate double dstring float function idouble ifloat ireal long real short string ubyte ucent uint ulong ushort wchar wstring",
+          literal: "false null true",
+        },
+        d =
+          "((0|[1-9][\\d_]*)|0[bB][01_]+|0[xX]([\\da-fA-F][\\da-fA-F_]*|_[\\da-fA-F][\\da-fA-F_]*))",
+        n =
+          "\\\\(['\"\\?\\\\abfnrtv]|u[\\dA-Fa-f]{4}|[0-7]{1,3}|x[\\dA-Fa-f]{2}|U[\\dA-Fa-f]{8})|&[a-zA-Z\\d]{2,};",
+        t = {
+          className: "number",
+          begin: "\\b" + d + "(L|u|U|Lu|LU|uL|UL)?",
+          relevance: 0,
+        },
+        _ = {
+          className: "number",
+          begin:
+            "\\b(((0[xX](([\\da-fA-F][\\da-fA-F_]*|_[\\da-fA-F][\\da-fA-F_]*)\\.([\\da-fA-F][\\da-fA-F_]*|_[\\da-fA-F][\\da-fA-F_]*)|\\.?([\\da-fA-F][\\da-fA-F_]*|_[\\da-fA-F][\\da-fA-F_]*))[pP][+-]?(0|[1-9][\\d_]*|\\d[\\d_]*|[\\d_]+?\\d))|((0|[1-9][\\d_]*|\\d[\\d_]*|[\\d_]+?\\d)(\\.\\d*|([eE][+-]?(0|[1-9][\\d_]*|\\d[\\d_]*|[\\d_]+?\\d)))|\\d+\\.(0|[1-9][\\d_]*|\\d[\\d_]*|[\\d_]+?\\d)(0|[1-9][\\d_]*|\\d[\\d_]*|[\\d_]+?\\d)|\\.(0|[1-9][\\d_]*)([eE][+-]?(0|[1-9][\\d_]*|\\d[\\d_]*|[\\d_]+?\\d))?))([fF]|L|i|[fF]i|Li)?|" +
+            d +
+            "(i|[fF]i|Li))",
+          relevance: 0,
+        },
+        r = {
+          className: "string",
+          begin: "'(" + n + "|.)",
+          end: "'",
+          illegal: ".",
+        },
+        i = {
+          className: "string",
+          begin: '"',
+          contains: [{ begin: n, relevance: 0 }],
+          end: '"[cwd]?',
+        },
+        s = e.COMMENT("\\/\\+", "\\+\\/", {
+          contains: ["self"],
+          relevance: 10,
+        });
+      return {
+        name: "D",
+        keywords: a,
+        contains: [
+          e.C_LINE_COMMENT_MODE,
+          e.C_BLOCK_COMMENT_MODE,
+          s,
+          {
+            className: "string",
+            begin: 'x"[\\da-fA-F\\s\\n\\r]*"[cwd]?',
+            relevance: 10,
+          },
+          i,
+          { className: "string", begin: '[rq]"', end: '"[cwd]?', relevance: 5 },
+          { className: "string", begin: "`", end: "`[cwd]?" },
+          { className: "string", begin: 'q"\\{', end: '\\}"' },
+          _,
+          t,
+          r,
+          { className: "meta", begin: "^#!", end: "$", relevance: 5 },
+          { className: "meta", begin: "#(line)", end: "$", relevance: 5 },
+          { className: "keyword", begin: "@[a-zA-Z_][a-zA-Z_\\d]*" },
+        ],
+      };
+    };
+  })()
+);
+hljs.registerLanguage(
+  "handlebars",
+  (function () {
+    "use strict";
+    function e(...e) {
+      return e
+        .map((e) =>
+          (function (e) {
+            return e ? ("string" == typeof e ? e : e.source) : null;
+          })(e)
+        )
+        .join("");
+    }
+    return function (n) {
+      const a = {
+          "builtin-name":
+            "action bindattr collection component concat debugger each each-in get hash if in input link-to loc log lookup mut outlet partial query-params render template textarea unbound unless view with yield",
+        },
+        t = /\[.*?\]/,
+        s = /[^\s!"#%&'()*+,.\/;<=>@\[\\\]^`{|}~]+/,
+        i = e("(", /'.*?'/, "|", /".*?"/, "|", t, "|", s, "|", /\.|\//, ")+"),
+        r = e("(", t, "|", s, ")(?==)"),
+        l = { begin: i, lexemes: /[\w.\/]+/ },
+        c = n.inherit(l, {
+          keywords: { literal: "true false undefined null" },
+        }),
+        o = { begin: /\(/, end: /\)/ },
+        m = {
+          className: "attr",
+          begin: r,
+          relevance: 0,
+          starts: {
+            begin: /=/,
+            end: /=/,
+            starts: {
+              contains: [
+                n.NUMBER_MODE,
+                n.QUOTE_STRING_MODE,
+                n.APOS_STRING_MODE,
+                c,
+                o,
+              ],
+            },
+          },
+        },
+        d = {
+          contains: [
+            n.NUMBER_MODE,
+            n.QUOTE_STRING_MODE,
+            n.APOS_STRING_MODE,
+            {
+              begin: /as\s+\|/,
+              keywords: { keyword: "as" },
+              end: /\|/,
+              contains: [{ begin: /\w+/ }],
+            },
+            m,
+            c,
+            o,
+          ],
+          returnEnd: !0,
+        },
+        g = n.inherit(l, {
+          className: "name",
+          keywords: a,
+          starts: n.inherit(d, { end: /\)/ }),
+        });
+      o.contains = [g];
+      const u = n.inherit(l, {
+          keywords: a,
+          className: "name",
+          starts: n.inherit(d, { end: /}}/ }),
+        }),
+        b = n.inherit(l, { keywords: a, className: "name" }),
+        h = n.inherit(l, {
+          className: "name",
+          keywords: a,
+          starts: n.inherit(d, { end: /}}/ }),
+        });
+      return {
+        name: "Handlebars",
+        aliases: ["hbs", "html.hbs", "html.handlebars", "htmlbars"],
+        case_insensitive: !0,
+        subLanguage: "xml",
+        contains: [
+          { begin: /\\\{\{/, skip: !0 },
+          { begin: /\\\\(?=\{\{)/, skip: !0 },
+          n.COMMENT(/\{\{!--/, /--\}\}/),
+          n.COMMENT(/\{\{!/, /\}\}/),
+          {
+            className: "template-tag",
+            begin: /\{\{\{\{(?!\/)/,
+            end: /\}\}\}\}/,
+            contains: [u],
+            starts: { end: /\{\{\{\{\//, returnEnd: !0, subLanguage: "xml" },
+          },
+          {
+            className: "template-tag",
+            begin: /\{\{\{\{\//,
+            end: /\}\}\}\}/,
+            contains: [b],
+          },
+          {
+            className: "template-tag",
+            begin: /\{\{#/,
+            end: /\}\}/,
+            contains: [u],
+          },
+          {
+            className: "template-tag",
+            begin: /\{\{(?=else\}\})/,
+            end: /\}\}/,
+            keywords: "else",
+          },
+          {
+            className: "template-tag",
+            begin: /\{\{\//,
+            end: /\}\}/,
+            contains: [b],
+          },
+          {
+            className: "template-variable",
+            begin: /\{\{\{/,
+            end: /\}\}\}/,
+            contains: [h],
+          },
+          {
+            className: "template-variable",
+            begin: /\{\{/,
+            end: /\}\}/,
+            contains: [h],
+          },
+        ],
+      };
+    };
+  })()
+);
+hljs.registerLanguage(
+  "haskell",
+  (function () {
+    "use strict";
+    return function (e) {
+      var n = {
+          variants: [
+            e.COMMENT("--", "$"),
+            e.COMMENT("{-", "-}", { contains: ["self"] }),
+          ],
+        },
+        i = { className: "meta", begin: "{-#", end: "#-}" },
+        a = { className: "meta", begin: "^#", end: "$" },
+        s = { className: "type", begin: "\\b[A-Z][\\w']*", relevance: 0 },
+        l = {
+          begin: "\\(",
+          end: "\\)",
+          illegal: '"',
+          contains: [
+            i,
+            a,
+            {
+              className: "type",
+              begin: "\\b[A-Z][\\w]*(\\((\\.\\.|,|\\w+)\\))?",
+            },
+            e.inherit(e.TITLE_MODE, { begin: "[_a-z][\\w']*" }),
+            n,
+          ],
+        };
+      return {
+        name: "Haskell",
+        aliases: ["hs"],
+        keywords:
+          "let in if then else case of where do module import hiding qualified type data newtype deriving class instance as default infix infixl infixr foreign export ccall stdcall cplusplus jvm dotnet safe unsafe family forall mdo proc rec",
+        contains: [
+          {
+            beginKeywords: "module",
+            end: "where",
+            keywords: "module where",
+            contains: [l, n],
+            illegal: "\\W\\.|;",
+          },
+          {
+            begin: "\\bimport\\b",
+            end: "$",
+            keywords: "import qualified as hiding",
+            contains: [l, n],
+            illegal: "\\W\\.|;",
+          },
+          {
+            className: "class",
+            begin: "^(\\s*)?(class|instance)\\b",
+            end: "where",
+            keywords: "class family instance where",
+            contains: [s, l, n],
+          },
+          {
+            className: "class",
+            begin: "\\b(data|(new)?type)\\b",
+            end: "$",
+            keywords: "data family type newtype deriving",
+            contains: [
+              i,
+              s,
+              l,
+              { begin: "{", end: "}", contains: l.contains },
+              n,
+            ],
+          },
+          { beginKeywords: "default", end: "$", contains: [s, l, n] },
+          {
+            beginKeywords: "infix infixl infixr",
+            end: "$",
+            contains: [e.C_NUMBER_MODE, n],
+          },
+          {
+            begin: "\\bforeign\\b",
+            end: "$",
+            keywords:
+              "foreign import export ccall stdcall cplusplus jvm dotnet safe unsafe",
+            contains: [s, e.QUOTE_STRING_MODE, n],
+          },
+          {
+            className: "meta",
+            begin: "#!\\/usr\\/bin\\/env runhaskell",
+            end: "$",
+          },
+          i,
+          a,
+          e.QUOTE_STRING_MODE,
+          e.C_NUMBER_MODE,
+          s,
+          e.inherit(e.TITLE_MODE, { begin: "^[_a-z][\\w']*" }),
+          n,
+          { begin: "->|<-" },
+        ],
+      };
+    };
+  })()
+);
+hljs.registerLanguage(
+  "julia",
+  (function () {
+    "use strict";
+    return function (e) {
+      var r = "[A-Za-z_\\u00A1-\\uFFFF][A-Za-z_0-9\\u00A1-\\uFFFF]*",
+        t = {
+          $pattern: r,
+          keyword:
+            "in isa where baremodule begin break catch ccall const continue do else elseif end export false finally for function global if import importall let local macro module quote return true try using while type immutable abstract bitstype typealias ",
+          literal:
+            "true false ARGS C_NULL DevNull ENDIAN_BOM ENV I Inf Inf16 Inf32 Inf64 InsertionSort JULIA_HOME LOAD_PATH MergeSort NaN NaN16 NaN32 NaN64 PROGRAM_FILE QuickSort RoundDown RoundFromZero RoundNearest RoundNearestTiesAway RoundNearestTiesUp RoundToZero RoundUp STDERR STDIN STDOUT VERSION catalan e|0 eu|0 eulergamma golden im nothing pi γ π φ ",
+          built_in:
+            "ANY AbstractArray AbstractChannel AbstractFloat AbstractMatrix AbstractRNG AbstractSerializer AbstractSet AbstractSparseArray AbstractSparseMatrix AbstractSparseVector AbstractString AbstractUnitRange AbstractVecOrMat AbstractVector Any ArgumentError Array AssertionError Associative Base64DecodePipe Base64EncodePipe Bidiagonal BigFloat BigInt BitArray BitMatrix BitVector Bool BoundsError BufferStream CachingPool CapturedException CartesianIndex CartesianRange Cchar Cdouble Cfloat Channel Char Cint Cintmax_t Clong Clonglong ClusterManager Cmd CodeInfo Colon Complex Complex128 Complex32 Complex64 CompositeException Condition ConjArray ConjMatrix ConjVector Cptrdiff_t Cshort Csize_t Cssize_t Cstring Cuchar Cuint Cuintmax_t Culong Culonglong Cushort Cwchar_t Cwstring DataType Date DateFormat DateTime DenseArray DenseMatrix DenseVecOrMat DenseVector Diagonal Dict DimensionMismatch Dims DirectIndexString Display DivideError DomainError EOFError EachLine Enum Enumerate ErrorException Exception ExponentialBackOff Expr Factorization FileMonitor Float16 Float32 Float64 Function Future GlobalRef GotoNode HTML Hermitian IO IOBuffer IOContext IOStream IPAddr IPv4 IPv6 IndexCartesian IndexLinear IndexStyle InexactError InitError Int Int128 Int16 Int32 Int64 Int8 IntSet Integer InterruptException InvalidStateException Irrational KeyError LabelNode LinSpace LineNumberNode LoadError LowerTriangular MIME Matrix MersenneTwister Method MethodError MethodTable Module NTuple NewvarNode NullException Nullable Number ObjectIdDict OrdinalRange OutOfMemoryError OverflowError Pair ParseError PartialQuickSort PermutedDimsArray Pipe PollingFileWatcher ProcessExitedException Ptr QuoteNode RandomDevice Range RangeIndex Rational RawFD ReadOnlyMemoryError Real ReentrantLock Ref Regex RegexMatch RemoteChannel RemoteException RevString RoundingMode RowVector SSAValue SegmentationFault SerializationState Set SharedArray SharedMatrix SharedVector Signed SimpleVector Slot SlotNumber SparseMatrixCSC SparseVector StackFrame StackOverflowError StackTrace StepRange StepRangeLen StridedArray StridedMatrix StridedVecOrMat StridedVector String SubArray SubString SymTridiagonal Symbol Symmetric SystemError TCPSocket Task Text TextDisplay Timer Tridiagonal Tuple Type TypeError TypeMapEntry TypeMapLevel TypeName TypeVar TypedSlot UDPSocket UInt UInt128 UInt16 UInt32 UInt64 UInt8 UndefRefError UndefVarError UnicodeError UniformScaling Union UnionAll UnitRange Unsigned UpperTriangular Val Vararg VecElement VecOrMat Vector VersionNumber Void WeakKeyDict WeakRef WorkerConfig WorkerPool ",
+        },
+        a = { keywords: t, illegal: /<\// },
+        n = { className: "subst", begin: /\$\(/, end: /\)/, keywords: t },
+        o = { className: "variable", begin: "\\$" + r },
+        i = {
+          className: "string",
+          contains: [e.BACKSLASH_ESCAPE, n, o],
+          variants: [
+            { begin: /\w*"""/, end: /"""\w*/, relevance: 10 },
+            { begin: /\w*"/, end: /"\w*/ },
+          ],
+        },
+        l = {
+          className: "string",
+          contains: [e.BACKSLASH_ESCAPE, n, o],
+          begin: "`",
+          end: "`",
+        },
+        s = { className: "meta", begin: "@" + r };
+      return (
+        (a.name = "Julia"),
+        (a.contains = [
+          {
+            className: "number",
+            begin:
+              /(\b0x[\d_]*(\.[\d_]*)?|0x\.\d[\d_]*)p[-+]?\d+|\b0[box][a-fA-F0-9][a-fA-F0-9_]*|(\b\d[\d_]*(\.[\d_]*)?|\.\d[\d_]*)([eEfF][-+]?\d+)?/,
+            relevance: 0,
+          },
+          { className: "string", begin: /'(.|\\[xXuU][a-zA-Z0-9]+)'/ },
+          i,
+          l,
+          s,
+          {
+            className: "comment",
+            variants: [
+              { begin: "#=", end: "=#", relevance: 10 },
+              { begin: "#", end: "$" },
+            ],
+          },
+          e.HASH_COMMENT_MODE,
+          {
+            className: "keyword",
+            begin:
+              "\\b(((abstract|primitive)\\s+)type|(mutable\\s+)?struct)\\b",
+          },
+          { begin: /<:/ },
+        ]),
+        (n.contains = a.contains),
+        a
+      );
+    };
+  })()
+);
+hljs.registerLanguage(
+  "nim",
+  (function () {
+    "use strict";
+    return function (e) {
+      return {
+        name: "Nim",
+        aliases: ["nim"],
+        keywords: {
+          keyword:
+            "addr and as asm bind block break case cast const continue converter discard distinct div do elif else end enum except export finally for from func generic if import in include interface is isnot iterator let macro method mixin mod nil not notin object of or out proc ptr raise ref return shl shr static template try tuple type using var when while with without xor yield",
+          literal: "shared guarded stdin stdout stderr result true false",
+          built_in:
+            "int int8 int16 int32 int64 uint uint8 uint16 uint32 uint64 float float32 float64 bool char string cstring pointer expr stmt void auto any range array openarray varargs seq set clong culong cchar cschar cshort cint csize clonglong cfloat cdouble clongdouble cuchar cushort cuint culonglong cstringarray semistatic",
+        },
+        contains: [
+          { className: "meta", begin: /{\./, end: /\.}/, relevance: 10 },
           {
             className: "string",
             begin: /[a-zA-Z]\w*"/,
@@ -6874,3311 +5286,229 @@
             relevance: 0,
             variants: [
               {
-                begin: /\b(0[xX][0-9a-fA-F][_0-9a-fA-F]*)('?[iIuU](8|16|32|64))?/,
+                begin:
+                  /\b(0[xX][0-9a-fA-F][_0-9a-fA-F]*)('?[iIuU](8|16|32|64))?/,
               },
-              {
-                begin: /\b(0o[0-7][_0-7]*)('?[iIuUfF](8|16|32|64))?/,
-              },
-              {
-                begin: /\b(0(b|B)[01][_01]*)('?[iIuUfF](8|16|32|64))?/,
-              },
-              {
-                begin: /\b(\d[_\d]*)('?[iIuUfF](8|16|32|64))?/,
-              },
+              { begin: /\b(0o[0-7][_0-7]*)('?[iIuUfF](8|16|32|64))?/ },
+              { begin: /\b(0(b|B)[01][_01]*)('?[iIuUfF](8|16|32|64))?/ },
+              { begin: /\b(\d[_\d]*)('?[iIuUfF](8|16|32|64))?/ },
             ],
           },
           e.HASH_COMMENT_MODE,
         ],
-      }),
-      grmr_nix: (e) => {
-        const n = {
-            keyword: [
-              "rec",
-              "with",
-              "let",
-              "in",
-              "inherit",
-              "assert",
-              "if",
-              "else",
-              "then",
-            ],
-            literal: ["true", "false", "or", "and", "null"],
-            built_in: [
-              "import",
-              "abort",
-              "baseNameOf",
-              "dirOf",
-              "isNull",
-              "builtins",
-              "map",
-              "removeAttrs",
-              "throw",
-              "toString",
-              "derivation",
-            ],
-          },
-          t = { className: "subst", begin: /\$\{/, end: /\}/, keywords: n },
-          s = {
-            className: "string",
-            contains: [{ className: "char.escape", begin: /''\$/ }, t],
-            variants: [
-              { begin: "''", end: "''" },
-              { begin: '"', end: '"' },
-            ],
-          },
-          a = [
-            e.NUMBER_MODE,
-            e.HASH_COMMENT_MODE,
-            e.C_BLOCK_COMMENT_MODE,
-            s,
-            {
-              begin: /[a-zA-Z0-9-_]+(\s*=)/,
-              returnBegin: !0,
-              relevance: 0,
-              contains: [
-                {
-                  className: "attr",
-                  begin: /\S+/,
-                  relevance: 0.2,
-                },
-              ],
-            },
-          ];
-        return (
-          (t.contains = a),
-          { name: "Nix", aliases: ["nixos"], keywords: n, contains: a }
-        );
-      },
-      grmr_objectivec: (e) => {
-        const n = /[a-zA-Z@][a-zA-Z0-9_]*/,
-          t = {
-            $pattern: n,
-            keyword: ["@interface", "@class", "@protocol", "@implementation"],
-          };
-        return {
-          name: "Objective-C",
-          aliases: ["mm", "objc", "obj-c", "obj-c++", "objective-c++"],
-          keywords: {
-            "variable.language": ["this", "super"],
-            $pattern: n,
-            keyword: [
-              "while",
-              "export",
-              "sizeof",
-              "typedef",
-              "const",
-              "struct",
-              "for",
-              "union",
-              "volatile",
-              "static",
-              "mutable",
-              "if",
-              "do",
-              "return",
-              "goto",
-              "enum",
-              "else",
-              "break",
-              "extern",
-              "asm",
-              "case",
-              "default",
-              "register",
-              "explicit",
-              "typename",
-              "switch",
-              "continue",
-              "inline",
-              "readonly",
-              "assign",
-              "readwrite",
-              "self",
-              "@synchronized",
-              "id",
-              "typeof",
-              "nonatomic",
-              "IBOutlet",
-              "IBAction",
-              "strong",
-              "weak",
-              "copy",
-              "in",
-              "out",
-              "inout",
-              "bycopy",
-              "byref",
-              "oneway",
-              "__strong",
-              "__weak",
-              "__block",
-              "__autoreleasing",
-              "@private",
-              "@protected",
-              "@public",
-              "@try",
-              "@property",
-              "@end",
-              "@throw",
-              "@catch",
-              "@finally",
-              "@autoreleasepool",
-              "@synthesize",
-              "@dynamic",
-              "@selector",
-              "@optional",
-              "@required",
-              "@encode",
-              "@package",
-              "@import",
-              "@defs",
-              "@compatibility_alias",
-              "__bridge",
-              "__bridge_transfer",
-              "__bridge_retained",
-              "__bridge_retain",
-              "__covariant",
-              "__contravariant",
-              "__kindof",
-              "_Nonnull",
-              "_Nullable",
-              "_Null_unspecified",
-              "__FUNCTION__",
-              "__PRETTY_FUNCTION__",
-              "__attribute__",
-              "getter",
-              "setter",
-              "retain",
-              "unsafe_unretained",
-              "nonnull",
-              "nullable",
-              "null_unspecified",
-              "null_resettable",
-              "class",
-              "instancetype",
-              "NS_DESIGNATED_INITIALIZER",
-              "NS_UNAVAILABLE",
-              "NS_REQUIRES_SUPER",
-              "NS_RETURNS_INNER_POINTER",
-              "NS_INLINE",
-              "NS_AVAILABLE",
-              "NS_DEPRECATED",
-              "NS_ENUM",
-              "NS_OPTIONS",
-              "NS_SWIFT_UNAVAILABLE",
-              "NS_ASSUME_NONNULL_BEGIN",
-              "NS_ASSUME_NONNULL_END",
-              "NS_REFINED_FOR_SWIFT",
-              "NS_SWIFT_NAME",
-              "NS_SWIFT_NOTHROW",
-              "NS_DURING",
-              "NS_HANDLER",
-              "NS_ENDHANDLER",
-              "NS_VALUERETURN",
-              "NS_VOIDRETURN",
-            ],
-            literal: [
-              "false",
-              "true",
-              "FALSE",
-              "TRUE",
-              "nil",
-              "YES",
-              "NO",
-              "NULL",
-            ],
-            built_in: [
-              "dispatch_once_t",
-              "dispatch_queue_t",
-              "dispatch_sync",
-              "dispatch_async",
-              "dispatch_once",
-            ],
-            type: [
-              "int",
-              "float",
-              "char",
-              "unsigned",
-              "signed",
-              "short",
-              "long",
-              "double",
-              "wchar_t",
-              "unichar",
-              "void",
-              "bool",
-              "BOOL",
-              "id|0",
-              "_Bool",
-            ],
-          },
-          illegal: "</",
-          contains: [
-            {
-              className: "built_in",
-              begin:
-                "\\b(AV|CA|CF|CG|CI|CL|CM|CN|CT|MK|MP|MTK|MTL|NS|SCN|SK|UI|WK|XC)\\w+",
-            },
-            e.C_LINE_COMMENT_MODE,
-            e.C_BLOCK_COMMENT_MODE,
-            e.C_NUMBER_MODE,
-            e.QUOTE_STRING_MODE,
-            e.APOS_STRING_MODE,
-            {
-              className: "string",
-              variants: [
-                {
-                  begin: '@"',
-                  end: '"',
-                  illegal: "\\n",
-                  contains: [e.BACKSLASH_ESCAPE],
-                },
-              ],
-            },
-            {
-              className: "meta",
-              begin: /#\s*[a-z]+\b/,
-              end: /$/,
-              keywords: {
-                keyword:
-                  "if else elif endif define undef warning error line pragma ifdef ifndef include",
-              },
-              contains: [
-                { begin: /\\\n/, relevance: 0 },
-                e.inherit(e.QUOTE_STRING_MODE, {
-                  className: "string",
-                }),
-                { className: "string", begin: /<.*?>/, end: /$/, illegal: "\\n" },
-                e.C_LINE_COMMENT_MODE,
-                e.C_BLOCK_COMMENT_MODE,
-              ],
-            },
-            {
-              className: "class",
-              begin: "(" + t.keyword.join("|") + ")\\b",
-              end: /(\{|$)/,
-              excludeEnd: !0,
-              keywords: t,
-              contains: [e.UNDERSCORE_TITLE_MODE],
-            },
-            { begin: "\\." + e.UNDERSCORE_IDENT_RE, relevance: 0 },
+      };
+    };
+  })()
+);
+hljs.registerLanguage(
+  "nix",
+  (function () {
+    "use strict";
+    return function (e) {
+      var n = {
+          keyword: "rec with let in inherit assert if else then",
+          literal: "true false or and null",
+          built_in:
+            "import abort baseNameOf dirOf isNull builtins map removeAttrs throw toString derivation",
+        },
+        i = { className: "subst", begin: /\$\{/, end: /}/, keywords: n },
+        t = {
+          className: "string",
+          contains: [i],
+          variants: [
+            { begin: "''", end: "''" },
+            { begin: '"', end: '"' },
           ],
-        };
-      },
-      grmr_perl: (e) => {
-        const n = e.regex,
-          t = /[dualxmsipngr]{0,12}/,
-          s = {
-            $pattern: /[\w.]+/,
-            keyword:
-              "abs accept alarm and atan2 bind binmode bless break caller chdir chmod chomp chop chown chr chroot class close closedir connect continue cos crypt dbmclose dbmopen defined delete die do dump each else elsif endgrent endhostent endnetent endprotoent endpwent endservent eof eval exec exists exit exp fcntl field fileno flock for foreach fork format formline getc getgrent getgrgid getgrnam gethostbyaddr gethostbyname gethostent getlogin getnetbyaddr getnetbyname getnetent getpeername getpgrp getpriority getprotobyname getprotobynumber getprotoent getpwent getpwnam getpwuid getservbyname getservbyport getservent getsockname getsockopt given glob gmtime goto grep gt hex if index int ioctl join keys kill last lc lcfirst length link listen local localtime log lstat lt ma map method mkdir msgctl msgget msgrcv msgsnd my ne next no not oct open opendir or ord our pack package pipe pop pos print printf prototype push q|0 qq quotemeta qw qx rand read readdir readline readlink readpipe recv redo ref rename require reset return reverse rewinddir rindex rmdir say scalar seek seekdir select semctl semget semop send setgrent sethostent setnetent setpgrp setpriority setprotoent setpwent setservent setsockopt shift shmctl shmget shmread shmwrite shutdown sin sleep socket socketpair sort splice split sprintf sqrt srand stat state study sub substr symlink syscall sysopen sysread sysseek system syswrite tell telldir tie tied time times tr truncate uc ucfirst umask undef unless unlink unpack unshift untie until use utime values vec wait waitpid wantarray warn when while write x|0 xor y|0",
-          },
-          a = { className: "subst", begin: "[$@]\\{", end: "\\}", keywords: s },
-          i = { begin: /->\{/, end: /\}/ },
-          r = { scope: "attr", match: /\s+:\s*\w+(\s*\(.*?\))?/ },
-          o = {
-            scope: "variable",
-            variants: [
-              { begin: /\$\d/ },
-              {
-                begin: n.concat(
-                  /[$%@](?!")(\^\w\b|#\w+(::\w+)*|\{\w+\}|\w+(::\w*)*)/,
-                  "(?![A-Za-z])(?![@$%])"
-                ),
-              },
-              { begin: /[$%@](?!")[^\s\w{=]|\$=/, relevance: 0 },
-            ],
-            contains: [r],
-          },
-          c = {
-            className: "number",
-            variants: [
-              { match: /0?\.[0-9][0-9_]+\b/ },
-              {
-                match: /\bv?(0|[1-9][0-9_]*(\.[0-9_]+)?|[1-9][0-9_]*)\b/,
-              },
-              {
-                match: /\b0[0-7][0-7_]*\b/,
-              },
-              { match: /\b0x[0-9a-fA-F][0-9a-fA-F_]*\b/ },
-              {
-                match: /\b0b[0-1][0-1_]*\b/,
-              },
-            ],
-            relevance: 0,
-          },
-          l = [e.BACKSLASH_ESCAPE, a, o],
-          d = [/!/, /\//, /\|/, /\?/, /'/, /"/, /#/],
-          p = (e, s, a = "\\1") => {
-            const i = "\\1" === a ? a : n.concat(a, s);
-            return n.concat(
-              n.concat("(?:", e, ")"),
-              s,
-              /(?:\\.|[^\\\/])*?/,
-              i,
-              /(?:\\.|[^\\\/])*?/,
-              a,
-              t
-            );
-          },
-          m = (e, s, a) =>
-            n.concat(n.concat("(?:", e, ")"), s, /(?:\\.|[^\\\/])*?/, a, t),
-          u = [
-            o,
-            e.HASH_COMMENT_MODE,
-            e.COMMENT(/^=\w/, /=cut/, {
-              endsWithParent: !0,
-            }),
-            i,
-            {
-              className: "string",
-              contains: l,
-              variants: [
-                {
-                  begin: "q[qwxr]?\\s*\\(",
-                  end: "\\)",
-                  relevance: 5,
-                },
-                { begin: "q[qwxr]?\\s*\\[", end: "\\]", relevance: 5 },
-                { begin: "q[qwxr]?\\s*\\{", end: "\\}", relevance: 5 },
-                {
-                  begin: "q[qwxr]?\\s*\\|",
-                  end: "\\|",
-                  relevance: 5,
-                },
-                { begin: "q[qwxr]?\\s*<", end: ">", relevance: 5 },
-                { begin: "qw\\s+q", end: "q", relevance: 5 },
-                { begin: "'", end: "'", contains: [e.BACKSLASH_ESCAPE] },
-                { begin: '"', end: '"' },
-                { begin: "`", end: "`", contains: [e.BACKSLASH_ESCAPE] },
-                { begin: /\{\w+\}/, relevance: 0 },
-                {
-                  begin: "-?\\w+\\s*=>",
-                  relevance: 0,
-                },
-              ],
-            },
-            c,
-            {
-              begin:
-                "(\\/\\/|" +
-                e.RE_STARTERS_RE +
-                "|\\b(split|return|print|reverse|grep)\\b)\\s*",
-              keywords: "split return print reverse grep",
-              relevance: 0,
-              contains: [
-                e.HASH_COMMENT_MODE,
-                {
-                  className: "regexp",
-                  variants: [
-                    {
-                      begin: p("s|tr|y", n.either(...d, { capture: !0 })),
-                    },
-                    { begin: p("s|tr|y", "\\(", "\\)") },
-                    {
-                      begin: p("s|tr|y", "\\[", "\\]"),
-                    },
-                    { begin: p("s|tr|y", "\\{", "\\}") },
-                  ],
-                  relevance: 2,
-                },
-                {
-                  className: "regexp",
-                  variants: [
-                    { begin: /(m|qr)\/\//, relevance: 0 },
-                    {
-                      begin: m("(?:m|qr)?", /\//, /\//),
-                    },
-                    { begin: m("m|qr", n.either(...d, { capture: !0 }), /\1/) },
-                    { begin: m("m|qr", /\(/, /\)/) },
-                    { begin: m("m|qr", /\[/, /\]/) },
-                    {
-                      begin: m("m|qr", /\{/, /\}/),
-                    },
-                  ],
-                },
-              ],
-            },
-            {
-              className: "function",
-              beginKeywords: "sub method",
-              end: "(\\s*\\(.*?\\))?[;{]",
-              excludeEnd: !0,
-              relevance: 5,
-              contains: [e.TITLE_MODE, r],
-            },
-            {
-              className: "class",
-              beginKeywords: "class",
-              end: "[;{]",
-              excludeEnd: !0,
-              relevance: 5,
-              contains: [e.TITLE_MODE, r, c],
-            },
-            { begin: "-\\w\\b", relevance: 0 },
-            {
-              begin: "^__DATA__$",
-              end: "^__END__$",
-              subLanguage: "mojolicious",
-              contains: [{ begin: "^@@.*", end: "$", className: "comment" }],
-            },
-          ];
-        return (
-          (a.contains = u),
-          (i.contains = u),
-          { name: "Perl", aliases: ["pl", "pm"], keywords: s, contains: u }
-        );
-      },
-      grmr_php: (e) => {
-        const n = e.regex,
-          t = /(?![A-Za-z0-9])(?![$])/,
-          s = n.concat(/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/, t),
-          a = n.concat(
-            /(\\?[A-Z][a-z0-9_\x7f-\xff]+|\\?[A-Z]+(?=[A-Z][a-z0-9_\x7f-\xff])){1,}/,
-            t
-          ),
-          i = {
-            scope: "variable",
-            match: "\\$+" + s,
-          },
-          r = {
-            scope: "subst",
-            variants: [
-              { begin: /\$\w+/ },
-              {
-                begin: /\{\$/,
-                end: /\}/,
-              },
-            ],
-          },
-          o = e.inherit(e.APOS_STRING_MODE, { illegal: null }),
-          c = "[ \t\n]",
-          l = {
-            scope: "string",
-            variants: [
-              e.inherit(e.QUOTE_STRING_MODE, {
-                illegal: null,
-                contains: e.QUOTE_STRING_MODE.contains.concat(r),
-              }),
-              o,
-              {
-                begin: /<<<[ \t]*(?:(\w+)|"(\w+)")\n/,
-                end: /[ \t]*(\w+)\b/,
-                contains: e.QUOTE_STRING_MODE.contains.concat(r),
-                "on:begin": (e, n) => {
-                  n.data._beginMatch = e[1] || e[2];
-                },
-                "on:end": (e, n) => {
-                  n.data._beginMatch !== e[1] && n.ignoreMatch();
-                },
-              },
-              e.END_SAME_AS_BEGIN({
-                begin: /<<<[ \t]*'(\w+)'\n/,
-                end: /[ \t]*(\w+)\b/,
-              }),
-            ],
-          },
-          d = {
-            scope: "number",
-            variants: [
-              {
-                begin: "\\b0[bB][01]+(?:_[01]+)*\\b",
-              },
-              { begin: "\\b0[oO][0-7]+(?:_[0-7]+)*\\b" },
-              {
-                begin: "\\b0[xX][\\da-fA-F]+(?:_[\\da-fA-F]+)*\\b",
-              },
-              {
-                begin:
-                  "(?:\\b\\d+(?:_\\d+)*(\\.(?:\\d+(?:_\\d+)*))?|\\B\\.\\d+)(?:[eE][+-]?\\d+)?",
-              },
-            ],
-            relevance: 0,
-          },
-          p = ["false", "null", "true"],
-          m = [
-            "__CLASS__",
-            "__DIR__",
-            "__FILE__",
-            "__FUNCTION__",
-            "__COMPILER_HALT_OFFSET__",
-            "__LINE__",
-            "__METHOD__",
-            "__NAMESPACE__",
-            "__TRAIT__",
-            "die",
-            "echo",
-            "exit",
-            "include",
-            "include_once",
-            "print",
-            "require",
-            "require_once",
-            "array",
-            "abstract",
-            "and",
-            "as",
-            "binary",
-            "bool",
-            "boolean",
-            "break",
-            "callable",
-            "case",
-            "catch",
-            "class",
-            "clone",
-            "const",
-            "continue",
-            "declare",
-            "default",
-            "do",
-            "double",
-            "else",
-            "elseif",
-            "empty",
-            "enddeclare",
-            "endfor",
-            "endforeach",
-            "endif",
-            "endswitch",
-            "endwhile",
-            "enum",
-            "eval",
-            "extends",
-            "final",
-            "finally",
-            "float",
-            "for",
-            "foreach",
-            "from",
-            "global",
-            "goto",
-            "if",
-            "implements",
-            "instanceof",
-            "insteadof",
-            "int",
-            "integer",
-            "interface",
-            "isset",
-            "iterable",
-            "list",
-            "match|0",
-            "mixed",
-            "new",
-            "never",
-            "object",
-            "or",
-            "private",
-            "protected",
-            "public",
-            "readonly",
-            "real",
-            "return",
-            "string",
-            "switch",
-            "throw",
-            "trait",
-            "try",
-            "unset",
-            "use",
-            "var",
-            "void",
-            "while",
-            "xor",
-            "yield",
-          ],
-          u = [
-            "Error|0",
-            "AppendIterator",
-            "ArgumentCountError",
-            "ArithmeticError",
-            "ArrayIterator",
-            "ArrayObject",
-            "AssertionError",
-            "BadFunctionCallException",
-            "BadMethodCallException",
-            "CachingIterator",
-            "CallbackFilterIterator",
-            "CompileError",
-            "Countable",
-            "DirectoryIterator",
-            "DivisionByZeroError",
-            "DomainException",
-            "EmptyIterator",
-            "ErrorException",
-            "Exception",
-            "FilesystemIterator",
-            "FilterIterator",
-            "GlobIterator",
-            "InfiniteIterator",
-            "InvalidArgumentException",
-            "IteratorIterator",
-            "LengthException",
-            "LimitIterator",
-            "LogicException",
-            "MultipleIterator",
-            "NoRewindIterator",
-            "OutOfBoundsException",
-            "OutOfRangeException",
-            "OuterIterator",
-            "OverflowException",
-            "ParentIterator",
-            "ParseError",
-            "RangeException",
-            "RecursiveArrayIterator",
-            "RecursiveCachingIterator",
-            "RecursiveCallbackFilterIterator",
-            "RecursiveDirectoryIterator",
-            "RecursiveFilterIterator",
-            "RecursiveIterator",
-            "RecursiveIteratorIterator",
-            "RecursiveRegexIterator",
-            "RecursiveTreeIterator",
-            "RegexIterator",
-            "RuntimeException",
-            "SeekableIterator",
-            "SplDoublyLinkedList",
-            "SplFileInfo",
-            "SplFileObject",
-            "SplFixedArray",
-            "SplHeap",
-            "SplMaxHeap",
-            "SplMinHeap",
-            "SplObjectStorage",
-            "SplObserver",
-            "SplPriorityQueue",
-            "SplQueue",
-            "SplStack",
-            "SplSubject",
-            "SplTempFileObject",
-            "TypeError",
-            "UnderflowException",
-            "UnexpectedValueException",
-            "UnhandledMatchError",
-            "ArrayAccess",
-            "BackedEnum",
-            "Closure",
-            "Fiber",
-            "Generator",
-            "Iterator",
-            "IteratorAggregate",
-            "Serializable",
-            "Stringable",
-            "Throwable",
-            "Traversable",
-            "UnitEnum",
-            "WeakReference",
-            "WeakMap",
-            "Directory",
-            "__PHP_Incomplete_Class",
-            "parent",
-            "php_user_filter",
-            "self",
-            "static",
-            "stdClass",
-          ],
-          b = {
-            keyword: m,
-            literal: ((e) => {
-              const n = [];
-              return (
-                e.forEach((e) => {
-                  n.push(e),
-                    e.toLowerCase() === e
-                      ? n.push(e.toUpperCase())
-                      : n.push(e.toLowerCase());
-                }),
-                n
-              );
-            })(p),
-            built_in: u,
-          },
-          g = (e) => e.map((e) => e.replace(/\|\d+$/, "")),
-          v = {
-            variants: [
-              {
-                match: [
-                  /new/,
-                  n.concat(c, "+"),
-                  n.concat("(?!", g(u).join("\\b|"), "\\b)"),
-                  a,
-                ],
-                scope: {
-                  1: "keyword",
-                  4: "title.class",
-                },
-              },
-            ],
-          },
-          _ = n.concat(s, "\\b(?!\\()"),
-          f = {
-            variants: [
-              {
-                match: [n.concat(/::/, n.lookahead(/(?!class\b)/)), _],
-                scope: { 2: "variable.constant" },
-              },
-              { match: [/::/, /class/], scope: { 2: "variable.language" } },
-              {
-                match: [a, n.concat(/::/, n.lookahead(/(?!class\b)/)), _],
-                scope: { 1: "title.class", 3: "variable.constant" },
-              },
-              {
-                match: [a, n.concat("::", n.lookahead(/(?!class\b)/))],
-                scope: { 1: "title.class" },
-              },
-              {
-                match: [a, /::/, /class/],
-                scope: { 1: "title.class", 3: "variable.language" },
-              },
-            ],
-          },
-          h = {
-            scope: "attr",
-            match: n.concat(s, n.lookahead(":"), n.lookahead(/(?!::)/)),
-          },
-          E = {
-            relevance: 0,
-            begin: /\(/,
-            end: /\)/,
-            keywords: b,
-            contains: [h, i, f, e.C_BLOCK_COMMENT_MODE, l, d, v],
-          },
-          w = {
-            relevance: 0,
-            match: [
-              /\b/,
-              n.concat(
-                "(?!fn\\b|function\\b|",
-                g(m).join("\\b|"),
-                "|",
-                g(u).join("\\b|"),
-                "\\b)"
-              ),
-              s,
-              n.concat(c, "*"),
-              n.lookahead(/(?=\()/),
-            ],
-            scope: { 3: "title.function.invoke" },
-            contains: [E],
-          };
-        E.contains.push(w);
-        const y = [h, f, e.C_BLOCK_COMMENT_MODE, l, d, v];
-        return {
-          case_insensitive: !1,
-          keywords: b,
-          contains: [
-            {
-              begin: n.concat(/#\[\s*/, a),
-              beginScope: "meta",
-              end: /]/,
-              endScope: "meta",
-              keywords: { literal: p, keyword: ["new", "array"] },
-              contains: [
-                {
-                  begin: /\[/,
-                  end: /]/,
-                  keywords: { literal: p, keyword: ["new", "array"] },
-                  contains: ["self", ...y],
-                },
-                ...y,
-                { scope: "meta", match: a },
-              ],
-            },
-            e.HASH_COMMENT_MODE,
-            e.COMMENT("//", "$"),
-            e.COMMENT("/\\*", "\\*/", {
-              contains: [
-                {
-                  scope: "doctag",
-                  match: "@[A-Za-z]+",
-                },
-              ],
-            }),
-            {
-              match: /__halt_compiler\(\);/,
-              keywords: "__halt_compiler",
-              starts: {
-                scope: "comment",
-                end: e.MATCH_NOTHING_RE,
-                contains: [{ match: /\?>/, scope: "meta", endsParent: !0 }],
-              },
-            },
-            {
-              scope: "meta",
-              variants: [
-                {
-                  begin: /<\?php/,
-                  relevance: 10,
-                },
-                { begin: /<\?=/ },
-                { begin: /<\?/, relevance: 0.1 },
-                {
-                  begin: /\?>/,
-                },
-              ],
-            },
-            { scope: "variable.language", match: /\$this\b/ },
-            i,
-            w,
-            f,
-            {
-              match: [/const/, /\s/, s],
-              scope: { 1: "keyword", 3: "variable.constant" },
-            },
-            v,
-            {
-              scope: "function",
-              relevance: 0,
-              beginKeywords: "fn function",
-              end: /[;{]/,
-              excludeEnd: !0,
-              illegal: "[$%\\[]",
-              contains: [
-                { beginKeywords: "use" },
-                e.UNDERSCORE_TITLE_MODE,
-                { begin: "=>", endsParent: !0 },
-                {
-                  scope: "params",
-                  begin: "\\(",
-                  end: "\\)",
-                  excludeBegin: !0,
-                  excludeEnd: !0,
-                  keywords: b,
-                  contains: ["self", i, f, e.C_BLOCK_COMMENT_MODE, l, d],
-                },
-              ],
-            },
-            {
-              scope: "class",
-              variants: [
-                {
-                  beginKeywords: "enum",
-                  illegal: /[($"]/,
-                },
-                { beginKeywords: "class interface trait", illegal: /[:($"]/ },
-              ],
-              relevance: 0,
-              end: /\{/,
-              excludeEnd: !0,
-              contains: [
-                {
-                  beginKeywords: "extends implements",
-                },
-                e.UNDERSCORE_TITLE_MODE,
-              ],
-            },
-            {
-              beginKeywords: "namespace",
-              relevance: 0,
-              end: ";",
-              illegal: /[.']/,
-              contains: [
-                e.inherit(e.UNDERSCORE_TITLE_MODE, { scope: "title.class" }),
-              ],
-            },
-            {
-              beginKeywords: "use",
-              relevance: 0,
-              end: ";",
-              contains: [
-                {
-                  match: /\b(as|const|function)\b/,
-                  scope: "keyword",
-                },
-                e.UNDERSCORE_TITLE_MODE,
-              ],
-            },
-            l,
-            d,
-          ],
-        };
-      },
-      grmr_php_template: (e) => ({
-        name: "PHP template",
-        subLanguage: "xml",
-        contains: [
+        },
+        s = [
+          e.NUMBER_MODE,
+          e.HASH_COMMENT_MODE,
+          e.C_BLOCK_COMMENT_MODE,
+          t,
           {
-            begin: /<\?(php|=)?/,
-            end: /\?>/,
-            subLanguage: "php",
-            contains: [
-              { begin: "/\\*", end: "\\*/", skip: !0 },
-              { begin: 'b"', end: '"', skip: !0 },
-              { begin: "b'", end: "'", skip: !0 },
-              e.inherit(e.APOS_STRING_MODE, {
-                illegal: null,
-                className: null,
-                contains: null,
-                skip: !0,
-              }),
-              e.inherit(e.QUOTE_STRING_MODE, {
-                illegal: null,
-                className: null,
-                contains: null,
-                skip: !0,
-              }),
-            ],
-          },
-        ],
-      }),
-      grmr_plaintext: (e) => ({
-        name: "Plain text",
-        aliases: ["text", "txt"],
-        disableAutodetect: !0,
-      }),
-      grmr_properties: (e) => {
-        const n = "[ \\t\\f]*",
-          t = n + "[:=]" + n,
-          s = "[ \\t\\f]+",
-          a = "([^\\\\:= \\t\\f\\n]|\\\\.)+",
-          i = {
-            end: "(" + t + "|" + s + ")",
+            begin: /[a-zA-Z0-9-_]+(\s*=)/,
+            returnBegin: !0,
             relevance: 0,
-            starts: {
-              className: "string",
-              end: /$/,
-              relevance: 0,
-              contains: [{ begin: "\\\\\\\\" }, { begin: "\\\\\\n" }],
-            },
-          };
-        return {
-          name: ".properties",
-          disableAutodetect: !0,
-          case_insensitive: !0,
-          illegal: /\S/,
-          contains: [
-            e.COMMENT("^\\s*[!#]", "$"),
-            {
-              returnBegin: !0,
-              variants: [
-                { begin: a + t },
-                {
-                  begin: a + s,
-                },
-              ],
-              contains: [{ className: "attr", begin: a, endsParent: !0 }],
-              starts: i,
-            },
-            {
-              className: "attr",
-              begin: a + n + "$",
-            },
-          ],
-        };
-      },
-      grmr_python: (e) => {
-        const n = e.regex,
-          t = /[\p{XID_Start}_]\p{XID_Continue}*/u,
-          s = [
-            "and",
-            "as",
-            "assert",
-            "async",
-            "await",
-            "break",
-            "case",
-            "class",
-            "continue",
-            "def",
-            "del",
-            "elif",
-            "else",
-            "except",
-            "finally",
-            "for",
-            "from",
-            "global",
-            "if",
-            "import",
-            "in",
-            "is",
-            "lambda",
-            "match",
-            "nonlocal|10",
-            "not",
-            "or",
-            "pass",
-            "raise",
-            "return",
-            "try",
-            "while",
-            "with",
-            "yield",
-          ],
-          a = {
-            $pattern: /[A-Za-z]\w+|__\w+__/,
-            keyword: s,
-            built_in: [
-              "__import__",
-              "abs",
-              "all",
-              "any",
-              "ascii",
-              "bin",
-              "bool",
-              "breakpoint",
-              "bytearray",
-              "bytes",
-              "callable",
-              "chr",
-              "classmethod",
-              "compile",
-              "complex",
-              "delattr",
-              "dict",
-              "dir",
-              "divmod",
-              "enumerate",
-              "eval",
-              "exec",
-              "filter",
-              "float",
-              "format",
-              "frozenset",
-              "getattr",
-              "globals",
-              "hasattr",
-              "hash",
-              "help",
-              "hex",
-              "id",
-              "input",
-              "int",
-              "isinstance",
-              "issubclass",
-              "iter",
-              "len",
-              "list",
-              "locals",
-              "map",
-              "max",
-              "memoryview",
-              "min",
-              "next",
-              "object",
-              "oct",
-              "open",
-              "ord",
-              "pow",
-              "print",
-              "property",
-              "range",
-              "repr",
-              "reversed",
-              "round",
-              "set",
-              "setattr",
-              "slice",
-              "sorted",
-              "staticmethod",
-              "str",
-              "sum",
-              "super",
-              "tuple",
-              "type",
-              "vars",
-              "zip",
-            ],
-            literal: [
-              "__debug__",
-              "Ellipsis",
-              "False",
-              "None",
-              "NotImplemented",
-              "True",
-            ],
-            type: [
-              "Any",
-              "Callable",
-              "Coroutine",
-              "Dict",
-              "List",
-              "Literal",
-              "Generic",
-              "Optional",
-              "Sequence",
-              "Set",
-              "Tuple",
-              "Type",
-              "Union",
-            ],
+            contains: [{ className: "attr", begin: /\S+/ }],
           },
-          i = { className: "meta", begin: /^(>>>|\.\.\.) / },
-          r = {
-            className: "subst",
-            begin: /\{/,
-            end: /\}/,
-            keywords: a,
-            illegal: /#/,
+        ];
+      return (
+        (i.contains = s),
+        { name: "Nix", aliases: ["nixos"], keywords: n, contains: s }
+      );
+    };
+  })()
+);
+hljs.registerLanguage(
+  "r",
+  (function () {
+    "use strict";
+    return function (e) {
+      var n = "([a-zA-Z]|\\.[a-zA-Z.])[a-zA-Z0-9._]*";
+      return {
+        name: "R",
+        contains: [
+          e.HASH_COMMENT_MODE,
+          {
+            begin: n,
+            keywords: {
+              $pattern: n,
+              keyword:
+                "function if in break next repeat else for return switch while try tryCatch stop warning require library attach detach source setMethod setGeneric setGroupGeneric setClass ...",
+              literal:
+                "NULL NA TRUE FALSE T F Inf NaN NA_integer_|10 NA_real_|10 NA_character_|10 NA_complex_|10",
+            },
+            relevance: 0,
           },
-          o = { begin: /\{\{/, relevance: 0 },
-          c = {
+          {
+            className: "number",
+            begin: "0[xX][0-9a-fA-F]+[Li]?\\b",
+            relevance: 0,
+          },
+          {
+            className: "number",
+            begin: "\\d+(?:[eE][+\\-]?\\d*)?L\\b",
+            relevance: 0,
+          },
+          {
+            className: "number",
+            begin: "\\d+\\.(?!\\d)(?:i\\b)?",
+            relevance: 0,
+          },
+          {
+            className: "number",
+            begin: "\\d+(?:\\.\\d*)?(?:[eE][+\\-]?\\d*)?i?\\b",
+            relevance: 0,
+          },
+          {
+            className: "number",
+            begin: "\\.\\d+(?:[eE][+\\-]?\\d*)?i?\\b",
+            relevance: 0,
+          },
+          { begin: "`", end: "`", relevance: 0 },
+          {
             className: "string",
             contains: [e.BACKSLASH_ESCAPE],
             variants: [
-              {
-                begin: /([uU]|[bB]|[rR]|[bB][rR]|[rR][bB])?'''/,
-                end: /'''/,
-                contains: [e.BACKSLASH_ESCAPE, i],
-                relevance: 10,
-              },
-              {
-                begin: /([uU]|[bB]|[rR]|[bB][rR]|[rR][bB])?"""/,
-                end: /"""/,
-                contains: [e.BACKSLASH_ESCAPE, i],
-                relevance: 10,
-              },
-              {
-                begin: /([fF][rR]|[rR][fF]|[fF])'''/,
-                end: /'''/,
-                contains: [e.BACKSLASH_ESCAPE, i, o, r],
-              },
-              {
-                begin: /([fF][rR]|[rR][fF]|[fF])"""/,
-                end: /"""/,
-                contains: [e.BACKSLASH_ESCAPE, i, o, r],
-              },
-              { begin: /([uU]|[rR])'/, end: /'/, relevance: 10 },
-              { begin: /([uU]|[rR])"/, end: /"/, relevance: 10 },
-              {
-                begin: /([bB]|[bB][rR]|[rR][bB])'/,
-                end: /'/,
-              },
-              { begin: /([bB]|[bB][rR]|[rR][bB])"/, end: /"/ },
-              {
-                begin: /([fF][rR]|[rR][fF]|[fF])'/,
-                end: /'/,
-                contains: [e.BACKSLASH_ESCAPE, o, r],
-              },
-              {
-                begin: /([fF][rR]|[rR][fF]|[fF])"/,
-                end: /"/,
-                contains: [e.BACKSLASH_ESCAPE, o, r],
-              },
-              e.APOS_STRING_MODE,
-              e.QUOTE_STRING_MODE,
-            ],
-          },
-          l = "[0-9](_?[0-9])*",
-          d = `(\\b(${l}))?\\.(${l})|\\b(${l})\\.`,
-          p = "\\b|" + s.join("|"),
-          m = {
-            className: "number",
-            relevance: 0,
-            variants: [
-              {
-                begin: `(\\b(${l})|(${d}))[eE][+-]?(${l})[jJ]?(?=${p})`,
-              },
-              { begin: `(${d})[jJ]?` },
-              {
-                begin: `\\b([1-9](_?[0-9])*|0+(_?0)*)[lLjJ]?(?=${p})`,
-              },
-              {
-                begin: `\\b0[bB](_?[01])+[lL]?(?=${p})`,
-              },
-              { begin: `\\b0[oO](_?[0-7])+[lL]?(?=${p})` },
-              { begin: `\\b0[xX](_?[0-9a-fA-F])+[lL]?(?=${p})` },
-              { begin: `\\b(${l})[jJ](?=${p})` },
-            ],
-          },
-          u = {
-            className: "comment",
-            begin: n.lookahead(/# type:/),
-            end: /$/,
-            keywords: a,
-            contains: [
-              { begin: /# type:/ },
-              { begin: /#/, end: /\b\B/, endsWithParent: !0 },
-            ],
-          },
-          b = {
-            className: "params",
-            variants: [
-              { className: "", begin: /\(\s*\)/, skip: !0 },
-              {
-                begin: /\(/,
-                end: /\)/,
-                excludeBegin: !0,
-                excludeEnd: !0,
-                keywords: a,
-                contains: ["self", i, m, c, e.HASH_COMMENT_MODE],
-              },
-            ],
-          };
-        return (
-          (r.contains = [c, m, i]),
-          {
-            name: "Python",
-            aliases: ["py", "gyp", "ipython"],
-            unicodeRegex: !0,
-            keywords: a,
-            illegal: /(<\/|\?)|=>/,
-            contains: [
-              i,
-              m,
-              { scope: "variable.language", match: /\bself\b/ },
-              { beginKeywords: "if", relevance: 0 },
-              { match: /\bor\b/, scope: "keyword" },
-              c,
-              u,
-              e.HASH_COMMENT_MODE,
-              {
-                match: [/\bdef/, /\s+/, t],
-                scope: { 1: "keyword", 3: "title.function" },
-                contains: [b],
-              },
-              {
-                variants: [
-                  {
-                    match: [/\bclass/, /\s+/, t, /\s*/, /\(\s*/, t, /\s*\)/],
-                  },
-                  { match: [/\bclass/, /\s+/, t] },
-                ],
-                scope: {
-                  1: "keyword",
-                  3: "title.class",
-                  6: "title.class.inherited",
-                },
-              },
-              {
-                className: "meta",
-                begin: /^[\t ]*@/,
-                end: /(?=#)|$/,
-                contains: [m, b, c],
-              },
-            ],
-          }
-        );
-      },
-      grmr_python_repl: (e) => ({
-        aliases: ["pycon"],
-        contains: [
-          {
-            className: "meta.prompt",
-            starts: { end: / |$/, starts: { end: "$", subLanguage: "python" } },
-            variants: [
-              {
-                begin: /^>>>(?=[ ]|$)/,
-              },
-              { begin: /^\.\.\.(?=[ ]|$)/ },
+              { begin: '"', end: '"' },
+              { begin: "'", end: "'" },
             ],
           },
         ],
-      }),
-      grmr_r: (e) => {
-        const n = e.regex,
-          t = /(?:(?:[a-zA-Z]|\.[._a-zA-Z])[._a-zA-Z0-9]*)|\.(?!\d)/,
-          s = n.either(
-            /0[xX][0-9a-fA-F]+\.[0-9a-fA-F]*[pP][+-]?\d+i?/,
-            /0[xX][0-9a-fA-F]+(?:[pP][+-]?\d+)?[Li]?/,
-            /(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?[Li]?/
-          ),
-          a = /[=!<>:]=|\|\||&&|:::?|<-|<<-|->>|->|\|>|[-+*\/?!$&|:<=>@^~]|\*\*/,
-          i = n.either(/[()]/, /[{}]/, /\[\[/, /[[\]]/, /\\/, /,/);
-        return {
-          name: "R",
-          keywords: {
-            $pattern: t,
-            keyword: "function if in break next repeat else for while",
-            literal:
-              "NULL NA TRUE FALSE Inf NaN NA_integer_|10 NA_real_|10 NA_character_|10 NA_complex_|10",
-            built_in:
-              "LETTERS letters month.abb month.name pi T F abs acos acosh all any anyNA Arg as.call as.character as.complex as.double as.environment as.integer as.logical as.null.default as.numeric as.raw asin asinh atan atanh attr attributes baseenv browser c call ceiling class Conj cos cosh cospi cummax cummin cumprod cumsum digamma dim dimnames emptyenv exp expression floor forceAndCall gamma gc.time globalenv Im interactive invisible is.array is.atomic is.call is.character is.complex is.double is.environment is.expression is.finite is.function is.infinite is.integer is.language is.list is.logical is.matrix is.na is.name is.nan is.null is.numeric is.object is.pairlist is.raw is.recursive is.single is.symbol lazyLoadDBfetch length lgamma list log max min missing Mod names nargs nzchar oldClass on.exit pos.to.env proc.time prod quote range Re rep retracemem return round seq_along seq_len seq.int sign signif sin sinh sinpi sqrt standardGeneric substitute sum switch tan tanh tanpi tracemem trigamma trunc unclass untracemem UseMethod xtfrm",
-          },
-          contains: [
-            e.COMMENT(/#'/, /$/, {
-              contains: [
-                {
-                  scope: "doctag",
-                  match: /@examples/,
-                  starts: {
-                    end: n.lookahead(
-                      n.either(/\n^#'\s*(?=@[a-zA-Z]+)/, /\n^(?!#')/)
-                    ),
-                    endsParent: !0,
-                  },
-                },
-                {
-                  scope: "doctag",
-                  begin: "@param",
-                  end: /$/,
-                  contains: [
-                    {
-                      scope: "variable",
-                      variants: [{ match: t }, { match: /`(?:\\.|[^`\\])+`/ }],
-                      endsParent: !0,
-                    },
-                  ],
-                },
-                { scope: "doctag", match: /@[a-zA-Z]+/ },
-                { scope: "keyword", match: /\\[a-zA-Z]+/ },
-              ],
-            }),
-            e.HASH_COMMENT_MODE,
+      };
+    };
+  })()
+);
+hljs.registerLanguage(
+  "scala",
+  (function () {
+    "use strict";
+    return function (e) {
+      var n = {
+          className: "subst",
+          variants: [
+            { begin: "\\$[A-Za-z0-9_]+" },
+            { begin: "\\${", end: "}" },
+          ],
+        },
+        a = {
+          className: "string",
+          variants: [
             {
-              scope: "string",
+              begin: '"',
+              end: '"',
+              illegal: "\\n",
               contains: [e.BACKSLASH_ESCAPE],
-              variants: [
-                e.END_SAME_AS_BEGIN({ begin: /[rR]"(-*)\(/, end: /\)(-*)"/ }),
-                e.END_SAME_AS_BEGIN({ begin: /[rR]"(-*)\{/, end: /\}(-*)"/ }),
-                e.END_SAME_AS_BEGIN({ begin: /[rR]"(-*)\[/, end: /\](-*)"/ }),
-                e.END_SAME_AS_BEGIN({ begin: /[rR]'(-*)\(/, end: /\)(-*)'/ }),
-                e.END_SAME_AS_BEGIN({ begin: /[rR]'(-*)\{/, end: /\}(-*)'/ }),
-                e.END_SAME_AS_BEGIN({ begin: /[rR]'(-*)\[/, end: /\](-*)'/ }),
-                { begin: '"', end: '"', relevance: 0 },
-                { begin: "'", end: "'", relevance: 0 },
-              ],
             },
+            { begin: '"""', end: '"""', relevance: 10 },
             {
-              relevance: 0,
-              variants: [
-                {
-                  scope: {
-                    1: "operator",
-                    2: "number",
-                  },
-                  match: [a, s],
-                },
-                { scope: { 1: "operator", 2: "number" }, match: [/%[^%]*%/, s] },
-                { scope: { 1: "punctuation", 2: "number" }, match: [i, s] },
-                {
-                  scope: {
-                    2: "number",
-                  },
-                  match: [/[^a-zA-Z0-9._]|^/, s],
-                },
-              ],
+              begin: '[a-z]+"',
+              end: '"',
+              illegal: "\\n",
+              contains: [e.BACKSLASH_ESCAPE, n],
             },
-            { scope: { 3: "operator" }, match: [t, /\s+/, /<-/, /\s+/] },
-            {
-              scope: "operator",
-              relevance: 0,
-              variants: [
-                { match: a },
-                {
-                  match: /%[^%]*%/,
-                },
-              ],
-            },
-            { scope: "punctuation", relevance: 0, match: i },
-            { begin: "`", end: "`", contains: [{ begin: /\\./ }] },
-          ],
-        };
-      },
-      grmr_ruby: (e) => {
-        const n = e.regex,
-          t =
-            "([a-zA-Z_]\\w*[!?=]?|[-+~]@|<<|>>|=~|===?|<=>|[<>]=?|\\*\\*|[-/+%^&*~`|]|\\[\\]=?)",
-          s = n.either(/\b([A-Z]+[a-z0-9]+)+/, /\b([A-Z]+[a-z0-9]+)+[A-Z]+/),
-          a = n.concat(s, /(::\w+)*/),
-          i = {
-            "variable.constant": ["__FILE__", "__LINE__", "__ENCODING__"],
-            "variable.language": ["self", "super"],
-            keyword: [
-              "alias",
-              "and",
-              "begin",
-              "BEGIN",
-              "break",
-              "case",
-              "class",
-              "defined",
-              "do",
-              "else",
-              "elsif",
-              "end",
-              "END",
-              "ensure",
-              "for",
-              "if",
-              "in",
-              "module",
-              "next",
-              "not",
-              "or",
-              "redo",
-              "require",
-              "rescue",
-              "retry",
-              "return",
-              "then",
-              "undef",
-              "unless",
-              "until",
-              "when",
-              "while",
-              "yield",
-              "include",
-              "extend",
-              "prepend",
-              "public",
-              "private",
-              "protected",
-              "raise",
-              "throw",
-            ],
-            built_in: [
-              "proc",
-              "lambda",
-              "attr_accessor",
-              "attr_reader",
-              "attr_writer",
-              "define_method",
-              "private_constant",
-              "module_function",
-            ],
-            literal: ["true", "false", "nil"],
-          },
-          r = { className: "doctag", begin: "@[A-Za-z]+" },
-          o = {
-            begin: "#<",
-            end: ">",
-          },
-          c = [
-            e.COMMENT("#", "$", { contains: [r] }),
-            e.COMMENT("^=begin", "^=end", { contains: [r], relevance: 10 }),
-            e.COMMENT("^__END__", e.MATCH_NOTHING_RE),
-          ],
-          l = { className: "subst", begin: /#\{/, end: /\}/, keywords: i },
-          d = {
-            className: "string",
-            contains: [e.BACKSLASH_ESCAPE, l],
-            variants: [
-              { begin: /'/, end: /'/ },
-              { begin: /"/, end: /"/ },
-              { begin: /`/, end: /`/ },
-              {
-                begin: /%[qQwWx]?\(/,
-                end: /\)/,
-              },
-              { begin: /%[qQwWx]?\[/, end: /\]/ },
-              {
-                begin: /%[qQwWx]?\{/,
-                end: /\}/,
-              },
-              { begin: /%[qQwWx]?</, end: />/ },
-              { begin: /%[qQwWx]?\//, end: /\// },
-              { begin: /%[qQwWx]?%/, end: /%/ },
-              { begin: /%[qQwWx]?-/, end: /-/ },
-              {
-                begin: /%[qQwWx]?\|/,
-                end: /\|/,
-              },
-              { begin: /\B\?(\\\d{1,3})/ },
-              {
-                begin: /\B\?(\\x[A-Fa-f0-9]{1,2})/,
-              },
-              { begin: /\B\?(\\u\{?[A-Fa-f0-9]{1,6}\}?)/ },
-              {
-                begin: /\B\?(\\M-\\C-|\\M-\\c|\\c\\M-|\\M-|\\C-\\M-)[\x20-\x7e]/,
-              },
-              {
-                begin: /\B\?\\(c|C-)[\x20-\x7e]/,
-              },
-              { begin: /\B\?\\?\S/ },
-              {
-                begin: n.concat(
-                  /<<[-~]?'?/,
-                  n.lookahead(/(\w+)(?=\W)[^\n]*\n(?:[^\n]*\n)*?\s*\1\b/)
-                ),
-                contains: [
-                  e.END_SAME_AS_BEGIN({
-                    begin: /(\w+)/,
-                    end: /(\w+)/,
-                    contains: [e.BACKSLASH_ESCAPE, l],
-                  }),
-                ],
-              },
-            ],
-          },
-          p = "[0-9](_?[0-9])*",
-          m = {
-            className: "number",
-            relevance: 0,
-            variants: [
-              {
-                begin: `\\b([1-9](_?[0-9])*|0)(\\.(${p}))?([eE][+-]?(${p})|r)?i?\\b`,
-              },
-              {
-                begin: "\\b0[dD][0-9](_?[0-9])*r?i?\\b",
-              },
-              { begin: "\\b0[bB][0-1](_?[0-1])*r?i?\\b" },
-              { begin: "\\b0[oO][0-7](_?[0-7])*r?i?\\b" },
-              {
-                begin: "\\b0[xX][0-9a-fA-F](_?[0-9a-fA-F])*r?i?\\b",
-              },
-              {
-                begin: "\\b0(_?[0-7])+r?i?\\b",
-              },
-            ],
-          },
-          u = {
-            variants: [
-              { match: /\(\)/ },
-              {
-                className: "params",
-                begin: /\(/,
-                end: /(?=\))/,
-                excludeBegin: !0,
-                endsParent: !0,
-                keywords: i,
-              },
-            ],
-          },
-          b = [
-            d,
-            {
-              variants: [
-                { match: [/class\s+/, a, /\s+<\s+/, a] },
-                {
-                  match: [/\b(class|module)\s+/, a],
-                },
-              ],
-              scope: { 2: "title.class", 4: "title.class.inherited" },
-              keywords: i,
-            },
-            {
-              match: [/(include|extend)\s+/, a],
-              scope: {
-                2: "title.class",
-              },
-              keywords: i,
-            },
-            {
-              relevance: 0,
-              match: [a, /\.new[. (]/],
-              scope: {
-                1: "title.class",
-              },
-            },
-            {
-              relevance: 0,
-              match: /\b[A-Z][A-Z_0-9]+\b/,
-              className: "variable.constant",
-            },
-            { relevance: 0, match: s, scope: "title.class" },
-            {
-              match: [/def/, /\s+/, t],
-              scope: { 1: "keyword", 3: "title.function" },
-              contains: [u],
-            },
-            {
-              begin: e.IDENT_RE + "::",
-            },
-            {
-              className: "symbol",
-              begin: e.UNDERSCORE_IDENT_RE + "(!|\\?)?:",
-              relevance: 0,
-            },
-            {
-              className: "symbol",
-              begin: ":(?!\\s)",
-              contains: [d, { begin: t }],
-              relevance: 0,
-            },
-            m,
-            {
-              className: "variable",
-              begin: "(\\$\\W)|((\\$|@@?)(\\w+))(?=[^@$?])(?![A-Za-z])(?![@$?'])",
-            },
-            {
-              className: "params",
-              begin: /\|/,
-              end: /\|/,
-              excludeBegin: !0,
-              excludeEnd: !0,
-              relevance: 0,
-              keywords: i,
-            },
-            {
-              begin: "(" + e.RE_STARTERS_RE + "|unless)\\s*",
-              keywords: "unless",
-              contains: [
-                {
-                  className: "regexp",
-                  contains: [e.BACKSLASH_ESCAPE, l],
-                  illegal: /\n/,
-                  variants: [
-                    { begin: "/", end: "/[a-z]*" },
-                    { begin: /%r\{/, end: /\}[a-z]*/ },
-                    {
-                      begin: "%r\\(",
-                      end: "\\)[a-z]*",
-                    },
-                    { begin: "%r!", end: "![a-z]*" },
-                    { begin: "%r\\[", end: "\\][a-z]*" },
-                  ],
-                },
-              ].concat(o, c),
-              relevance: 0,
-            },
-          ].concat(o, c);
-        (l.contains = b), (u.contains = b);
-        const g = [
-          { begin: /^\s*=>/, starts: { end: "$", contains: b } },
-          {
-            className: "meta.prompt",
-            begin:
-              "^([>?]>|[\\w#]+\\(\\w+\\):\\d+:\\d+[>*]|(\\w+-)?\\d+\\.\\d+\\.\\d+(p\\d+)?[^\\d][^>]+>)(?=[ ])",
-            starts: { end: "$", keywords: i, contains: b },
-          },
-        ];
-        return (
-          c.unshift(o),
-          {
-            name: "Ruby",
-            aliases: ["rb", "gemspec", "podspec", "thor", "irb"],
-            keywords: i,
-            illegal: /\/\*/,
-            contains: [e.SHEBANG({ binary: "ruby" })]
-              .concat(g)
-              .concat(c)
-              .concat(b),
-          }
-        );
-      },
-      grmr_rust: (e) => {
-        const n = e.regex,
-          t = /(r#)?/,
-          s = n.concat(t, e.UNDERSCORE_IDENT_RE),
-          a = n.concat(t, e.IDENT_RE),
-          i = {
-            className: "title.function.invoke",
-            relevance: 0,
-            begin: n.concat(
-              /\b/,
-              /(?!let|for|while|if|else|match\b)/,
-              a,
-              n.lookahead(/\s*\(/)
-            ),
-          },
-          r = "([ui](8|16|32|64|128|size)|f(32|64))?",
-          o = [
-            "drop ",
-            "Copy",
-            "Send",
-            "Sized",
-            "Sync",
-            "Drop",
-            "Fn",
-            "FnMut",
-            "FnOnce",
-            "ToOwned",
-            "Clone",
-            "Debug",
-            "PartialEq",
-            "PartialOrd",
-            "Eq",
-            "Ord",
-            "AsRef",
-            "AsMut",
-            "Into",
-            "From",
-            "Default",
-            "Iterator",
-            "Extend",
-            "IntoIterator",
-            "DoubleEndedIterator",
-            "ExactSizeIterator",
-            "SliceConcatExt",
-            "ToString",
-            "assert!",
-            "assert_eq!",
-            "bitflags!",
-            "bytes!",
-            "cfg!",
-            "col!",
-            "concat!",
-            "concat_idents!",
-            "debug_assert!",
-            "debug_assert_eq!",
-            "env!",
-            "eprintln!",
-            "panic!",
-            "file!",
-            "format!",
-            "format_args!",
-            "include_bytes!",
-            "include_str!",
-            "line!",
-            "local_data_key!",
-            "module_path!",
-            "option_env!",
-            "print!",
-            "println!",
-            "select!",
-            "stringify!",
-            "try!",
-            "unimplemented!",
-            "unreachable!",
-            "vec!",
-            "write!",
-            "writeln!",
-            "macro_rules!",
-            "assert_ne!",
-            "debug_assert_ne!",
-          ],
-          c = [
-            "i8",
-            "i16",
-            "i32",
-            "i64",
-            "i128",
-            "isize",
-            "u8",
-            "u16",
-            "u32",
-            "u64",
-            "u128",
-            "usize",
-            "f32",
-            "f64",
-            "str",
-            "char",
-            "bool",
-            "Box",
-            "Option",
-            "Result",
-            "String",
-            "Vec",
-          ];
-        return {
-          name: "Rust",
-          aliases: ["rs"],
-          keywords: {
-            $pattern: e.IDENT_RE + "!?",
-            type: c,
-            keyword: [
-              "abstract",
-              "as",
-              "async",
-              "await",
-              "become",
-              "box",
-              "break",
-              "const",
-              "continue",
-              "crate",
-              "do",
-              "dyn",
-              "else",
-              "enum",
-              "extern",
-              "false",
-              "final",
-              "fn",
-              "for",
-              "if",
-              "impl",
-              "in",
-              "let",
-              "loop",
-              "macro",
-              "match",
-              "mod",
-              "move",
-              "mut",
-              "override",
-              "priv",
-              "pub",
-              "ref",
-              "return",
-              "self",
-              "Self",
-              "static",
-              "struct",
-              "super",
-              "trait",
-              "true",
-              "try",
-              "type",
-              "typeof",
-              "union",
-              "unsafe",
-              "unsized",
-              "use",
-              "virtual",
-              "where",
-              "while",
-              "yield",
-            ],
-            literal: ["true", "false", "Some", "None", "Ok", "Err"],
-            built_in: o,
-          },
-          illegal: "</",
-          contains: [
-            e.C_LINE_COMMENT_MODE,
-            e.COMMENT("/\\*", "\\*/", { contains: ["self"] }),
-            e.inherit(e.QUOTE_STRING_MODE, { begin: /b?"/, illegal: null }),
             {
               className: "string",
-              variants: [
-                { begin: /b?r(#*)"(.|\n)*?"\1(?!#)/ },
-                {
-                  begin: /b?'\\?(x\w{2}|u\w{4}|U\w{8}|.)'/,
-                },
-              ],
+              begin: '[a-z]+"""',
+              end: '"""',
+              contains: [n],
+              relevance: 10,
             },
-            { className: "symbol", begin: /'[a-zA-Z_][a-zA-Z0-9_]*/ },
-            {
-              className: "number",
-              variants: [
-                {
-                  begin: "\\b0b([01_]+)" + r,
-                },
-                { begin: "\\b0o([0-7_]+)" + r },
-                {
-                  begin: "\\b0x([A-Fa-f0-9_]+)" + r,
-                },
-                {
-                  begin: "\\b(\\d[\\d_]*(\\.[0-9_]+)?([eE][+-]?[0-9_]+)?)" + r,
-                },
-              ],
-              relevance: 0,
-            },
-            {
-              begin: [/fn/, /\s+/, s],
-              className: { 1: "keyword", 3: "title.function" },
-            },
-            {
-              className: "meta",
-              begin: "#!?\\[",
-              end: "\\]",
-              contains: [
-                {
-                  className: "string",
-                  begin: /"/,
-                  end: /"/,
-                  contains: [e.BACKSLASH_ESCAPE],
-                },
-              ],
-            },
-            {
-              begin: [/let/, /\s+/, /(?:mut\s+)?/, s],
-              className: { 1: "keyword", 3: "keyword", 4: "variable" },
-            },
-            {
-              begin: [/for/, /\s+/, s, /\s+/, /in/],
-              className: { 1: "keyword", 3: "variable", 5: "keyword" },
-            },
-            {
-              begin: [/type/, /\s+/, s],
-              className: { 1: "keyword", 3: "title.class" },
-            },
-            {
-              begin: [/(?:trait|enum|struct|union|impl|for)/, /\s+/, s],
-              className: { 1: "keyword", 3: "title.class" },
-            },
-            {
-              begin: e.IDENT_RE + "::",
-              keywords: {
-                keyword: "Self",
-                built_in: o,
-                type: c,
-              },
-            },
-            { className: "punctuation", begin: "->" },
-            i,
           ],
-        };
-      },
-      grmr_scala: (e) => {
-        const n = e.regex,
-          t = {
-            className: "subst",
-            variants: [
-              {
-                begin: "\\$[A-Za-z0-9_]+",
-              },
-              { begin: /\$\{/, end: /\}/ },
-            ],
-          },
-          s = {
-            className: "string",
-            variants: [
-              { begin: '"""', end: '"""' },
-              {
-                begin: '"',
-                end: '"',
-                illegal: "\\n",
-                contains: [e.BACKSLASH_ESCAPE],
-              },
-              {
-                begin: '[a-z]+"',
-                end: '"',
-                illegal: "\\n",
-                contains: [e.BACKSLASH_ESCAPE, t],
-              },
-              {
-                className: "string",
-                begin: '[a-z]+"""',
-                end: '"""',
-                contains: [t],
-                relevance: 10,
-              },
-            ],
-          },
-          a = { className: "type", begin: "\\b[A-Z][A-Za-z0-9_]*", relevance: 0 },
-          i = {
-            className: "title",
-            begin:
-              /[^0-9\n\t "'(),.`{}\[\]:;][^\n\t "'(),.`{}\[\]:;]+|[^0-9\n\t "'(),.`{}\[\]:;=]/,
-            relevance: 0,
-          },
-          r = {
-            className: "class",
-            beginKeywords: "class object trait type",
-            end: /[:={\[\n;]/,
-            excludeEnd: !0,
-            contains: [
-              e.C_LINE_COMMENT_MODE,
-              e.C_BLOCK_COMMENT_MODE,
-              {
-                beginKeywords: "extends with",
-                relevance: 10,
-              },
-              {
-                begin: /\[/,
-                end: /\]/,
-                excludeBegin: !0,
-                excludeEnd: !0,
-                relevance: 0,
-                contains: [a, e.C_LINE_COMMENT_MODE, e.C_BLOCK_COMMENT_MODE],
-              },
-              {
-                className: "params",
-                begin: /\(/,
-                end: /\)/,
-                excludeBegin: !0,
-                excludeEnd: !0,
-                relevance: 0,
-                contains: [a, e.C_LINE_COMMENT_MODE, e.C_BLOCK_COMMENT_MODE],
-              },
-              i,
-            ],
-          },
-          o = {
-            className: "function",
-            beginKeywords: "def",
-            end: n.lookahead(/[:={\[(\n;]/),
-            contains: [i],
-          };
-        return {
-          name: "Scala",
-          keywords: {
-            literal: "true false null",
-            keyword:
-              "type yield lazy override def with val var sealed abstract private trait object if then forSome for while do throw finally protected extends import final return else break new catch super class case package default try this match continue throws implicit export enum given transparent",
-          },
+        },
+        s = { className: "type", begin: "\\b[A-Z][A-Za-z0-9_]*", relevance: 0 },
+        t = {
+          className: "title",
+          begin:
+            /[^0-9\n\t "'(),.`{}\[\]:;][^\n\t "'(),.`{}\[\]:;]+|[^0-9\n\t "'(),.`{}\[\]:;=]/,
+          relevance: 0,
+        },
+        i = {
+          className: "class",
+          beginKeywords: "class object trait type",
+          end: /[:={\[\n;]/,
+          excludeEnd: !0,
           contains: [
-            {
-              begin: ["//>", /\s+/, /using/, /\s+/, /\S+/],
-              beginScope: { 1: "comment", 3: "keyword", 5: "type" },
-              end: /$/,
-              contains: [{ className: "string", begin: /\S+/ }],
-            },
-            e.C_LINE_COMMENT_MODE,
-            e.C_BLOCK_COMMENT_MODE,
-            s,
-            a,
-            o,
-            r,
-            e.C_NUMBER_MODE,
-            {
-              begin: [/^\s*/, "extension", /\s+(?=[[(])/],
-              beginScope: { 2: "keyword" },
-            },
-            {
-              begin: [/^\s*/, /end/, /\s+/, /(extension\b)?/],
-              beginScope: { 2: "keyword", 4: "keyword" },
-            },
-            { match: /\.inline\b/ },
-            { begin: /\binline(?=\s)/, keywords: "inline" },
-            {
-              begin: [/\(\s*/, /using/, /\s+(?!\))/],
-              beginScope: { 2: "keyword" },
-            },
-            { className: "meta", begin: "@[A-Za-z]+" },
-          ],
-        };
-      },
-      grmr_scss: (e) => {
-        const n = se(e),
-          t = oe,
-          s = re,
-          a = "@[a-z-]+",
-          i = {
-            className: "variable",
-            begin: "(\\$[a-zA-Z-][a-zA-Z0-9_-]*)\\b",
-            relevance: 0,
-          };
-        return {
-          name: "SCSS",
-          case_insensitive: !0,
-          illegal: "[=/|']",
-          contains: [
-            e.C_LINE_COMMENT_MODE,
-            e.C_BLOCK_COMMENT_MODE,
-            n.CSS_NUMBER_MODE,
-            {
-              className: "selector-id",
-              begin: "#[A-Za-z0-9_-]+",
-              relevance: 0,
-            },
-            {
-              className: "selector-class",
-              begin: "\\.[A-Za-z0-9_-]+",
-              relevance: 0,
-            },
-            n.ATTRIBUTE_SELECTOR_MODE,
-            {
-              className: "selector-tag",
-              begin: "\\b(" + ae.join("|") + ")\\b",
-              relevance: 0,
-            },
-            { className: "selector-pseudo", begin: ":(" + s.join("|") + ")" },
-            { className: "selector-pseudo", begin: ":(:)?(" + t.join("|") + ")" },
-            i,
-            { begin: /\(/, end: /\)/, contains: [n.CSS_NUMBER_MODE] },
-            n.CSS_VARIABLE,
-            { className: "attribute", begin: "\\b(" + ce.join("|") + ")\\b" },
-            {
-              begin:
-                "\\b(whitespace|wait|w-resize|visible|vertical-text|vertical-ideographic|uppercase|upper-roman|upper-alpha|underline|transparent|top|thin|thick|text|text-top|text-bottom|tb-rl|table-header-group|table-footer-group|sw-resize|super|strict|static|square|solid|small-caps|separate|se-resize|scroll|s-resize|rtl|row-resize|ridge|right|repeat|repeat-y|repeat-x|relative|progress|pointer|overline|outside|outset|oblique|nowrap|not-allowed|normal|none|nw-resize|no-repeat|no-drop|newspaper|ne-resize|n-resize|move|middle|medium|ltr|lr-tb|lowercase|lower-roman|lower-alpha|loose|list-item|line|line-through|line-edge|lighter|left|keep-all|justify|italic|inter-word|inter-ideograph|inside|inset|inline|inline-block|inherit|inactive|ideograph-space|ideograph-parenthesis|ideograph-numeric|ideograph-alpha|horizontal|hidden|help|hand|groove|fixed|ellipsis|e-resize|double|dotted|distribute|distribute-space|distribute-letter|distribute-all-lines|disc|disabled|default|decimal|dashed|crosshair|collapse|col-resize|circle|char|center|capitalize|break-word|break-all|bottom|both|bolder|bold|block|bidi-override|below|baseline|auto|always|all-scroll|absolute|table|table-cell)\\b",
-            },
-            {
-              begin: /:/,
-              end: /[;}{]/,
-              relevance: 0,
-              contains: [
-                n.BLOCK_COMMENT,
-                i,
-                n.HEXCOLOR,
-                n.CSS_NUMBER_MODE,
-                e.QUOTE_STRING_MODE,
-                e.APOS_STRING_MODE,
-                n.IMPORTANT,
-                n.FUNCTION_DISPATCH,
-              ],
-            },
-            {
-              begin: "@(page|font-face)",
-              keywords: { $pattern: a, keyword: "@page @font-face" },
-            },
-            {
-              begin: "@",
-              end: "[{;]",
-              returnBegin: !0,
-              keywords: {
-                $pattern: /[a-z-]+/,
-                keyword: "and or not only",
-                attribute: ie.join(" "),
-              },
-              contains: [
-                { begin: a, className: "keyword" },
-                { begin: /[a-z-]+(?=:)/, className: "attribute" },
-                i,
-                e.QUOTE_STRING_MODE,
-                e.APOS_STRING_MODE,
-                n.HEXCOLOR,
-                n.CSS_NUMBER_MODE,
-              ],
-            },
-            n.FUNCTION_DISPATCH,
-          ],
-        };
-      },
-      grmr_shell: (e) => ({
-        name: "Shell Session",
-        aliases: ["console", "shellsession"],
-        contains: [
-          {
-            className: "meta.prompt",
-            begin: /^\s{0,3}[/~\w\d[\]()@-]*[>%$#][ ]?/,
-            starts: { end: /[^\\](?=\s*$)/, subLanguage: "bash" },
-          },
-        ],
-      }),
-      grmr_sql: (e) => {
-        const n = e.regex,
-          t = e.COMMENT("--", "$"),
-          s = ["true", "false", "unknown"],
-          a = [
-            "bigint",
-            "binary",
-            "blob",
-            "boolean",
-            "char",
-            "character",
-            "clob",
-            "date",
-            "dec",
-            "decfloat",
-            "decimal",
-            "float",
-            "int",
-            "integer",
-            "interval",
-            "nchar",
-            "nclob",
-            "national",
-            "numeric",
-            "real",
-            "row",
-            "smallint",
-            "time",
-            "timestamp",
-            "varchar",
-            "varying",
-            "varbinary",
-          ],
-          i = [
-            "abs",
-            "acos",
-            "array_agg",
-            "asin",
-            "atan",
-            "avg",
-            "cast",
-            "ceil",
-            "ceiling",
-            "coalesce",
-            "corr",
-            "cos",
-            "cosh",
-            "count",
-            "covar_pop",
-            "covar_samp",
-            "cume_dist",
-            "dense_rank",
-            "deref",
-            "element",
-            "exp",
-            "extract",
-            "first_value",
-            "floor",
-            "json_array",
-            "json_arrayagg",
-            "json_exists",
-            "json_object",
-            "json_objectagg",
-            "json_query",
-            "json_table",
-            "json_table_primitive",
-            "json_value",
-            "lag",
-            "last_value",
-            "lead",
-            "listagg",
-            "ln",
-            "log",
-            "log10",
-            "lower",
-            "max",
-            "min",
-            "mod",
-            "nth_value",
-            "ntile",
-            "nullif",
-            "percent_rank",
-            "percentile_cont",
-            "percentile_disc",
-            "position",
-            "position_regex",
-            "power",
-            "rank",
-            "regr_avgx",
-            "regr_avgy",
-            "regr_count",
-            "regr_intercept",
-            "regr_r2",
-            "regr_slope",
-            "regr_sxx",
-            "regr_sxy",
-            "regr_syy",
-            "row_number",
-            "sin",
-            "sinh",
-            "sqrt",
-            "stddev_pop",
-            "stddev_samp",
-            "substring",
-            "substring_regex",
-            "sum",
-            "tan",
-            "tanh",
-            "translate",
-            "translate_regex",
-            "treat",
-            "trim",
-            "trim_array",
-            "unnest",
-            "upper",
-            "value_of",
-            "var_pop",
-            "var_samp",
-            "width_bucket",
-          ],
-          r = [
-            "create table",
-            "insert into",
-            "primary key",
-            "foreign key",
-            "not null",
-            "alter table",
-            "add constraint",
-            "grouping sets",
-            "on overflow",
-            "character set",
-            "respect nulls",
-            "ignore nulls",
-            "nulls first",
-            "nulls last",
-            "depth first",
-            "breadth first",
-          ],
-          o = i,
-          c = [
-            "abs",
-            "acos",
-            "all",
-            "allocate",
-            "alter",
-            "and",
-            "any",
-            "are",
-            "array",
-            "array_agg",
-            "array_max_cardinality",
-            "as",
-            "asensitive",
-            "asin",
-            "asymmetric",
-            "at",
-            "atan",
-            "atomic",
-            "authorization",
-            "avg",
-            "begin",
-            "begin_frame",
-            "begin_partition",
-            "between",
-            "bigint",
-            "binary",
-            "blob",
-            "boolean",
-            "both",
-            "by",
-            "call",
-            "called",
-            "cardinality",
-            "cascaded",
-            "case",
-            "cast",
-            "ceil",
-            "ceiling",
-            "char",
-            "char_length",
-            "character",
-            "character_length",
-            "check",
-            "classifier",
-            "clob",
-            "close",
-            "coalesce",
-            "collate",
-            "collect",
-            "column",
-            "commit",
-            "condition",
-            "connect",
-            "constraint",
-            "contains",
-            "convert",
-            "copy",
-            "corr",
-            "corresponding",
-            "cos",
-            "cosh",
-            "count",
-            "covar_pop",
-            "covar_samp",
-            "create",
-            "cross",
-            "cube",
-            "cume_dist",
-            "current",
-            "current_catalog",
-            "current_date",
-            "current_default_transform_group",
-            "current_path",
-            "current_role",
-            "current_row",
-            "current_schema",
-            "current_time",
-            "current_timestamp",
-            "current_path",
-            "current_role",
-            "current_transform_group_for_type",
-            "current_user",
-            "cursor",
-            "cycle",
-            "date",
-            "day",
-            "deallocate",
-            "dec",
-            "decimal",
-            "decfloat",
-            "declare",
-            "default",
-            "define",
-            "delete",
-            "dense_rank",
-            "deref",
-            "describe",
-            "deterministic",
-            "disconnect",
-            "distinct",
-            "double",
-            "drop",
-            "dynamic",
-            "each",
-            "element",
-            "else",
-            "empty",
-            "end",
-            "end_frame",
-            "end_partition",
-            "end-exec",
-            "equals",
-            "escape",
-            "every",
-            "except",
-            "exec",
-            "execute",
-            "exists",
-            "exp",
-            "external",
-            "extract",
-            "false",
-            "fetch",
-            "filter",
-            "first_value",
-            "float",
-            "floor",
-            "for",
-            "foreign",
-            "frame_row",
-            "free",
-            "from",
-            "full",
-            "function",
-            "fusion",
-            "get",
-            "global",
-            "grant",
-            "group",
-            "grouping",
-            "groups",
-            "having",
-            "hold",
-            "hour",
-            "identity",
-            "in",
-            "indicator",
-            "initial",
-            "inner",
-            "inout",
-            "insensitive",
-            "insert",
-            "int",
-            "integer",
-            "intersect",
-            "intersection",
-            "interval",
-            "into",
-            "is",
-            "join",
-            "json_array",
-            "json_arrayagg",
-            "json_exists",
-            "json_object",
-            "json_objectagg",
-            "json_query",
-            "json_table",
-            "json_table_primitive",
-            "json_value",
-            "lag",
-            "language",
-            "large",
-            "last_value",
-            "lateral",
-            "lead",
-            "leading",
-            "left",
-            "like",
-            "like_regex",
-            "listagg",
-            "ln",
-            "local",
-            "localtime",
-            "localtimestamp",
-            "log",
-            "log10",
-            "lower",
-            "match",
-            "match_number",
-            "match_recognize",
-            "matches",
-            "max",
-            "member",
-            "merge",
-            "method",
-            "min",
-            "minute",
-            "mod",
-            "modifies",
-            "module",
-            "month",
-            "multiset",
-            "national",
-            "natural",
-            "nchar",
-            "nclob",
-            "new",
-            "no",
-            "none",
-            "normalize",
-            "not",
-            "nth_value",
-            "ntile",
-            "null",
-            "nullif",
-            "numeric",
-            "octet_length",
-            "occurrences_regex",
-            "of",
-            "offset",
-            "old",
-            "omit",
-            "on",
-            "one",
-            "only",
-            "open",
-            "or",
-            "order",
-            "out",
-            "outer",
-            "over",
-            "overlaps",
-            "overlay",
-            "parameter",
-            "partition",
-            "pattern",
-            "per",
-            "percent",
-            "percent_rank",
-            "percentile_cont",
-            "percentile_disc",
-            "period",
-            "portion",
-            "position",
-            "position_regex",
-            "power",
-            "precedes",
-            "precision",
-            "prepare",
-            "primary",
-            "procedure",
-            "ptf",
-            "range",
-            "rank",
-            "reads",
-            "real",
-            "recursive",
-            "ref",
-            "references",
-            "referencing",
-            "regr_avgx",
-            "regr_avgy",
-            "regr_count",
-            "regr_intercept",
-            "regr_r2",
-            "regr_slope",
-            "regr_sxx",
-            "regr_sxy",
-            "regr_syy",
-            "release",
-            "result",
-            "return",
-            "returns",
-            "revoke",
-            "right",
-            "rollback",
-            "rollup",
-            "row",
-            "row_number",
-            "rows",
-            "running",
-            "savepoint",
-            "scope",
-            "scroll",
-            "search",
-            "second",
-            "seek",
-            "select",
-            "sensitive",
-            "session_user",
-            "set",
-            "show",
-            "similar",
-            "sin",
-            "sinh",
-            "skip",
-            "smallint",
-            "some",
-            "specific",
-            "specifictype",
-            "sql",
-            "sqlexception",
-            "sqlstate",
-            "sqlwarning",
-            "sqrt",
-            "start",
-            "static",
-            "stddev_pop",
-            "stddev_samp",
-            "submultiset",
-            "subset",
-            "substring",
-            "substring_regex",
-            "succeeds",
-            "sum",
-            "symmetric",
-            "system",
-            "system_time",
-            "system_user",
-            "table",
-            "tablesample",
-            "tan",
-            "tanh",
-            "then",
-            "time",
-            "timestamp",
-            "timezone_hour",
-            "timezone_minute",
-            "to",
-            "trailing",
-            "translate",
-            "translate_regex",
-            "translation",
-            "treat",
-            "trigger",
-            "trim",
-            "trim_array",
-            "true",
-            "truncate",
-            "uescape",
-            "union",
-            "unique",
-            "unknown",
-            "unnest",
-            "update",
-            "upper",
-            "user",
-            "using",
-            "value",
-            "values",
-            "value_of",
-            "var_pop",
-            "var_samp",
-            "varbinary",
-            "varchar",
-            "varying",
-            "versioning",
-            "when",
-            "whenever",
-            "where",
-            "width_bucket",
-            "window",
-            "with",
-            "within",
-            "without",
-            "year",
-            "add",
-            "asc",
-            "collation",
-            "desc",
-            "final",
-            "first",
-            "last",
-            "view",
-          ].filter((e) => !i.includes(e)),
-          l = {
-            begin: n.concat(/\b/, n.either(...o), /\s*\(/),
-            relevance: 0,
-            keywords: { built_in: o },
-          };
-        return {
-          name: "SQL",
-          case_insensitive: !0,
-          illegal: /[{}]|<\//,
-          keywords: {
-            $pattern: /\b[\w\.]+/,
-            keyword: ((e, { exceptions: n, when: t } = {}) => {
-              const s = t;
-              return (
-                (n = n || []),
-                e.map((e) =>
-                  e.match(/\|\d+$/) || n.includes(e) ? e : s(e) ? e + "|0" : e
-                )
-              );
-            })(c, { when: (e) => e.length < 3 }),
-            literal: s,
-            type: a,
-            built_in: [
-              "current_catalog",
-              "current_date",
-              "current_default_transform_group",
-              "current_path",
-              "current_role",
-              "current_schema",
-              "current_transform_group_for_type",
-              "current_user",
-              "session_user",
-              "system_time",
-              "system_user",
-              "current_time",
-              "localtime",
-              "current_timestamp",
-              "localtimestamp",
-            ],
-          },
-          contains: [
-            {
-              begin: n.either(...r),
-              relevance: 0,
-              keywords: {
-                $pattern: /[\w\.]+/,
-                keyword: c.concat(r),
-                literal: s,
-                type: a,
-              },
-            },
-            {
-              className: "type",
-              begin: n.either(
-                "double precision",
-                "large object",
-                "with timezone",
-                "without timezone"
-              ),
-            },
-            l,
-            { className: "variable", begin: /@[a-z0-9][a-z0-9_]*/ },
-            {
-              className: "string",
-              variants: [{ begin: /'/, end: /'/, contains: [{ begin: /''/ }] }],
-            },
-            { begin: /"/, end: /"/, contains: [{ begin: /""/ }] },
-            e.C_NUMBER_MODE,
-            e.C_BLOCK_COMMENT_MODE,
-            t,
-            {
-              className: "operator",
-              begin: /[-+*/=%^~]|&&?|\|\|?|!=?|<(?:=>?|<|>)?|>[>=]?/,
-              relevance: 0,
-            },
-          ],
-        };
-      },
-      grmr_swift: (e) => {
-        const n = { match: /\s+/, relevance: 0 },
-          t = e.COMMENT("/\\*", "\\*/", { contains: ["self"] }),
-          s = [e.C_LINE_COMMENT_MODE, t],
-          a = {
-            match: [/\./, b(...ke, ...Oe)],
-            className: { 2: "keyword" },
-          },
-          i = { match: u(/\./, b(...Ae)), relevance: 0 },
-          r = Ae.filter((e) => "string" == typeof e).concat(["_|0"]),
-          o = {
-            variants: [
-              {
-                className: "keyword",
-                match: b(
-                  ...Ae.filter((e) => "string" != typeof e)
-                    .concat(Me)
-                    .map(xe),
-                  ...Oe
-                ),
-              },
-            ],
-          },
-          c = {
-            $pattern: b(/\b\w+/, /#\w+/),
-            keyword: r.concat(Te),
-            literal: Se,
-          },
-          l = [a, i, o],
-          p = [
-            {
-              match: u(/\./, b(...qe)),
-              relevance: 0,
-            },
-            { className: "built_in", match: u(/\b/, b(...qe), /(?=\()/) },
-          ],
-          m = { match: /->/, relevance: 0 },
-          g = [
-            m,
-            {
-              className: "operator",
-              relevance: 0,
-              variants: [{ match: Ie }, { match: `\\.(\\.|${Re})+` }],
-            },
-          ],
-          v = "([0-9]_*)+",
-          _ = "([0-9a-fA-F]_*)+",
-          f = {
-            className: "number",
-            relevance: 0,
-            variants: [
-              { match: `\\b(${v})(\\.(${v}))?([eE][+-]?(${v}))?\\b` },
-              {
-                match: `\\b0x(${_})(\\.(${_}))?([pP][+-]?(${v}))?\\b`,
-              },
-              { match: /\b0o([0-7]_*)+\b/ },
-              { match: /\b0b([01]_*)+\b/ },
-            ],
-          },
-          h = (e = "") => ({
-            className: "subst",
-            variants: [
-              {
-                match: u(/\\/, e, /[0\\tnr"']/),
-              },
-              { match: u(/\\/, e, /u\{[0-9a-fA-F]{1,8}\}/) },
-            ],
-          }),
-          E = (e = "") => ({
-            className: "subst",
-            match: u(/\\/, e, /[\t ]*(?:[\r\n]|\r\n)/),
-          }),
-          w = (e = "") => ({
-            className: "subst",
-            label: "interpol",
-            begin: u(/\\/, e, /\(/),
-            end: /\)/,
-          }),
-          y = (e = "") => ({
-            begin: u(e, /"""/),
-            end: u(/"""/, e),
-            contains: [h(e), E(e), w(e)],
-          }),
-          N = (e = "") => ({
-            begin: u(e, /"/),
-            end: u(/"/, e),
-            contains: [h(e), w(e)],
-          }),
-          x = {
-            className: "string",
-            variants: [
-              y(),
-              y("#"),
-              y("##"),
-              y("###"),
-              N(),
-              N("#"),
-              N("##"),
-              N("###"),
-            ],
-          },
-          k = [
-            e.BACKSLASH_ESCAPE,
+            { beginKeywords: "extends with", relevance: 10 },
             {
               begin: /\[/,
               end: /\]/,
+              excludeBegin: !0,
+              excludeEnd: !0,
               relevance: 0,
-              contains: [e.BACKSLASH_ESCAPE],
-            },
-          ],
-          O = { begin: /\/[^\s](?=[^/\n]*\/)/, end: /\//, contains: k },
-          M = (e) => {
-            const n = u(e, /\//),
-              t = u(/\//, e);
-            return {
-              begin: n,
-              end: t,
-              contains: [
-                ...k,
-                { scope: "comment", begin: `#(?!.*${t})`, end: /$/ },
-              ],
-            };
-          },
-          A = {
-            scope: "regexp",
-            variants: [M("###"), M("##"), M("#"), O],
-          },
-          S = { match: u(/`/, ze, /`/) },
-          C = [
-            S,
-            { className: "variable", match: /\$\d+/ },
-            { className: "variable", match: `\\$${Be}+` },
-          ],
-          T = [
-            {
-              match: /(@|#(un)?)available/,
-              scope: "keyword",
-              starts: {
-                contains: [
-                  {
-                    begin: /\(/,
-                    end: /\)/,
-                    keywords: Ue,
-                    contains: [...g, f, x],
-                  },
-                ],
-              },
+              contains: [s],
             },
             {
-              scope: "keyword",
-              match: u(/@/, b(...$e), d(b(/\(/, /\s+/))),
-            },
-            { scope: "meta", match: u(/@/, ze) },
-          ],
-          q = {
-            match: d(/\b[A-Z]/),
-            relevance: 0,
-            contains: [
-              {
-                className: "type",
-                match: u(
-                  /(AV|CA|CF|CG|CI|CL|CM|CN|CT|MK|MP|MTK|MTL|NS|SCN|SK|UI|WK|XC)/,
-                  Be,
-                  "+"
-                ),
-              },
-              { className: "type", match: Fe, relevance: 0 },
-              { match: /[?!]+/, relevance: 0 },
-              {
-                match: /\.\.\./,
-                relevance: 0,
-              },
-              { match: u(/\s+&\s+/, d(Fe)), relevance: 0 },
-            ],
-          },
-          D = {
-            begin: /</,
-            end: />/,
-            keywords: c,
-            contains: [...s, ...l, ...T, m, q],
-          };
-        q.contains.push(D);
-        const R = {
-            begin: /\(/,
-            end: /\)/,
-            relevance: 0,
-            keywords: c,
-            contains: [
-              "self",
-              {
-                match: u(ze, /\s*:/),
-                keywords: "_|0",
-                relevance: 0,
-              },
-              ...s,
-              A,
-              ...l,
-              ...p,
-              ...g,
-              f,
-              x,
-              ...C,
-              ...T,
-              q,
-            ],
-          },
-          I = {
-            begin: /</,
-            end: />/,
-            keywords: "repeat each",
-            contains: [...s, q],
-          },
-          L = {
-            begin: /\(/,
-            end: /\)/,
-            keywords: c,
-            contains: [
-              {
-                begin: b(d(u(ze, /\s*:/)), d(u(ze, /\s+/, ze, /\s*:/))),
-                end: /:/,
-                relevance: 0,
-                contains: [
-                  { className: "keyword", match: /\b_\b/ },
-                  { className: "params", match: ze },
-                ],
-              },
-              ...s,
-              ...l,
-              ...g,
-              f,
-              x,
-              ...T,
-              q,
-              R,
-            ],
-            endsParent: !0,
-            illegal: /["']/,
-          },
-          B = {
-            match: [/(func|macro)/, /\s+/, b(S.match, ze, Ie)],
-            className: { 1: "keyword", 3: "title.function" },
-            contains: [I, L, n],
-            illegal: [/\[/, /%/],
-          },
-          z = {
-            match: [/\b(?:subscript|init[?!]?)/, /\s*(?=[<(])/],
-            className: { 1: "keyword" },
-            contains: [I, L, n],
-            illegal: /\[|%/,
-          },
-          F = {
-            match: [/operator/, /\s+/, Ie],
-            className: {
-              1: "keyword",
-              3: "title",
-            },
-          },
-          $ = {
-            begin: [/precedencegroup/, /\s+/, Fe],
-            className: {
-              1: "keyword",
-              3: "title",
-            },
-            contains: [q],
-            keywords: [...Ce, ...Se],
-            end: /}/,
-          },
-          U = {
-            begin: [
-              /(struct|protocol|class|extension|enum|actor)/,
-              /\s+/,
-              ze,
-              /\s*/,
-            ],
-            beginScope: { 1: "keyword", 3: "title.class" },
-            keywords: c,
-            contains: [
-              I,
-              ...l,
-              {
-                begin: /:/,
-                end: /\{/,
-                keywords: c,
-                contains: [{ scope: "title.class.inherited", match: Fe }, ...l],
-                relevance: 0,
-              },
-            ],
-          };
-        for (const e of x.variants) {
-          const n = e.contains.find((e) => "interpol" === e.label);
-          n.keywords = c;
-          const t = [...l, ...p, ...g, f, x, ...C];
-          n.contains = [
-            ...t,
-            { begin: /\(/, end: /\)/, contains: ["self", ...t] },
-          ];
-        }
-        return {
-          name: "Swift",
-          keywords: c,
-          contains: [
-            ...s,
-            B,
-            z,
-            U,
-            F,
-            $,
-            { beginKeywords: "import", end: /$/, contains: [...s], relevance: 0 },
-            A,
-            ...l,
-            ...p,
-            ...g,
-            f,
-            x,
-            ...C,
-            ...T,
-            q,
-            R,
-          ],
-        };
-      },
-      grmr_typescript: (e) => {
-        const n = Ne(e),
-          t = ge,
-          s = [
-            "any",
-            "void",
-            "number",
-            "boolean",
-            "string",
-            "object",
-            "never",
-            "symbol",
-            "bigint",
-            "unknown",
-          ],
-          a = {
-            begin: [/namespace/, /\s+/, e.IDENT_RE],
-            beginScope: { 1: "keyword", 3: "title.class" },
-          },
-          i = {
-            beginKeywords: "interface",
-            end: /\{/,
-            excludeEnd: !0,
-            keywords: {
-              keyword: "interface extends",
-              built_in: s,
-            },
-            contains: [n.exports.CLASS_REFERENCE],
-          },
-          r = {
-            $pattern: ge,
-            keyword: ve.concat([
-              "type",
-              "interface",
-              "public",
-              "private",
-              "protected",
-              "implements",
-              "declare",
-              "abstract",
-              "readonly",
-              "enum",
-              "override",
-              "satisfies",
-            ]),
-            literal: _e,
-            built_in: ye.concat(s),
-            "variable.language": we,
-          },
-          o = { className: "meta", begin: "@" + t },
-          c = (e, n, t) => {
-            const s = e.contains.findIndex((e) => e.label === n);
-            if (-1 === s) throw Error("can not find mode to replace");
-            e.contains.splice(s, 1, t);
-          };
-        Object.assign(n.keywords, r), n.exports.PARAMS_CONTAINS.push(o);
-        const l = n.contains.find((e) => "attr" === e.className);
-        return (
-          n.exports.PARAMS_CONTAINS.push([n.exports.CLASS_REFERENCE, l]),
-          (n.contains = n.contains.concat([o, a, i])),
-          c(n, "shebang", e.SHEBANG()),
-          c(n, "use_strict", {
-            className: "meta",
-            relevance: 10,
-            begin: /^\s*['"]use strict['"]/,
-          }),
-          (n.contains.find((e) => "func.def" === e.label).relevance = 0),
-          Object.assign(n, {
-            name: "TypeScript",
-            aliases: ["ts", "tsx", "mts", "cts"],
-          }),
-          n
-        );
-      },
-      grmr_vbnet: (e) => {
-        const n = e.regex,
-          t = /\d{1,2}\/\d{1,2}\/\d{4}/,
-          s = /\d{4}-\d{1,2}-\d{1,2}/,
-          a = /(\d|1[012])(:\d+){0,2} *(AM|PM)/,
-          i = /\d{1,2}(:\d{1,2}){1,2}/,
-          r = {
-            className: "literal",
-            variants: [
-              { begin: n.concat(/# */, n.either(s, t), / *#/) },
-              {
-                begin: n.concat(/# */, i, / *#/),
-              },
-              { begin: n.concat(/# */, a, / *#/) },
-              {
-                begin: n.concat(
-                  /# */,
-                  n.either(s, t),
-                  / +/,
-                  n.either(a, i),
-                  / *#/
-                ),
-              },
-            ],
-          },
-          o = e.COMMENT(/'''/, /$/, {
-            contains: [{ className: "doctag", begin: /<\/?/, end: />/ }],
-          }),
-          c = e.COMMENT(null, /$/, {
-            variants: [{ begin: /'/ }, { begin: /([\t ]|^)REM(?=\s)/ }],
-          });
-        return {
-          name: "Visual Basic .NET",
-          aliases: ["vb"],
-          case_insensitive: !0,
-          classNameAliases: { label: "symbol" },
-          keywords: {
-            keyword:
-              "addhandler alias aggregate ansi as async assembly auto binary by byref byval call case catch class compare const continue custom declare default delegate dim distinct do each equals else elseif end enum erase error event exit explicit finally for friend from function get global goto group handles if implements imports in inherits interface into iterator join key let lib loop me mid module mustinherit mustoverride mybase myclass namespace narrowing new next notinheritable notoverridable of off on operator option optional order overloads overridable overrides paramarray partial preserve private property protected public raiseevent readonly redim removehandler resume return select set shadows shared skip static step stop structure strict sub synclock take text then throw to try unicode until using when where while widening with withevents writeonly yield",
-            built_in:
-              "addressof and andalso await directcast gettype getxmlnamespace is isfalse isnot istrue like mod nameof new not or orelse trycast typeof xor cbool cbyte cchar cdate cdbl cdec cint clng cobj csbyte cshort csng cstr cuint culng cushort",
-            type: "boolean byte char date decimal double integer long object sbyte short single string uinteger ulong ushort",
-            literal: "true false nothing",
-          },
-          illegal: "//|\\{|\\}|endif|gosub|variant|wend|^\\$ ",
-          contains: [
-            {
-              className: "string",
-              begin: /"(""|[^/n])"C\b/,
-            },
-            {
-              className: "string",
-              begin: /"/,
-              end: /"/,
-              illegal: /\n/,
-              contains: [{ begin: /""/ }],
-            },
-            r,
-            {
-              className: "number",
+              className: "params",
+              begin: /\(/,
+              end: /\)/,
+              excludeBegin: !0,
+              excludeEnd: !0,
               relevance: 0,
-              variants: [
-                {
-                  begin:
-                    /\b\d[\d_]*((\.[\d_]+(E[+-]?[\d_]+)?)|(E[+-]?[\d_]+))[RFD@!#]?/,
-                },
-                { begin: /\b\d[\d_]*((U?[SIL])|[%&])?/ },
-                { begin: /&H[\dA-F_]+((U?[SIL])|[%&])?/ },
-                {
-                  begin: /&O[0-7_]+((U?[SIL])|[%&])?/,
-                },
-                { begin: /&B[01_]+((U?[SIL])|[%&])?/ },
-              ],
+              contains: [s],
             },
-            {
-              className: "label",
-              begin: /^\w+:/,
-            },
-            o,
-            c,
-            {
-              className: "meta",
-              begin:
-                /[\t ]*#(const|disable|else|elseif|enable|end|externalsource|if|region)\b/,
-              end: /$/,
-              keywords: {
-                keyword:
-                  "const disable else elseif enable end externalsource if region then",
-              },
-              contains: [c],
-            },
+            t,
           ],
+        },
+        l = {
+          className: "function",
+          beginKeywords: "def",
+          end: /[:={\[(\n;]/,
+          excludeEnd: !0,
+          contains: [t],
         };
-      },
-      grmr_wasm: (e) => {
-        e.regex;
-        const n = e.COMMENT(/\(;/, /;\)/);
-        return (
-          n.contains.push("self"),
-          {
-            name: "WebAssembly",
-            keywords: {
-              $pattern: /[\w.]+/,
-              keyword: [
-                "anyfunc",
-                "block",
-                "br",
-                "br_if",
-                "br_table",
-                "call",
-                "call_indirect",
-                "data",
-                "drop",
-                "elem",
-                "else",
-                "end",
-                "export",
-                "func",
-                "global.get",
-                "global.set",
-                "local.get",
-                "local.set",
-                "local.tee",
-                "get_global",
-                "get_local",
-                "global",
-                "if",
-                "import",
-                "local",
-                "loop",
-                "memory",
-                "memory.grow",
-                "memory.size",
-                "module",
-                "mut",
-                "nop",
-                "offset",
-                "param",
-                "result",
-                "return",
-                "select",
-                "set_global",
-                "set_local",
-                "start",
-                "table",
-                "tee_local",
-                "then",
-                "type",
-                "unreachable",
-              ],
-            },
-            contains: [
-              e.COMMENT(/;;/, /$/),
-              n,
-              {
-                match: [/(?:offset|align)/, /\s*/, /=/],
-                className: { 1: "keyword", 3: "operator" },
-              },
-              { className: "variable", begin: /\$[\w_]+/ },
-              {
-                match: /(\((?!;)|\))+/,
-                className: "punctuation",
-                relevance: 0,
-              },
-              {
-                begin: [/(?:func|call|call_indirect)/, /\s+/, /\$[^\s)]+/],
-                className: { 1: "keyword", 3: "title.function" },
-              },
-              e.QUOTE_STRING_MODE,
-              { match: /(i32|i64|f32|f64)(?!\.)/, className: "type" },
-              {
-                className: "keyword",
-                match:
-                  /\b(f32|f64|i32|i64)(?:\.(?:abs|add|and|ceil|clz|const|convert_[su]\/i(?:32|64)|copysign|ctz|demote\/f64|div(?:_[su])?|eqz?|extend_[su]\/i32|floor|ge(?:_[su])?|gt(?:_[su])?|le(?:_[su])?|load(?:(?:8|16|32)_[su])?|lt(?:_[su])?|max|min|mul|nearest|neg?|or|popcnt|promote\/f32|reinterpret\/[fi](?:32|64)|rem_[su]|rot[lr]|shl|shr_[su]|store(?:8|16|32)?|sqrt|sub|trunc(?:_[su]\/f(?:32|64))?|wrap\/i64|xor))\b/,
-              },
-              {
-                className: "number",
-                relevance: 0,
-                match:
-                  /[+-]?\b(?:\d(?:_?\d)*(?:\.\d(?:_?\d)*)?(?:[eE][+-]?\d(?:_?\d)*)?|0x[\da-fA-F](?:_?[\da-fA-F])*(?:\.[\da-fA-F](?:_?[\da-fA-D])*)?(?:[pP][+-]?\d(?:_?\d)*)?)\b|\binf\b|\bnan(?::0x[\da-fA-F](?:_?[\da-fA-D])*)?\b/,
-              },
-            ],
-          }
-        );
-      },
-      grmr_x86asm: (e) => ({
+      return {
+        name: "Scala",
+        keywords: {
+          literal: "true false null",
+          keyword:
+            "type yield lazy override def with val var sealed abstract private trait object if forSome for while throw finally protected extends import final return else break new catch super class case package default try this match continue throws implicit",
+        },
+        contains: [
+          e.C_LINE_COMMENT_MODE,
+          e.C_BLOCK_COMMENT_MODE,
+          a,
+          { className: "symbol", begin: "'\\w[\\w\\d_]*(?!')" },
+          s,
+          l,
+          i,
+          e.C_NUMBER_MODE,
+          { className: "meta", begin: "@[A-Za-z]+" },
+        ],
+      };
+    };
+  })()
+);
+hljs.registerLanguage(
+  "x86asm",
+  (function () {
+    "use strict";
+    return function (s) {
+      return {
         name: "Intel x86 Assembly",
         case_insensitive: !0,
         keywords: {
-          $pattern: "[.%]?" + e.IDENT_RE,
+          $pattern: "[.%]?" + s.IDENT_RE,
           keyword:
             "lock rep repe repz repne repnz xaquire xrelease bnd nobnd aaa aad aam aas adc add and arpl bb0_reset bb1_reset bound bsf bsr bswap bt btc btr bts call cbw cdq cdqe clc cld cli clts cmc cmp cmpsb cmpsd cmpsq cmpsw cmpxchg cmpxchg486 cmpxchg8b cmpxchg16b cpuid cpu_read cpu_write cqo cwd cwde daa das dec div dmint emms enter equ f2xm1 fabs fadd faddp fbld fbstp fchs fclex fcmovb fcmovbe fcmove fcmovnb fcmovnbe fcmovne fcmovnu fcmovu fcom fcomi fcomip fcomp fcompp fcos fdecstp fdisi fdiv fdivp fdivr fdivrp femms feni ffree ffreep fiadd ficom ficomp fidiv fidivr fild fimul fincstp finit fist fistp fisttp fisub fisubr fld fld1 fldcw fldenv fldl2e fldl2t fldlg2 fldln2 fldpi fldz fmul fmulp fnclex fndisi fneni fninit fnop fnsave fnstcw fnstenv fnstsw fpatan fprem fprem1 fptan frndint frstor fsave fscale fsetpm fsin fsincos fsqrt fst fstcw fstenv fstp fstsw fsub fsubp fsubr fsubrp ftst fucom fucomi fucomip fucomp fucompp fxam fxch fxtract fyl2x fyl2xp1 hlt ibts icebp idiv imul in inc incbin insb insd insw int int01 int1 int03 int3 into invd invpcid invlpg invlpga iret iretd iretq iretw jcxz jecxz jrcxz jmp jmpe lahf lar lds lea leave les lfence lfs lgdt lgs lidt lldt lmsw loadall loadall286 lodsb lodsd lodsq lodsw loop loope loopne loopnz loopz lsl lss ltr mfence monitor mov movd movq movsb movsd movsq movsw movsx movsxd movzx mul mwait neg nop not or out outsb outsd outsw packssdw packsswb packuswb paddb paddd paddsb paddsiw paddsw paddusb paddusw paddw pand pandn pause paveb pavgusb pcmpeqb pcmpeqd pcmpeqw pcmpgtb pcmpgtd pcmpgtw pdistib pf2id pfacc pfadd pfcmpeq pfcmpge pfcmpgt pfmax pfmin pfmul pfrcp pfrcpit1 pfrcpit2 pfrsqit1 pfrsqrt pfsub pfsubr pi2fd pmachriw pmaddwd pmagw pmulhriw pmulhrwa pmulhrwc pmulhw pmullw pmvgezb pmvlzb pmvnzb pmvzb pop popa popad popaw popf popfd popfq popfw por prefetch prefetchw pslld psllq psllw psrad psraw psrld psrlq psrlw psubb psubd psubsb psubsiw psubsw psubusb psubusw psubw punpckhbw punpckhdq punpckhwd punpcklbw punpckldq punpcklwd push pusha pushad pushaw pushf pushfd pushfq pushfw pxor rcl rcr rdshr rdmsr rdpmc rdtsc rdtscp ret retf retn rol ror rdm rsdc rsldt rsm rsts sahf sal salc sar sbb scasb scasd scasq scasw sfence sgdt shl shld shr shrd sidt sldt skinit smi smint smintold smsw stc std sti stosb stosd stosq stosw str sub svdc svldt svts swapgs syscall sysenter sysexit sysret test ud0 ud1 ud2b ud2 ud2a umov verr verw fwait wbinvd wrshr wrmsr xadd xbts xchg xlatb xlat xor cmove cmovz cmovne cmovnz cmova cmovnbe cmovae cmovnb cmovb cmovnae cmovbe cmovna cmovg cmovnle cmovge cmovnl cmovl cmovnge cmovle cmovng cmovc cmovnc cmovo cmovno cmovs cmovns cmovp cmovpe cmovnp cmovpo je jz jne jnz ja jnbe jae jnb jb jnae jbe jna jg jnle jge jnl jl jnge jle jng jc jnc jo jno js jns jpo jnp jpe jp sete setz setne setnz seta setnbe setae setnb setnc setb setnae setcset setbe setna setg setnle setge setnl setl setnge setle setng sets setns seto setno setpe setp setpo setnp addps addss andnps andps cmpeqps cmpeqss cmpleps cmpless cmpltps cmpltss cmpneqps cmpneqss cmpnleps cmpnless cmpnltps cmpnltss cmpordps cmpordss cmpunordps cmpunordss cmpps cmpss comiss cvtpi2ps cvtps2pi cvtsi2ss cvtss2si cvttps2pi cvttss2si divps divss ldmxcsr maxps maxss minps minss movaps movhps movlhps movlps movhlps movmskps movntps movss movups mulps mulss orps rcpps rcpss rsqrtps rsqrtss shufps sqrtps sqrtss stmxcsr subps subss ucomiss unpckhps unpcklps xorps fxrstor fxrstor64 fxsave fxsave64 xgetbv xsetbv xsave xsave64 xsaveopt xsaveopt64 xrstor xrstor64 prefetchnta prefetcht0 prefetcht1 prefetcht2 maskmovq movntq pavgb pavgw pextrw pinsrw pmaxsw pmaxub pminsw pminub pmovmskb pmulhuw psadbw pshufw pf2iw pfnacc pfpnacc pi2fw pswapd maskmovdqu clflush movntdq movnti movntpd movdqa movdqu movdq2q movq2dq paddq pmuludq pshufd pshufhw pshuflw pslldq psrldq psubq punpckhqdq punpcklqdq addpd addsd andnpd andpd cmpeqpd cmpeqsd cmplepd cmplesd cmpltpd cmpltsd cmpneqpd cmpneqsd cmpnlepd cmpnlesd cmpnltpd cmpnltsd cmpordpd cmpordsd cmpunordpd cmpunordsd cmppd comisd cvtdq2pd cvtdq2ps cvtpd2dq cvtpd2pi cvtpd2ps cvtpi2pd cvtps2dq cvtps2pd cvtsd2si cvtsd2ss cvtsi2sd cvtss2sd cvttpd2pi cvttpd2dq cvttps2dq cvttsd2si divpd divsd maxpd maxsd minpd minsd movapd movhpd movlpd movmskpd movupd mulpd mulsd orpd shufpd sqrtpd sqrtsd subpd subsd ucomisd unpckhpd unpcklpd xorpd addsubpd addsubps haddpd haddps hsubpd hsubps lddqu movddup movshdup movsldup clgi stgi vmcall vmclear vmfunc vmlaunch vmload vmmcall vmptrld vmptrst vmread vmresume vmrun vmsave vmwrite vmxoff vmxon invept invvpid pabsb pabsw pabsd palignr phaddw phaddd phaddsw phsubw phsubd phsubsw pmaddubsw pmulhrsw pshufb psignb psignw psignd extrq insertq movntsd movntss lzcnt blendpd blendps blendvpd blendvps dppd dpps extractps insertps movntdqa mpsadbw packusdw pblendvb pblendw pcmpeqq pextrb pextrd pextrq phminposuw pinsrb pinsrd pinsrq pmaxsb pmaxsd pmaxud pmaxuw pminsb pminsd pminud pminuw pmovsxbw pmovsxbd pmovsxbq pmovsxwd pmovsxwq pmovsxdq pmovzxbw pmovzxbd pmovzxbq pmovzxwd pmovzxwq pmovzxdq pmuldq pmulld ptest roundpd roundps roundsd roundss crc32 pcmpestri pcmpestrm pcmpistri pcmpistrm pcmpgtq popcnt getsec pfrcpv pfrsqrtv movbe aesenc aesenclast aesdec aesdeclast aesimc aeskeygenassist vaesenc vaesenclast vaesdec vaesdeclast vaesimc vaeskeygenassist vaddpd vaddps vaddsd vaddss vaddsubpd vaddsubps vandpd vandps vandnpd vandnps vblendpd vblendps vblendvpd vblendvps vbroadcastss vbroadcastsd vbroadcastf128 vcmpeq_ospd vcmpeqpd vcmplt_ospd vcmpltpd vcmple_ospd vcmplepd vcmpunord_qpd vcmpunordpd vcmpneq_uqpd vcmpneqpd vcmpnlt_uspd vcmpnltpd vcmpnle_uspd vcmpnlepd vcmpord_qpd vcmpordpd vcmpeq_uqpd vcmpnge_uspd vcmpngepd vcmpngt_uspd vcmpngtpd vcmpfalse_oqpd vcmpfalsepd vcmpneq_oqpd vcmpge_ospd vcmpgepd vcmpgt_ospd vcmpgtpd vcmptrue_uqpd vcmptruepd vcmplt_oqpd vcmple_oqpd vcmpunord_spd vcmpneq_uspd vcmpnlt_uqpd vcmpnle_uqpd vcmpord_spd vcmpeq_uspd vcmpnge_uqpd vcmpngt_uqpd vcmpfalse_ospd vcmpneq_ospd vcmpge_oqpd vcmpgt_oqpd vcmptrue_uspd vcmppd vcmpeq_osps vcmpeqps vcmplt_osps vcmpltps vcmple_osps vcmpleps vcmpunord_qps vcmpunordps vcmpneq_uqps vcmpneqps vcmpnlt_usps vcmpnltps vcmpnle_usps vcmpnleps vcmpord_qps vcmpordps vcmpeq_uqps vcmpnge_usps vcmpngeps vcmpngt_usps vcmpngtps vcmpfalse_oqps vcmpfalseps vcmpneq_oqps vcmpge_osps vcmpgeps vcmpgt_osps vcmpgtps vcmptrue_uqps vcmptrueps vcmplt_oqps vcmple_oqps vcmpunord_sps vcmpneq_usps vcmpnlt_uqps vcmpnle_uqps vcmpord_sps vcmpeq_usps vcmpnge_uqps vcmpngt_uqps vcmpfalse_osps vcmpneq_osps vcmpge_oqps vcmpgt_oqps vcmptrue_usps vcmpps vcmpeq_ossd vcmpeqsd vcmplt_ossd vcmpltsd vcmple_ossd vcmplesd vcmpunord_qsd vcmpunordsd vcmpneq_uqsd vcmpneqsd vcmpnlt_ussd vcmpnltsd vcmpnle_ussd vcmpnlesd vcmpord_qsd vcmpordsd vcmpeq_uqsd vcmpnge_ussd vcmpngesd vcmpngt_ussd vcmpngtsd vcmpfalse_oqsd vcmpfalsesd vcmpneq_oqsd vcmpge_ossd vcmpgesd vcmpgt_ossd vcmpgtsd vcmptrue_uqsd vcmptruesd vcmplt_oqsd vcmple_oqsd vcmpunord_ssd vcmpneq_ussd vcmpnlt_uqsd vcmpnle_uqsd vcmpord_ssd vcmpeq_ussd vcmpnge_uqsd vcmpngt_uqsd vcmpfalse_ossd vcmpneq_ossd vcmpge_oqsd vcmpgt_oqsd vcmptrue_ussd vcmpsd vcmpeq_osss vcmpeqss vcmplt_osss vcmpltss vcmple_osss vcmpless vcmpunord_qss vcmpunordss vcmpneq_uqss vcmpneqss vcmpnlt_usss vcmpnltss vcmpnle_usss vcmpnless vcmpord_qss vcmpordss vcmpeq_uqss vcmpnge_usss vcmpngess vcmpngt_usss vcmpngtss vcmpfalse_oqss vcmpfalsess vcmpneq_oqss vcmpge_osss vcmpgess vcmpgt_osss vcmpgtss vcmptrue_uqss vcmptruess vcmplt_oqss vcmple_oqss vcmpunord_sss vcmpneq_usss vcmpnlt_uqss vcmpnle_uqss vcmpord_sss vcmpeq_usss vcmpnge_uqss vcmpngt_uqss vcmpfalse_osss vcmpneq_osss vcmpge_oqss vcmpgt_oqss vcmptrue_usss vcmpss vcomisd vcomiss vcvtdq2pd vcvtdq2ps vcvtpd2dq vcvtpd2ps vcvtps2dq vcvtps2pd vcvtsd2si vcvtsd2ss vcvtsi2sd vcvtsi2ss vcvtss2sd vcvtss2si vcvttpd2dq vcvttps2dq vcvttsd2si vcvttss2si vdivpd vdivps vdivsd vdivss vdppd vdpps vextractf128 vextractps vhaddpd vhaddps vhsubpd vhsubps vinsertf128 vinsertps vlddqu vldqqu vldmxcsr vmaskmovdqu vmaskmovps vmaskmovpd vmaxpd vmaxps vmaxsd vmaxss vminpd vminps vminsd vminss vmovapd vmovaps vmovd vmovq vmovddup vmovdqa vmovqqa vmovdqu vmovqqu vmovhlps vmovhpd vmovhps vmovlhps vmovlpd vmovlps vmovmskpd vmovmskps vmovntdq vmovntqq vmovntdqa vmovntpd vmovntps vmovsd vmovshdup vmovsldup vmovss vmovupd vmovups vmpsadbw vmulpd vmulps vmulsd vmulss vorpd vorps vpabsb vpabsw vpabsd vpacksswb vpackssdw vpackuswb vpackusdw vpaddb vpaddw vpaddd vpaddq vpaddsb vpaddsw vpaddusb vpaddusw vpalignr vpand vpandn vpavgb vpavgw vpblendvb vpblendw vpcmpestri vpcmpestrm vpcmpistri vpcmpistrm vpcmpeqb vpcmpeqw vpcmpeqd vpcmpeqq vpcmpgtb vpcmpgtw vpcmpgtd vpcmpgtq vpermilpd vpermilps vperm2f128 vpextrb vpextrw vpextrd vpextrq vphaddw vphaddd vphaddsw vphminposuw vphsubw vphsubd vphsubsw vpinsrb vpinsrw vpinsrd vpinsrq vpmaddwd vpmaddubsw vpmaxsb vpmaxsw vpmaxsd vpmaxub vpmaxuw vpmaxud vpminsb vpminsw vpminsd vpminub vpminuw vpminud vpmovmskb vpmovsxbw vpmovsxbd vpmovsxbq vpmovsxwd vpmovsxwq vpmovsxdq vpmovzxbw vpmovzxbd vpmovzxbq vpmovzxwd vpmovzxwq vpmovzxdq vpmulhuw vpmulhrsw vpmulhw vpmullw vpmulld vpmuludq vpmuldq vpor vpsadbw vpshufb vpshufd vpshufhw vpshuflw vpsignb vpsignw vpsignd vpslldq vpsrldq vpsllw vpslld vpsllq vpsraw vpsrad vpsrlw vpsrld vpsrlq vptest vpsubb vpsubw vpsubd vpsubq vpsubsb vpsubsw vpsubusb vpsubusw vpunpckhbw vpunpckhwd vpunpckhdq vpunpckhqdq vpunpcklbw vpunpcklwd vpunpckldq vpunpcklqdq vpxor vrcpps vrcpss vrsqrtps vrsqrtss vroundpd vroundps vroundsd vroundss vshufpd vshufps vsqrtpd vsqrtps vsqrtsd vsqrtss vstmxcsr vsubpd vsubps vsubsd vsubss vtestps vtestpd vucomisd vucomiss vunpckhpd vunpckhps vunpcklpd vunpcklps vxorpd vxorps vzeroall vzeroupper pclmullqlqdq pclmulhqlqdq pclmullqhqdq pclmulhqhqdq pclmulqdq vpclmullqlqdq vpclmulhqlqdq vpclmullqhqdq vpclmulhqhqdq vpclmulqdq vfmadd132ps vfmadd132pd vfmadd312ps vfmadd312pd vfmadd213ps vfmadd213pd vfmadd123ps vfmadd123pd vfmadd231ps vfmadd231pd vfmadd321ps vfmadd321pd vfmaddsub132ps vfmaddsub132pd vfmaddsub312ps vfmaddsub312pd vfmaddsub213ps vfmaddsub213pd vfmaddsub123ps vfmaddsub123pd vfmaddsub231ps vfmaddsub231pd vfmaddsub321ps vfmaddsub321pd vfmsub132ps vfmsub132pd vfmsub312ps vfmsub312pd vfmsub213ps vfmsub213pd vfmsub123ps vfmsub123pd vfmsub231ps vfmsub231pd vfmsub321ps vfmsub321pd vfmsubadd132ps vfmsubadd132pd vfmsubadd312ps vfmsubadd312pd vfmsubadd213ps vfmsubadd213pd vfmsubadd123ps vfmsubadd123pd vfmsubadd231ps vfmsubadd231pd vfmsubadd321ps vfmsubadd321pd vfnmadd132ps vfnmadd132pd vfnmadd312ps vfnmadd312pd vfnmadd213ps vfnmadd213pd vfnmadd123ps vfnmadd123pd vfnmadd231ps vfnmadd231pd vfnmadd321ps vfnmadd321pd vfnmsub132ps vfnmsub132pd vfnmsub312ps vfnmsub312pd vfnmsub213ps vfnmsub213pd vfnmsub123ps vfnmsub123pd vfnmsub231ps vfnmsub231pd vfnmsub321ps vfnmsub321pd vfmadd132ss vfmadd132sd vfmadd312ss vfmadd312sd vfmadd213ss vfmadd213sd vfmadd123ss vfmadd123sd vfmadd231ss vfmadd231sd vfmadd321ss vfmadd321sd vfmsub132ss vfmsub132sd vfmsub312ss vfmsub312sd vfmsub213ss vfmsub213sd vfmsub123ss vfmsub123sd vfmsub231ss vfmsub231sd vfmsub321ss vfmsub321sd vfnmadd132ss vfnmadd132sd vfnmadd312ss vfnmadd312sd vfnmadd213ss vfnmadd213sd vfnmadd123ss vfnmadd123sd vfnmadd231ss vfnmadd231sd vfnmadd321ss vfnmadd321sd vfnmsub132ss vfnmsub132sd vfnmsub312ss vfnmsub312sd vfnmsub213ss vfnmsub213sd vfnmsub123ss vfnmsub123sd vfnmsub231ss vfnmsub231sd vfnmsub321ss vfnmsub321sd rdfsbase rdgsbase rdrand wrfsbase wrgsbase vcvtph2ps vcvtps2ph adcx adox rdseed clac stac xstore xcryptecb xcryptcbc xcryptctr xcryptcfb xcryptofb montmul xsha1 xsha256 llwpcb slwpcb lwpval lwpins vfmaddpd vfmaddps vfmaddsd vfmaddss vfmaddsubpd vfmaddsubps vfmsubaddpd vfmsubaddps vfmsubpd vfmsubps vfmsubsd vfmsubss vfnmaddpd vfnmaddps vfnmaddsd vfnmaddss vfnmsubpd vfnmsubps vfnmsubsd vfnmsubss vfrczpd vfrczps vfrczsd vfrczss vpcmov vpcomb vpcomd vpcomq vpcomub vpcomud vpcomuq vpcomuw vpcomw vphaddbd vphaddbq vphaddbw vphadddq vphaddubd vphaddubq vphaddubw vphaddudq vphadduwd vphadduwq vphaddwd vphaddwq vphsubbw vphsubdq vphsubwd vpmacsdd vpmacsdqh vpmacsdql vpmacssdd vpmacssdqh vpmacssdql vpmacsswd vpmacssww vpmacswd vpmacsww vpmadcsswd vpmadcswd vpperm vprotb vprotd vprotq vprotw vpshab vpshad vpshaq vpshaw vpshlb vpshld vpshlq vpshlw vbroadcasti128 vpblendd vpbroadcastb vpbroadcastw vpbroadcastd vpbroadcastq vpermd vpermpd vpermps vpermq vperm2i128 vextracti128 vinserti128 vpmaskmovd vpmaskmovq vpsllvd vpsllvq vpsravd vpsrlvd vpsrlvq vgatherdpd vgatherqpd vgatherdps vgatherqps vpgatherdd vpgatherqd vpgatherdq vpgatherqq xabort xbegin xend xtest andn bextr blci blcic blsi blsic blcfill blsfill blcmsk blsmsk blsr blcs bzhi mulx pdep pext rorx sarx shlx shrx tzcnt tzmsk t1mskc valignd valignq vblendmpd vblendmps vbroadcastf32x4 vbroadcastf64x4 vbroadcasti32x4 vbroadcasti64x4 vcompresspd vcompressps vcvtpd2udq vcvtps2udq vcvtsd2usi vcvtss2usi vcvttpd2udq vcvttps2udq vcvttsd2usi vcvttss2usi vcvtudq2pd vcvtudq2ps vcvtusi2sd vcvtusi2ss vexpandpd vexpandps vextractf32x4 vextractf64x4 vextracti32x4 vextracti64x4 vfixupimmpd vfixupimmps vfixupimmsd vfixupimmss vgetexppd vgetexpps vgetexpsd vgetexpss vgetmantpd vgetmantps vgetmantsd vgetmantss vinsertf32x4 vinsertf64x4 vinserti32x4 vinserti64x4 vmovdqa32 vmovdqa64 vmovdqu32 vmovdqu64 vpabsq vpandd vpandnd vpandnq vpandq vpblendmd vpblendmq vpcmpltd vpcmpled vpcmpneqd vpcmpnltd vpcmpnled vpcmpd vpcmpltq vpcmpleq vpcmpneqq vpcmpnltq vpcmpnleq vpcmpq vpcmpequd vpcmpltud vpcmpleud vpcmpnequd vpcmpnltud vpcmpnleud vpcmpud vpcmpequq vpcmpltuq vpcmpleuq vpcmpnequq vpcmpnltuq vpcmpnleuq vpcmpuq vpcompressd vpcompressq vpermi2d vpermi2pd vpermi2ps vpermi2q vpermt2d vpermt2pd vpermt2ps vpermt2q vpexpandd vpexpandq vpmaxsq vpmaxuq vpminsq vpminuq vpmovdb vpmovdw vpmovqb vpmovqd vpmovqw vpmovsdb vpmovsdw vpmovsqb vpmovsqd vpmovsqw vpmovusdb vpmovusdw vpmovusqb vpmovusqd vpmovusqw vpord vporq vprold vprolq vprolvd vprolvq vprord vprorq vprorvd vprorvq vpscatterdd vpscatterdq vpscatterqd vpscatterqq vpsraq vpsravq vpternlogd vpternlogq vptestmd vptestmq vptestnmd vptestnmq vpxord vpxorq vrcp14pd vrcp14ps vrcp14sd vrcp14ss vrndscalepd vrndscaleps vrndscalesd vrndscaless vrsqrt14pd vrsqrt14ps vrsqrt14sd vrsqrt14ss vscalefpd vscalefps vscalefsd vscalefss vscatterdpd vscatterdps vscatterqpd vscatterqps vshuff32x4 vshuff64x2 vshufi32x4 vshufi64x2 kandnw kandw kmovw knotw kortestw korw kshiftlw kshiftrw kunpckbw kxnorw kxorw vpbroadcastmb2q vpbroadcastmw2d vpconflictd vpconflictq vplzcntd vplzcntq vexp2pd vexp2ps vrcp28pd vrcp28ps vrcp28sd vrcp28ss vrsqrt28pd vrsqrt28ps vrsqrt28sd vrsqrt28ss vgatherpf0dpd vgatherpf0dps vgatherpf0qpd vgatherpf0qps vgatherpf1dpd vgatherpf1dps vgatherpf1qpd vgatherpf1qps vscatterpf0dpd vscatterpf0dps vscatterpf0qpd vscatterpf0qps vscatterpf1dpd vscatterpf1dps vscatterpf1qpd vscatterpf1qps prefetchwt1 bndmk bndcl bndcu bndcn bndmov bndldx bndstx sha1rnds4 sha1nexte sha1msg1 sha1msg2 sha256rnds2 sha256msg1 sha256msg2 hint_nop0 hint_nop1 hint_nop2 hint_nop3 hint_nop4 hint_nop5 hint_nop6 hint_nop7 hint_nop8 hint_nop9 hint_nop10 hint_nop11 hint_nop12 hint_nop13 hint_nop14 hint_nop15 hint_nop16 hint_nop17 hint_nop18 hint_nop19 hint_nop20 hint_nop21 hint_nop22 hint_nop23 hint_nop24 hint_nop25 hint_nop26 hint_nop27 hint_nop28 hint_nop29 hint_nop30 hint_nop31 hint_nop32 hint_nop33 hint_nop34 hint_nop35 hint_nop36 hint_nop37 hint_nop38 hint_nop39 hint_nop40 hint_nop41 hint_nop42 hint_nop43 hint_nop44 hint_nop45 hint_nop46 hint_nop47 hint_nop48 hint_nop49 hint_nop50 hint_nop51 hint_nop52 hint_nop53 hint_nop54 hint_nop55 hint_nop56 hint_nop57 hint_nop58 hint_nop59 hint_nop60 hint_nop61 hint_nop62 hint_nop63",
           built_in:
@@ -10186,13 +5516,13 @@
           meta: "%define %xdefine %+ %undef %defstr %deftok %assign %strcat %strlen %substr %rotate %elif %else %endif %if %ifmacro %ifctx %ifidn %ifidni %ifid %ifnum %ifstr %iftoken %ifempty %ifenv %error %warning %fatal %rep %endrep %include %push %pop %repl %pathsearch %depend %use %arg %stacksize %local %line %comment %endcomment .nolist __FILE__ __LINE__ __SECT__  __BITS__ __OUTPUT_FORMAT__ __DATE__ __TIME__ __DATE_NUM__ __TIME_NUM__ __UTC_DATE__ __UTC_TIME__ __UTC_DATE_NUM__ __UTC_TIME_NUM__  __PASS__ struc endstruc istruc at iend align alignb sectalign daz nodaz up down zero default option assume public bits use16 use32 use64 default section segment absolute extern global common cpu float __utf16__ __utf16le__ __utf16be__ __utf32__ __utf32le__ __utf32be__ __float8__ __float16__ __float32__ __float64__ __float80m__ __float80e__ __float128l__ __float128h__ __Infinity__ __QNaN__ __SNaN__ Inf NaN QNaN SNaN float8 float16 float32 float64 float80m float80e float128l float128h __FLOAT_DAZ__ __FLOAT_ROUND__ __FLOAT__",
         },
         contains: [
-          e.COMMENT(";", "$", { relevance: 0 }),
+          s.COMMENT(";", "$", { relevance: 0 }),
           {
             className: "number",
             variants: [
               {
                 begin:
-                  "\\b(?:([0-9][0-9_]*)?\\.[0-9_]*(?:[eE][+-]?[0-9_]+)?|(0[Xx])?[0-9][0-9_]*(\\.[0-9_]*)?(?:[pP](?:[+-]?[0-9_]+)?)?)\\b",
+                  "\\b(?:([0-9][0-9_]*)?\\.[0-9_]*(?:[eE][+-]?[0-9_]+)?|(0[Xx])?[0-9][0-9_]*\\.?[0-9_]*(?:[pP](?:[+-]?[0-9_]+)?)?)\\b",
                 relevance: 0,
               },
               { begin: "\\$[0-9][0-9A-Fa-f]*", relevance: 0 },
@@ -10206,7 +5536,7 @@
               },
             ],
           },
-          e.QUOTE_STRING_MODE,
+          s.QUOTE_STRING_MODE,
           {
             className: "string",
             variants: [
@@ -10218,295 +5548,91 @@
           {
             className: "symbol",
             variants: [
-              {
-                begin: "^\\s*[A-Za-z._?][A-Za-z0-9_$#@~.?]*(:|\\s+label)",
-              },
-              {
-                begin: "^\\s*%%[A-Za-z0-9_$#@~.?]*:",
-              },
+              { begin: "^\\s*[A-Za-z._?][A-Za-z0-9_$#@~.?]*(:|\\s+label)" },
+              { begin: "^\\s*%%[A-Za-z0-9_$#@~.?]*:" },
             ],
             relevance: 0,
           },
           { className: "subst", begin: "%[0-9]+", relevance: 0 },
           { className: "subst", begin: "%!S+", relevance: 0 },
+          { className: "meta", begin: /^\s*\.[\w_-]+/ },
+        ],
+      };
+    };
+  })()
+);
+hljs.registerLanguage(
+  "cairo",
+  (function () {
+    "use strict";
+    return function (e) {
+      var n = "([ui](8|16|32|64|128|size)|f(32|64))?",
+        t =
+          "Copy Send Serde Sized Sync Drop Fn FnMut FnOnce ToOwned Clone Debug PartialEq PartialOrd Eq Ord AsRef AsMut Into From Default Iterator Extend IntoIterator DoubleEndedIterator ExactSizeIterator SliceConcatExt ToString assert! assert_eq! assert_ne! assert_lt! assert_le! assert_gt! assert_ge! format! write! writeln! get_dep_component! get_dep_component_mut! component! consteval_int! array! panic! print! println!";
+      return {
+        name: "Cairo",
+        aliases: ["cairo"],
+        keywords: {
+          $pattern: e.IDENT_RE + "!?",
+          keyword:
+            "as break const continue else enum extern false fn if impl implicits let loop match mod mut nopanic of pub ref return self struct super trait true type use while",
+          literal: "true false",
+          built_in: t,
+        },
+        illegal: "</",
+        contains: [
+          e.C_LINE_COMMENT_MODE,
+          e.COMMENT("/\\*", "\\*/", { contains: ["self"] }),
+          e.inherit(e.QUOTE_STRING_MODE, { begin: /b?"/, illegal: null }),
+          {
+            className: "string",
+            variants: [
+              { begin: /r(#*)"(.|\n)*?"\1(?!#)/ },
+              { begin: /b?'\\?(x\w{2}|u\w{4}|U\w{8}|.)'/ },
+            ],
+          },
+          { className: "symbol", begin: /'[a-zA-Z_][a-zA-Z0-9_]*/ },
+          {
+            className: "number",
+            variants: [
+              { begin: "\\b0b([01_]+)" + n },
+              { begin: "\\b0o([0-7_]+)" + n },
+              { begin: "\\b0x([A-Fa-f0-9_]+)" + n },
+              { begin: "\\b(\\d[\\d_]*(\\.[0-9_]+)?([eE][+-]?[0-9_]+)?)" + n },
+            ],
+            relevance: 0,
+          },
+          {
+            className: "function",
+            beginKeywords: "fn",
+            end: "(\\(|<)",
+            excludeEnd: !0,
+            contains: [e.UNDERSCORE_TITLE_MODE],
+          },
           {
             className: "meta",
-            begin: /^\s*\.[\w_-]+/,
-          },
-        ],
-      }),
-      grmr_xml: (e) => {
-        const n = e.regex,
-          t = n.concat(
-            /[\p{L}_]/u,
-            n.optional(/[\p{L}0-9_.-]*:/u),
-            /[\p{L}0-9_.-]*/u
-          ),
-          s = {
-            className: "symbol",
-            begin: /&[a-z]+;|&#[0-9]+;|&#x[a-f0-9]+;/,
-          },
-          a = {
-            begin: /\s/,
-            contains: [
-              {
-                className: "keyword",
-                begin: /#?[a-z_][a-z1-9_-]+/,
-                illegal: /\n/,
-              },
-            ],
-          },
-          i = e.inherit(a, { begin: /\(/, end: /\)/ }),
-          r = e.inherit(e.APOS_STRING_MODE, {
-            className: "string",
-          }),
-          o = e.inherit(e.QUOTE_STRING_MODE, { className: "string" }),
-          c = {
-            endsWithParent: !0,
-            illegal: /</,
-            relevance: 0,
-            contains: [
-              { className: "attr", begin: /[\p{L}0-9._:-]+/u, relevance: 0 },
-              {
-                begin: /=\s*/,
-                relevance: 0,
-                contains: [
-                  {
-                    className: "string",
-                    endsParent: !0,
-                    variants: [
-                      { begin: /"/, end: /"/, contains: [s] },
-                      {
-                        begin: /'/,
-                        end: /'/,
-                        contains: [s],
-                      },
-                      { begin: /[^\s"'=<>`]+/ },
-                    ],
-                  },
-                ],
-              },
-            ],
-          };
-        return {
-          name: "HTML, XML",
-          aliases: [
-            "html",
-            "xhtml",
-            "rss",
-            "atom",
-            "xjb",
-            "xsd",
-            "xsl",
-            "plist",
-            "wsf",
-            "svg",
-          ],
-          case_insensitive: !0,
-          unicodeRegex: !0,
-          contains: [
-            {
-              className: "meta",
-              begin: /<![a-z]/,
-              end: />/,
-              relevance: 10,
-              contains: [
-                a,
-                o,
-                r,
-                i,
-                {
-                  begin: /\[/,
-                  end: /\]/,
-                  contains: [
-                    {
-                      className: "meta",
-                      begin: /<![a-z]/,
-                      end: />/,
-                      contains: [a, i, o, r],
-                    },
-                  ],
-                },
-              ],
-            },
-            e.COMMENT(/<!--/, /-->/, { relevance: 10 }),
-            { begin: /<!\[CDATA\[/, end: /\]\]>/, relevance: 10 },
-            s,
-            {
-              className: "meta",
-              end: /\?>/,
-              variants: [
-                { begin: /<\?xml/, relevance: 10, contains: [o] },
-                { begin: /<\?[a-z][a-z0-9]+/ },
-              ],
-            },
-            {
-              className: "tag",
-              begin: /<style(?=\s|>)/,
-              end: />/,
-              keywords: { name: "style" },
-              contains: [c],
-              starts: {
-                end: /<\/style>/,
-                returnEnd: !0,
-                subLanguage: ["css", "xml"],
-              },
-            },
-            {
-              className: "tag",
-              begin: /<script(?=\s|>)/,
-              end: />/,
-              keywords: { name: "script" },
-              contains: [c],
-              starts: {
-                end: /<\/script>/,
-                returnEnd: !0,
-                subLanguage: ["javascript", "handlebars", "xml"],
-              },
-            },
-            {
-              className: "tag",
-              begin: /<>|<\/>/,
-            },
-            {
-              className: "tag",
-              begin: n.concat(
-                /</,
-                n.lookahead(n.concat(t, n.either(/\/>/, />/, /\s/)))
-              ),
-              end: /\/?>/,
-              contains: [
-                { className: "name", begin: t, relevance: 0, starts: c },
-              ],
-            },
-            {
-              className: "tag",
-              begin: n.concat(/<\//, n.lookahead(n.concat(t, />/))),
-              contains: [
-                {
-                  className: "name",
-                  begin: t,
-                  relevance: 0,
-                },
-                { begin: />/, relevance: 0, endsParent: !0 },
-              ],
-            },
-          ],
-        };
-      },
-      grmr_yaml: (e) => {
-        const n = "true false yes no null",
-          t = "[\\w#;/?:@&=+$,.~*'()[\\]]+",
-          s = {
-            className: "string",
-            relevance: 0,
-            variants: [
-              { begin: /'/, end: /'/ },
-              { begin: /"/, end: /"/ },
-              { begin: /\S+/ },
-            ],
-            contains: [
-              e.BACKSLASH_ESCAPE,
-              {
-                className: "template-variable",
-                variants: [
-                  { begin: /\{\{/, end: /\}\}/ },
-                  { begin: /%\{/, end: /\}/ },
-                ],
-              },
-            ],
-          },
-          a = e.inherit(s, {
-            variants: [
-              { begin: /'/, end: /'/ },
-              { begin: /"/, end: /"/ },
-              { begin: /[^\s,{}[\]]+/ },
-            ],
-          }),
-          i = {
-            end: ",",
-            endsWithParent: !0,
-            excludeEnd: !0,
-            keywords: n,
-            relevance: 0,
-          },
-          r = {
-            begin: /\{/,
-            end: /\}/,
-            contains: [i],
-            illegal: "\\n",
-            relevance: 0,
-          },
-          o = {
-            begin: "\\[",
+            begin: "#\\!?\\[",
             end: "\\]",
-            contains: [i],
-            illegal: "\\n",
-            relevance: 0,
+            contains: [{ className: "meta-string", begin: /"/, end: /"/ }],
           },
-          c = [
-            {
-              className: "attr",
-              variants: [
-                {
-                  begin: /\w[\w :()\./-]*:(?=[ \t]|$)/,
-                },
-                { begin: /"\w[\w :()\./-]*":(?=[ \t]|$)/ },
-                {
-                  begin: /'\w[\w :()\./-]*':(?=[ \t]|$)/,
-                },
-              ],
-            },
-            { className: "meta", begin: "^---\\s*$", relevance: 10 },
-            {
-              className: "string",
-              begin:
-                "[\\|>]([1-9]?[+-])?[ ]*\\n( +)[^ ][^\\n]*\\n(\\2[^\\n]+\\n?)*",
-            },
-            {
-              begin: "<%[%=-]?",
-              end: "[%-]?%>",
-              subLanguage: "ruby",
-              excludeBegin: !0,
-              excludeEnd: !0,
-              relevance: 0,
-            },
-            { className: "type", begin: "!\\w+!" + t },
-            { className: "type", begin: "!<" + t + ">" },
-            { className: "type", begin: "!" + t },
-            { className: "type", begin: "!!" + t },
-            { className: "meta", begin: "&" + e.UNDERSCORE_IDENT_RE + "$" },
-            { className: "meta", begin: "\\*" + e.UNDERSCORE_IDENT_RE + "$" },
-            { className: "bullet", begin: "-(?=[ ]|$)", relevance: 0 },
-            e.HASH_COMMENT_MODE,
-            { beginKeywords: n, keywords: { literal: n } },
-            {
-              className: "number",
-              begin:
-                "\\b[0-9]{4}(-[0-9][0-9]){0,2}([Tt \\t][0-9][0-9]?(:[0-9][0-9]){2})?(\\.[0-9]*)?([ \\t])*(Z|[-+][0-9][0-9]?(:[0-9][0-9])?)?\\b",
-            },
-            { className: "number", begin: e.C_NUMBER_RE + "\\b", relevance: 0 },
-            r,
-            o,
-            s,
-          ],
-          l = [...c];
-        return (
-          l.pop(),
-          l.push(a),
-          (i.contains = l),
-          { name: "YAML", case_insensitive: !0, aliases: ["yml"], contains: c }
-        );
-      },
-    });
-    const je = te;
-    for (const e of Object.keys(Pe)) {
-      const n = e.replace("grmr_", "").replace("_", "-");
-      je.registerLanguage(n, Pe[e]);
-    }
-    return je;
-  })();
-  "object" == typeof exports &&
-    "undefined" != typeof module &&
-    (module.exports = hljs);
-  
+          {
+            className: "class",
+            beginKeywords: "type",
+            end: ";",
+            contains: [e.inherit(e.UNDERSCORE_TITLE_MODE, { endsParent: !0 })],
+            illegal: "\\S",
+          },
+          {
+            className: "class",
+            beginKeywords: "trait enum struct union",
+            end: "{",
+            contains: [e.inherit(e.UNDERSCORE_TITLE_MODE, { endsParent: !0 })],
+            illegal: "[\\w\\d]",
+          },
+          { begin: e.IDENT_RE + "::", keywords: { built_in: t } },
+          { begin: "->" },
+        ],
+      };
+    };
+  })()
+);


### PR DESCRIPTION
fix #1565 

## Why?
mdBook during the parsing, put's all the hidden lines (beggining with `#`) inside the `span` tag with `className="boring"`.
mdBook generated css files sets all the files with `boring` className to be `display: none`. Unfortunately, new version of `highlight.js` wipes all those mdBook spans during the highlighting process.

This version of `highlight.js` is based directly upon the mdBook `highlight.js`, so hidden lines work as intended inside rust codes examples.