### PR TITLE
Split nightly crates tests job to build and run steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,11 +89,37 @@ jobs:
       - name: run tests
         run: cargo test -p scarb-metadata
 
-  test-nightly-crates:
-    name: test nightly crates ${{ matrix.platform.name }}
+  build-nightly-test:
+    name: build nightly test ${{ matrix.platform.name }}
+    runs-on: ${{ matrix.platform.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - name: linux x86-64
+            os: ubuntu-latest
+          - name: windows x86-64
+            os: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_NIGHTLY_TOOLCHAIN }}
+      - uses: taiki-e/install-action@nextest
+      - uses: Swatinem/rust-cache@v2
+      - name: nextest archive
+        run: cargo nextest archive --all-features --cargo-profile ci --archive-file 'nextest-nightly-archive-${{ matrix.platform.os }}.tar.zst' --package scarb-prove --package scarb-verify
+      - uses: actions/upload-artifact@v4
+        with:
+          name: nextest-nightly-archive-${{ matrix.platform.os }}
+          path: nextest-nightly-archive-${{ matrix.platform.os }}.tar.zst
+
+  test-nightly:
+    name: test nightly ${{ matrix.platform.name }}
     runs-on: ${{ matrix.platform.os }}
     needs:
       - build-test
+      - build-nightly-test
     strategy:
       fail-fast: false
       matrix:
@@ -108,20 +134,34 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUST_NIGHTLY_TOOLCHAIN }}
+      - uses: taiki-e/install-action@nextest
       - uses: Swatinem/rust-cache@v2
       - uses: actions/download-artifact@v4
         with:
           name: nextest-archive-${{ matrix.platform.os }}
-      - name: Unpack build stable rust artifacts on ubuntu
+      - name: Unpack build stable rust artifacts from nextest archive on linux
         if: matrix.platform.os == 'ubuntu-latest'
-        run: tar --use-compress-program=unzstd -xvf nextest-archive-ubuntu-latest.tar.zst
-      - name: Unpack build stable rust artifacts on windows
-        if: matrix.platform.os == 'windows-latest'
         run: |
-          zstd -d nextest-archive-windows-latest.tar.zst
-          tar -xf nextest-archive-windows-latest.tar
-      - name: Run scarb-prove and scarb-verify tests
-        run: cargo +${{ env.RUST_NIGHTLY_TOOLCHAIN }} test -p scarb-prove -p scarb-verify --profile=ci
+          tar --use-compress-program=unzstd -xvf nextest-archive-ubuntu-latest.tar.zst
+          mv target stable-crates-target
+          echo "NEXTEST_BIN_EXE_scarb=$GITHUB_WORKSPACE/stable-crates-target/ci/scarb" >> $GITHUB_ENV
+          echo "$GITHUB_WORKSPACE/stable-crates-target/ci" >> $GITHUB_PATH
+          echo "$GITHUB_WORKSPACE/target/ci" >> $GITHUB_PATH
+      # Do not run tests on windows, until stwo supports it.
+      # - name: Unpack build stable rust artifacts from nextest archive on windows
+      #   if: matrix.platform.os == 'windows-latest'
+      #   run: |
+      #     zstd -d nextest-archive-windows-latest.tar.zst
+      #     tar -xf nextest-archive-windows-latest.tar
+      #     ren target stable-crates-target
+      #     echo "NEXTEST_BIN_EXE_scarb=$env:GITHUB_WORKSPACE/stable-crates-target/ci/scarb" >> $env:GITHUB_ENV
+      #     Add-Content $env:GITHUB_PATH "$env:GITHUB_WORKSPACE/stable-crates-target/ci"
+      #     Add-Content $env:GITHUB_PATH "$env:GITHUB_WORKSPACE/target/ci"
+      - uses: actions/download-artifact@v4
+        with:
+          name: nextest-nightly-archive-${{ matrix.platform.os }}
+      - name: nextest partition
+        run: cargo nextest run --archive-file 'nextest-nightly-archive-${{ matrix.platform.os }}.tar.zst' --extract-to ./
 
   check-rust:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,8 @@ jobs:
           toolchain: ${{ env.RUST_NIGHTLY_TOOLCHAIN }}
       - uses: taiki-e/install-action@nextest
       - uses: Swatinem/rust-cache@v2
-      - uses: actions/download-artifact@v4
+      - name: Download stable build artifacts  
+         uses: actions/download-artifact@v4
         with:
           name: nextest-archive-${{ matrix.platform.os }}
       - name: Unpack build stable rust artifacts from nextest archive on linux
@@ -157,7 +158,8 @@ jobs:
       #     echo "NEXTEST_BIN_EXE_scarb=$env:GITHUB_WORKSPACE/stable-crates-target/ci/scarb" >> $env:GITHUB_ENV
       #     Add-Content $env:GITHUB_PATH "$env:GITHUB_WORKSPACE/stable-crates-target/ci"
       #     Add-Content $env:GITHUB_PATH "$env:GITHUB_WORKSPACE/target/ci"
-      - uses: actions/download-artifact@v4
+      - name: Download nightly build artifacts  
+         uses: actions/download-artifact@v4
         with:
           name: nextest-nightly-archive-${{ matrix.platform.os }}
       - name: nextest partition

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,10 +96,9 @@ jobs:
       fail-fast: false
       matrix:
         platform:
+          # TODO: Enable tests on windows when stwo supports it.
           - name: linux x86-64
             os: ubuntu-latest
-          - name: windows x86-64
-            os: windows-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -126,9 +125,6 @@ jobs:
         platform:
           - name: linux x86-64
             os: ubuntu-latest
-          # Do not run tests on windows, until stwo supports it.
-          # - name: windows x86-64
-          #  os: windows-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -137,7 +133,7 @@ jobs:
       - uses: taiki-e/install-action@nextest
       - uses: Swatinem/rust-cache@v2
       - name: Download stable build artifacts  
-         uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4
         with:
           name: nextest-archive-${{ matrix.platform.os }}
       - name: Unpack build stable rust artifacts from nextest archive on linux
@@ -148,18 +144,8 @@ jobs:
           echo "NEXTEST_BIN_EXE_scarb=$GITHUB_WORKSPACE/stable-crates-target/ci/scarb" >> $GITHUB_ENV
           echo "$GITHUB_WORKSPACE/stable-crates-target/ci" >> $GITHUB_PATH
           echo "$GITHUB_WORKSPACE/target/ci" >> $GITHUB_PATH
-      # Do not run tests on windows, until stwo supports it.
-      # - name: Unpack build stable rust artifacts from nextest archive on windows
-      #   if: matrix.platform.os == 'windows-latest'
-      #   run: |
-      #     zstd -d nextest-archive-windows-latest.tar.zst
-      #     tar -xf nextest-archive-windows-latest.tar
-      #     ren target stable-crates-target
-      #     echo "NEXTEST_BIN_EXE_scarb=$env:GITHUB_WORKSPACE/stable-crates-target/ci/scarb" >> $env:GITHUB_ENV
-      #     Add-Content $env:GITHUB_PATH "$env:GITHUB_WORKSPACE/stable-crates-target/ci"
-      #     Add-Content $env:GITHUB_PATH "$env:GITHUB_WORKSPACE/target/ci"
-      - name: Download nightly build artifacts  
-         uses: actions/download-artifact@v4
+      - name: Download nightly build artifacts
+        uses: actions/download-artifact@v4
         with:
           name: nextest-nightly-archive-${{ matrix.platform.os }}
       - name: nextest partition


### PR DESCRIPTION
This way we can build stable and nightly in parallel, instead of first waiting for stable to build and then building nightly. I suggest using nextest, even if we do not use partitioning, because it's well suited for archiving build and running from the archive. 