### PR TITLE
Pubgrub lockfile lookup fix

### DIFF
--- a/scarb/src/resolver/algorithm/provider.rs
+++ b/scarb/src/resolver/algorithm/provider.rs
@@ -179,19 +179,20 @@ impl PubGrubDependencyProvider {
     }
 
     fn request_dependencies(&self, summary: &Summary) -> Result<(), DependencyProviderError> {
-        for dependency in summary.dependencies.iter() {
-            let dep = lock_dependency(&self.lockfile, dependency.clone())?;
-            if self.state.index.packages().register(dep.clone()) {
+        for original_dependency in summary.dependencies.iter() {
+            let dependency = lock_dependency(&self.lockfile, original_dependency.clone())?;
+            if self.state.index.packages().register(dependency.clone()) {
                 self.request_sink
-                    .blocking_send(Request::Package(dep))
+                    .blocking_send(Request::Package(dependency))
                     .unwrap();
             }
 
-            let dep = rewrite_path_dependency_source_id(summary.package_id, dependency);
-            let dep = lock_dependency(&self.lockfile, dep)?;
-            if self.state.index.packages().register(dep.clone()) {
+            let dependency =
+                rewrite_path_dependency_source_id(summary.package_id, original_dependency);
+            let dependency = lock_dependency(&self.lockfile, dependency)?;
+            if self.state.index.packages().register(dependency.clone()) {
                 self.request_sink
-                    .blocking_send(Request::Package(dep))
+                    .blocking_send(Request::Package(dependency))
                     .unwrap();
             }
         }

--- a/scarb/src/resolver/mod.rs
+++ b/scarb/src/resolver/mod.rs
@@ -324,8 +324,8 @@ mod tests {
             &[deps![("top1", "1"), ("top2", "1")]],
             Err(indoc! {"
                 version solving failed:
-                Because there is no version of top1 in >1.0.0, <2.0.0 and top1 1.0.0 depends on foo >=1.0.0, <2.0.0, top1 >=1.0.0, <2.0.0 depends on foo >=1.0.0, <2.0.0.
-                And because top2 1.0.0 depends on foo >=2.0.0, <3.0.0 and there is no version of top2 in >1.0.0, <2.0.0, top1 >=1.0.0, <2.0.0, top2 >=1.0.0, <2.0.0 are incompatible.
+                Because there is no version of top2 in >1.0.0, <2.0.0 and top2 1.0.0 depends on foo >=2.0.0, <3.0.0, top2 >=1.0.0, <2.0.0 depends on foo >=2.0.0, <3.0.0.
+                And because top1 1.0.0 depends on foo >=1.0.0, <2.0.0 and there is no version of top1 in >1.0.0, <2.0.0, top1 >=1.0.0, <2.0.0, top2 >=1.0.0, <2.0.0 are incompatible.
                 And because root_1 1.0.0 depends on top1 >=1.0.0, <2.0.0 and root_1 1.0.0 depends on top2 >=1.0.0, <2.0.0, root_1 1.0.0 is forbidden.
             "}),
         )
@@ -789,8 +789,8 @@ mod tests {
             Err(indoc! {"
                 found dependencies on the same package `baz` coming from \
                 incompatible sources:
-                source 1: git+https://example.com/foo.git
-                source 2: git+https://example.com/bar.git
+                source 1: git+https://example.com/bar.git
+                source 2: git+https://example.com/foo.git
             "}),
         )
     }

--- a/scarb/src/resolver/mod.rs
+++ b/scarb/src/resolver/mod.rs
@@ -38,8 +38,7 @@ pub async fn resolve(
             let s = var.as_str();
             s == "true" || s == "1"
         })
-        // Defaults to primitive!
-        .unwrap_or(true);
+        .unwrap_or(false);
     if algo_primitive {
         primitive::resolve(summaries, registry, lockfile).await
     } else {
@@ -253,7 +252,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "TODO(#1883): Unignore after fixing pubgrub and changing default registry."]
     fn backtrack_1() {
         check(
             registry![
@@ -270,7 +268,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "TODO(#1883): Unignore after fixing pubgrub and changing default registry."]
     fn backtrack_2() {
         check(
             registry![
@@ -316,7 +313,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "TODO(#1883): Unignore after fixing pubgrub and changing default registry."]
     fn sub_dependencies() {
         check(
             registry![
@@ -345,7 +341,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "TODO(#1883): Unignore after fixing pubgrub and changing default registry."]
     fn unsatisfied_version_constraint() {
         check(
             registry![("foo v2.0.0", []),],
@@ -364,7 +359,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "TODO(#1883): Unignore after fixing pubgrub and changing default registry."]
     fn no_matching_transient_dependency_1() {
         check(
             registry![
@@ -381,7 +375,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "TODO(#1883): Unignore after fixing pubgrub and changing default registry."]
     fn no_matching_transient_dependency_2() {
         check(
             registry![
@@ -402,7 +395,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "TODO(#1883): Unignore after fixing pubgrub and changing default registry."]
     fn no_matching_transient_dependency_3() {
         check(
             registry![
@@ -517,7 +509,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "TODO(#1883): Unignore after fixing pubgrub and changing default registry."]
     fn lock_conflict_1() {
         check_with_lock(
             registry![("foo v1.0.0", []),],

--- a/scarb/tests/add.rs
+++ b/scarb/tests/add.rs
@@ -199,7 +199,6 @@ fn path_version() {
 }
 
 #[test]
-#[ignore = "TODO(#1883): Unignore after fixing pubgrub and changing default registry."]
 fn runs_resolver_if_network_is_allowed() {
     let t = TempDir::new().unwrap();
 

--- a/scarb/tests/git_source.rs
+++ b/scarb/tests/git_source.rs
@@ -465,6 +465,7 @@ fn transitive_path_dep() {
 
 #[test]
 fn transitive_path_dep_with_lock() {
+    let cache_dir = TempDir::new().unwrap().child("c");
     let git_dep = gitx::new("dep1", |t| {
         ProjectBuilder::start()
             .name("dep0")
@@ -490,16 +491,22 @@ fn transitive_path_dep_with_lock() {
         .build(&t);
 
     Scarb::quick_snapbox()
+        .env("SCARB_CACHE", cache_dir.path())
         .arg("fetch")
         .current_dir(&t)
         .assert()
-        .success();
+        .success()
+        .stdout_matches(indoc! {r#"
+        [..]Updating git repository [..]dep1
+        "#});
 
     Scarb::quick_snapbox()
+        .env("SCARB_CACHE", cache_dir.path())
         .arg("fetch")
         .current_dir(&t)
         .assert()
-        .success();
+        .success()
+        .stdout_eq("");
 }
 
 #[test]

--- a/scarb/tests/git_source_network.rs
+++ b/scarb/tests/git_source_network.rs
@@ -9,7 +9,6 @@ use scarb_test_support::command::Scarb;
 use scarb_test_support::project_builder::{Dep, DepBuilder, ProjectBuilder};
 
 #[test]
-#[ignore = "TODO(#1883): Unignore after fixing pubgrub and changing default registry."]
 fn https_something_happens() {
     thread::scope(|ts| {
         let server = TcpListener::bind("127.0.0.1:0").unwrap();
@@ -49,7 +48,6 @@ fn https_something_happens() {
 }
 
 #[test]
-#[ignore = "TODO(#1883): Unignore after fixing pubgrub and changing default registry."]
 fn ssh_something_happens() {
     thread::scope(|ts| {
         let server = TcpListener::bind("127.0.0.1:0").unwrap();

--- a/scarb/tests/http_registry.rs
+++ b/scarb/tests/http_registry.rs
@@ -71,6 +71,19 @@ fn usage() {
 
         ###
 
+        GET /index/3/b/bar.json
+        accept: */*
+        accept-encoding: gzip, br, deflate
+        host: ...
+        if-none-match: ...
+        user-agent: ...
+
+        304 Not Modified
+        content-length: 0
+        etag: ...
+
+        ###
+
         GET /bar-1.0.0.tar.zst
         accept: */*
         accept-encoding: gzip, br, deflate
@@ -148,6 +161,19 @@ fn publish_verified() {
 
         ###
 
+        GET /index/3/b/bar.json
+        accept: */*
+        accept-encoding: gzip, br, deflate
+        host: ...
+        if-none-match: ...
+        user-agent: ...
+
+        304 Not Modified
+        content-length: 0
+        etag: ...
+
+        ###
+
         GET /bar-1.0.0.tar.zst
         accept: */*
         accept-encoding: gzip, br, deflate
@@ -165,7 +191,6 @@ fn publish_verified() {
 }
 
 #[test]
-#[ignore = "TODO(#1883): Unignore after fixing pubgrub and changing default registry."]
 fn not_found() {
     let mut registry = HttpRegistry::serve(None);
     registry.publish(|t| {
@@ -229,7 +254,6 @@ fn not_found() {
 }
 
 #[test]
-#[ignore = "TODO(#1883): Unignore after fixing pubgrub and changing default registry."]
 fn missing_config_json() {
     let registry = HttpRegistry::serve(None);
     fs::remove_file(registry.child("api/v1/index/config.json")).unwrap();
@@ -353,6 +377,19 @@ fn caching() {
 
         ###
 
+        GET /index/3/b/bar.json
+        accept: */*
+        accept-encoding: gzip, br, deflate
+        host: ...
+        if-none-match: ...
+        user-agent: ...
+
+        304 Not Modified
+        content-length: 0
+        etag: ...
+
+        ###
+
         GET /bar-1.0.0.tar.zst
         accept: */*
         accept-encoding: gzip, br, deflate
@@ -365,6 +402,32 @@ fn caching() {
         content-type: application/octet-stream
         etag: ...
         last-modified: ...
+
+        ###
+
+        GET /index/3/b/bar.json
+        accept: */*
+        accept-encoding: gzip, br, deflate
+        host: ...
+        if-none-match: ...
+        user-agent: ...
+
+        304 Not Modified
+        content-length: 0
+        etag: ...
+
+        ###
+
+        GET /index/3/b/bar.json
+        accept: */*
+        accept-encoding: gzip, br, deflate
+        host: ...
+        if-none-match: ...
+        user-agent: ...
+
+        304 Not Modified
+        content-length: 0
+        etag: ...
 
         ###
 

--- a/scarb/tests/local_registry.rs
+++ b/scarb/tests/local_registry.rs
@@ -38,7 +38,6 @@ fn usage() {
 }
 
 #[test]
-#[ignore = "TODO(#1883): Unignore after fixing pubgrub and changing default registry."]
 fn not_found() {
     let mut registry = LocalRegistry::create();
     registry.publish(|t| {
@@ -76,7 +75,6 @@ fn not_found() {
 // TODO(mkaput): Test path dependencies overrides.
 
 #[test]
-#[ignore = "TODO(#1883): Unignore after fixing pubgrub and changing default registry."]
 fn empty_registry() {
     let registry = LocalRegistry::create();
 
@@ -102,7 +100,6 @@ fn empty_registry() {
 }
 
 #[test]
-#[ignore = "TODO(#1883): Unignore after fixing pubgrub and changing default registry."]
 fn url_pointing_to_file() {
     let registry_t = TempDir::new().unwrap();
     let registry = registry_t.child("r");


### PR DESCRIPTION
fixes #1883

When resolving package dependencies, the resolver accepts workspace lockfile (Scarb.lock) as one of the inputs. If manifest dependencies can be locked to concrete revisions defined in the lockfile (https://github.com/software-mansion/scarb/blob/52c5afe0e26c49e81b93d1b8929dc500a61495e5/scarb/src/core/lockfile.rs#L98) (i.e. unless the dependency conflicts with the locked version, for instance because the rev in dependency has been changed by the user between runs), it should be used by the resolver instead of the most recent one. 

This PR attempts to solve a bug in mechanism of applying locked revisions in the resolver. When querying the registry for dependency package summaries (https://github.com/software-mansion/scarb/blob/47c7c7d8dda31fccc4f63836027977e4ea0f28f4/scarb/src/resolver/algorithm/provider.rs#L181) we try to lock the manifest dependency to the version specified in the lockfile. You can see, that we actually request two different dependencies. If our package A depends on some package B via git dependency, but B depends on another package C via path dependency, we attempt to rewrite the dependency between B and C from path to git. This allows unification if A (or other package in the dep tree) also depends on C via git dependency. However, we cannot know for sure if this attempt will be successful, as C may be under B in the directory tree, thus being shadowed when access via git dependency (we traverse the dir tree to look for packages, but we do not enter subdirectories of any directory with Scarb.toml file). Instead, we send to request and use the rewritten git one if it succeeds, or fallback to path one if not. 

This code did not attempt to lock a transitive dependency that has been rewritten from path to git according to the lockfile, which it should.

Changes:
- **Revert "Temporarily default to primitive resolver (#1892)"**
- **Update error message**
- **Lookup dependency in lockfile after rewriting nested path to git source when requesting dependency metadata**
