### PR TITLE
`cairo-lang-macro` fix null-byte panics

### DIFF
--- a/plugins/cairo-lang-macro/src/types/conversion.rs
+++ b/plugins/cairo-lang-macro/src/types/conversion.rs
@@ -95,7 +95,9 @@ impl TokenStream {
     ///
     /// # Safety
     #[doc(hidden)]
-    pub fn into_stable(self) -> StableTokenStream {
+    pub fn into_stable(mut self) -> StableTokenStream {
+        // Remove 0 bytes so conversion will always work.
+        self.value.retain(|c| c != '\0');
         let cstr = CString::new(self.value).unwrap();
         StableTokenStream {
             value: cstr.into_raw(),


### PR DESCRIPTION
**Stack**:
- #1686
- #1685
- #1684
- #1683
- #1682
- #1681
- #1680
- #1679
- #1715
- #1716 ⬅
- #1676


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*