### PR TITLE
Feat: Support --print-detailed-resources parameter in cairo-run

### DIFF
--- a/extensions/scarb-cairo-run/src/main.rs
+++ b/extensions/scarb-cairo-run/src/main.rs
@@ -233,7 +233,7 @@ struct Summary {
     result: RunResultStarknet,
     print_full_memory: bool,
     gas_defined: bool,
-    detailed_resources: bool
+    detailed_resources: bool,
 }
 
 impl Message for Summary {
@@ -301,9 +301,9 @@ impl Message for Summary {
 }
 
 fn sort_by_value<'a, K, V, M>(map: M) -> Vec<(&'a K, &'a V)>
-    where
-        M: IntoIterator<Item = (&'a K, &'a V)>,
-        V: Ord,
+where
+    M: IntoIterator<Item = (&'a K, &'a V)>,
+    V: Ord,
 {
     let mut sorted: Vec<_> = map.into_iter().collect();
     sorted.sort_by(|a, b| b.1.cmp(a.1));
@@ -311,9 +311,9 @@ fn sort_by_value<'a, K, V, M>(map: M) -> Vec<(&'a K, &'a V)>
 }
 
 fn format_items<K, V>(items: &[(K, V)]) -> String
-    where
-        K: std::fmt::Debug,
-        V: std::fmt::Display,
+where
+    K: std::fmt::Debug,
+    V: std::fmt::Display,
 {
     items
         .iter()

--- a/extensions/scarb-cairo-run/src/main.rs
+++ b/extensions/scarb-cairo-run/src/main.rs
@@ -43,6 +43,10 @@ struct Args {
     #[arg(long, default_value_t = false)]
     print_full_memory: bool,
 
+    /// Print detailed resources.
+    #[arg(long, default_value_t = false)]
+    print_detailed_resources: bool,
+
     /// Do not rebuild the package.
     #[arg(long, default_value_t = false)]
     no_build: bool,
@@ -150,6 +154,7 @@ fn main_inner(ui: &Ui, args: Args) -> Result<()> {
         result,
         print_full_memory: args.print_full_memory,
         gas_defined: available_gas.is_defined(),
+        detailed_resources: args.print_detailed_resources,
     });
 
     Ok(())
@@ -228,6 +233,7 @@ struct Summary {
     result: RunResultStarknet,
     print_full_memory: bool,
     gas_defined: bool,
+    detailed_resources: bool
 }
 
 impl Message for Summary {
@@ -272,6 +278,18 @@ impl Message for Summary {
             }
             println!("]");
         }
+
+        if self.detailed_resources {
+            let resources = self.result.used_resources.basic_resources;
+            let sorted_builtins = sort_by_value(&resources.builtin_instance_counter);
+            let sorted_syscalls = sort_by_value(&self.result.used_resources.syscalls);
+
+            println!("Resources:");
+            println!("\tsteps: {}", resources.n_steps);
+            println!("\tmemory holes: {}", resources.n_memory_holes);
+            println!("\tbuiltins: ({})", format_items(&sorted_builtins));
+            println!("\tsyscalls: ({})", format_items(&sorted_syscalls));
+        }
     }
 
     fn structured<S: Serializer>(self, _ser: S) -> Result<S::Ok, S::Error>
@@ -280,6 +298,28 @@ impl Message for Summary {
     {
         todo!("JSON output is not implemented yet for this command")
     }
+}
+
+fn sort_by_value<'a, K, V, M>(map: M) -> Vec<(&'a K, &'a V)>
+    where
+        M: IntoIterator<Item = (&'a K, &'a V)>,
+        V: Ord,
+{
+    let mut sorted: Vec<_> = map.into_iter().collect();
+    sorted.sort_by(|a, b| b.1.cmp(a.1));
+    sorted
+}
+
+fn format_items<K, V>(items: &[(K, V)]) -> String
+    where
+        K: std::fmt::Debug,
+        V: std::fmt::Display,
+{
+    items
+        .iter()
+        .map(|(key, value)| format!("{key:?}: {value}"))
+        .collect::<Vec<String>>()
+        .join(", ")
 }
 
 enum GasLimit {

--- a/extensions/scarb-cairo-run/src/main.rs
+++ b/extensions/scarb-cairo-run/src/main.rs
@@ -45,7 +45,7 @@ struct Args {
 
     /// Print detailed resources.
     #[arg(long, default_value_t = false)]
-    print_detailed_resources: bool,
+    print_resource_usage: bool,
 
     /// Do not rebuild the package.
     #[arg(long, default_value_t = false)]
@@ -154,7 +154,7 @@ fn main_inner(ui: &Ui, args: Args) -> Result<()> {
         result,
         print_full_memory: args.print_full_memory,
         gas_defined: available_gas.is_defined(),
-        detailed_resources: args.print_detailed_resources,
+        detailed_resources: args.print_resource_usage,
     });
 
     Ok(())


### PR DESCRIPTION
This PR introduces an optional CLI parameter --print-detailed-resources for scarb cairo-run extension that prints detailed used resources report:
![image](https://github.com/user-attachments/assets/2378ae24-b5be-4461-a21c-7f731e05c738)
