### PR TITLE
Make TextSpan u32 to match the compiler one

### DIFF
--- a/plugins/cairo-lang-macro-stable/src/lib.rs
+++ b/plugins/cairo-lang-macro-stable/src/lib.rs
@@ -16,8 +16,8 @@ pub struct StableToken {
 #[repr(C)]
 #[derive(Debug)]
 pub struct StableTextSpan {
-    pub start: usize,
-    pub end: usize,
+    pub start: u32,
+    pub end: u32,
 }
 
 #[repr(C)]

--- a/plugins/cairo-lang-macro/src/types/conversion.rs
+++ b/plugins/cairo-lang-macro/src/types/conversion.rs
@@ -88,8 +88,8 @@ impl TextSpan {
     #[doc(hidden)]
     pub fn into_stable(self) -> StableTextSpan {
         StableTextSpan {
-            start: self.start,
-            end: self.end,
+            start: self.start.as_u32(),
+            end: self.end.as_u32(),
         }
     }
 
@@ -97,8 +97,8 @@ impl TextSpan {
     #[doc(hidden)]
     pub fn from_stable(span: &StableTextSpan) -> Self {
         Self {
-            start: span.start,
-            end: span.end,
+            start: span.start.into(),
+            end: span.end.into(),
         }
     }
 

--- a/plugins/cairo-lang-macro/src/types/token.rs
+++ b/plugins/cairo-lang-macro/src/types/token.rs
@@ -95,12 +95,32 @@ impl TokenTree {
     }
 }
 
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct TextOffset(u32);
+
+impl TextOffset {
+    pub fn new(value: u32) -> Self {
+        Self(value)
+    }
+
+    pub(crate) fn as_u32(&self) -> u32 {
+        self.0
+    }
+}
+
+impl From<u32> for TextOffset {
+    fn from(value: u32) -> Self {
+        Self::new(value)
+    }
+}
+
 /// A range of text offsets that form a span (like text selection).
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TextSpan {
-    pub start: usize,
-    pub end: usize,
+    pub start: TextOffset,
+    pub end: TextOffset,
 }
 
 /// A single Cairo token.
@@ -302,7 +322,7 @@ impl TokenTree {
 
 impl TextSpan {
     /// Create a new [`TextSpan`].
-    pub fn new(start: usize, end: usize) -> TextSpan {
+    pub fn new(start: TextOffset, end: TextOffset) -> TextSpan {
         TextSpan { start, end }
     }
 }


### PR DESCRIPTION
**Stack**:
- #1746 ⬅
- #1745
- #1734
- #1722


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*