### PR TITLE
Use less partitions in Scarb CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           path: nextest-archive-${{ matrix.platform.os }}.tar.zst
 
   test:
-    name: test ${{ matrix.platform.name }} ${{ matrix.partition }}/8
+    name: test ${{ matrix.platform.name }} ${{ matrix.partition }}/4
     runs-on: ${{ matrix.platform.os }}
     needs:
       - build-test
@@ -44,7 +44,7 @@ jobs:
             os: ubuntu-latest
           - name: windows x86-64
             os: windows-latest
-        partition: [ 1, 2, 3, 4, 5, 6, 7, 8 ]
+        partition: [ 1, 2, 3, 4 ]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -52,8 +52,8 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: nextest-archive-${{ matrix.platform.os }}
-      - name: nextest partition ${{ matrix.partition }}/8
-        run: cargo nextest run --partition 'count:${{ matrix.partition }}/8' --archive-file 'nextest-archive-${{ matrix.platform.os }}.tar.zst'
+      - name: nextest partition ${{ matrix.partition }}/4
+        run: cargo nextest run --partition 'count:${{ matrix.partition }}/4' --archive-file 'nextest-archive-${{ matrix.platform.os }}.tar.zst'
 
   test-doc:
     name: doc tests


### PR DESCRIPTION
Spend more time in a single runner, but less time waiting for runners. 

With only 20 runners available in the org, few open Scarb PRs will quickly use all of them. While a single jobs will finish quickly, jobs from multiple PRs will start taking runners simultaneously, causing them to spend a lot of time waiting for available runners, while each PR has few jobs finished and few not yet started. 