### PR TITLE
Propagate ui verbosity when using scarbcommand in extensions

### DIFF
--- a/extensions/scarb-cairo-run/src/main.rs
+++ b/extensions/scarb-cairo-run/src/main.rs
@@ -101,11 +101,7 @@ fn main_inner(ui: &Ui, args: Args) -> Result<()> {
         ScarbCommand::new()
             .arg("build")
             .env("SCARB_PACKAGES_FILTER", filter.to_env())
-            .env_if(
-                "SCARB_UI_VERBOSITY",
-                ui.verbosity().to_string(),
-                !ui.verbosity().is_default(),
-            )
+            .env("SCARB_UI_VERBOSITY", ui.verbosity().to_string())
             .run()?;
     }
 

--- a/extensions/scarb-cairo-run/src/main.rs
+++ b/extensions/scarb-cairo-run/src/main.rs
@@ -101,6 +101,11 @@ fn main_inner(ui: &Ui, args: Args) -> Result<()> {
         ScarbCommand::new()
             .arg("build")
             .env("SCARB_PACKAGES_FILTER", filter.to_env())
+            .env_if(
+                "SCARB_UI_VERBOSITY",
+                ui.verbosity().to_string(),
+                !ui.verbosity().is_default(),
+            )
             .run()?;
     }
 

--- a/extensions/scarb-cairo-test/src/main.rs
+++ b/extensions/scarb-cairo-test/src/main.rs
@@ -12,7 +12,9 @@ use indoc::formatdoc;
 use scarb_metadata::{
     Metadata, MetadataCommand, PackageId, PackageMetadata, ScarbCommand, TargetMetadata,
 };
-use scarb_ui::args::PackagesFilter;
+use scarb_ui::args::{PackagesFilter, VerbositySpec};
+use scarb_ui::components::{NewLine, Status};
+use scarb_ui::{OutputFormat, Ui};
 
 /// Execute all unit tests of a local package.
 #[derive(Parser, Clone, Debug)]
@@ -40,6 +42,10 @@ struct Args {
     /// Whether to print resource usage after each test.
     #[arg(long, default_value_t = false)]
     print_resource_usage: bool,
+
+    /// Logging verbosity.
+    #[command(flatten)]
+    pub verbose: VerbositySpec,
 }
 
 #[derive(ValueEnum, Clone, Debug, Default)]
@@ -62,10 +68,12 @@ impl TestKind {
 
 fn main() -> Result<()> {
     let args: Args = Args::parse();
+    let ui = Ui::new(args.verbose.clone().into(), OutputFormat::Text);
 
     let metadata = MetadataCommand::new().inherit_stderr().exec()?;
 
-    check_scarb_version(&metadata);
+    check_scarb_version(&metadata, &ui);
+    check_cairo_test_plugin(&metadata, &ui);
 
     let matched = args.packages_filter.match_many(&metadata)?;
     let matched_ids = matched.iter().map(|p| p.id.clone()).collect::<Vec<_>>();
@@ -109,7 +117,8 @@ fn main() -> Result<()> {
 
     let mut deduplicator = TargetGroupDeduplicator::default();
     for package in matched {
-        println!("testing {} ...", package.name);
+        ui.print(Status::new("Testing", &package.name.to_string()));
+        let mut first = true;
         for target in find_testable_targets(&package) {
             if !target_names.contains(&target.name) {
                 continue;
@@ -124,6 +133,10 @@ fn main() -> Result<()> {
             if already_seen {
                 continue;
             }
+            if !first {
+                ui.print(NewLine::new());
+            }
+            first = false;
             let test_compilation = deserialize_test_compilation(&target_dir, name.clone())?;
             let config = TestRunConfig {
                 filter: args.filter.clone(),
@@ -135,7 +148,6 @@ fn main() -> Result<()> {
             };
             let runner = CompiledTestRunner::new(test_compilation, config);
             runner.run(None)?;
-            println!();
         }
     }
 
@@ -199,7 +211,7 @@ fn find_testable_targets(package: &PackageMetadata) -> Vec<&TargetMetadata> {
         .collect()
 }
 
-fn check_scarb_version(metadata: &Metadata) {
+fn check_scarb_version(metadata: &Metadata, ui: &Ui) {
     let app_version = env!("CARGO_PKG_VERSION").to_string();
     let scarb_version = metadata
         .app_version_info
@@ -208,28 +220,25 @@ fn check_scarb_version(metadata: &Metadata) {
         .clone()
         .to_string();
     if app_version != scarb_version {
-        println!(
+        ui.print(format!(
             "warn: the version of cairo-test does not match the version of scarb.\
          cairo-test: `{}`, scarb: `{}`",
-            app_version, scarb_version
-        );
+            app_version, scarb_version,
+        ));
     }
 }
 
-fn check_cairo_test_plugin(metadata: &Metadata, packages: &[PackageId]) {
+fn check_cairo_test_plugin(metadata: &Metadata, ui: &Ui) {
     let app_version = env!("CARGO_PKG_VERSION").to_string();
     let warn = || {
-        println!(
-            "{}",
-            formatdoc! {r#"
+        ui.print(formatdoc! {r#"
         warn: `cairo_test` plugin not found
         please add the following snippet to your Scarb.toml manifest:
         ```
         [dev-dependencies]
         cairo_test = "{}"
         ```
-        "#, app_version}
-        );
+        "#, app_version});
     };
 
     let Some(plugin_pkg) = metadata.packages.iter().find(|pkg| {

--- a/extensions/scarb-cairo-test/src/main.rs
+++ b/extensions/scarb-cairo-test/src/main.rs
@@ -104,11 +104,7 @@ fn main() -> Result<()> {
         .arg("--test")
         .env("SCARB_TARGET_NAMES", target_names.clone().join(","))
         .env("SCARB_PACKAGES_FILTER", filter.to_env())
-        .env_if(
-            "SCARB_UI_VERBOSITY",
-            ui.verbosity().to_string(),
-            !ui.verbosity().is_default(),
-        )
+        .env("SCARB_UI_VERBOSITY", ui.verbosity().to_string())
         .run()?;
 
     let profile = env::var("SCARB_PROFILE").unwrap_or("dev".into());

--- a/extensions/scarb-cairo-test/tests/build.rs
+++ b/extensions/scarb-cairo-test/tests/build.rs
@@ -310,10 +310,9 @@ fn do_not_warn_on_non_tested_package() {
         .stdout_matches(indoc! {r#"
             [..]Compiling test(second_unittest) second v1.0.0 ([..]Scarb.toml)
             [..]Finished `dev` profile target(s) in [..]
-            testing second ...
+            [..]Testing second
             running 0 tests
             test result: ok. 0 passed; 0 failed; 0 ignored; 0 filtered out;
-            
         "#});
 }
 

--- a/extensions/scarb-cairo-test/tests/build.rs
+++ b/extensions/scarb-cairo-test/tests/build.rs
@@ -49,11 +49,10 @@ fn can_test_without_gas() {
         .stdout_matches(indoc! {r#"
             [..]Compiling test(hello_unittest) hello v1.0.0 ([..]Scarb.toml)
             [..]Finished `dev` profile target(s) in [..]
-            testing hello ...
+            [..]Testing hello
             running 1 test
             test hello::tests::test_foo ... ok
             test result: ok. 1 passed; 0 failed; 0 ignored; 0 filtered out;
-
         "#});
 }
 
@@ -100,14 +99,13 @@ fn can_print_test_resources() {
         .stdout_matches(indoc! {r#"
             [..]Compiling test(hello_unittest) hello v1.0.0 ([..]Scarb.toml)
             [..]Finished `dev` profile target(s) in [..]
-            testing hello ...
+            [..]Testing hello
             running 1 test
             test hello::tests::it_works ... ok (gas usage est.: [..])
                 steps: [..]
                 memory holes: [..]
                 builtins: ("range_check_builtin": [..])
             test result: ok. 1 passed; 0 failed; 0 ignored; 0 filtered out;
-
         "#});
 }
 
@@ -152,11 +150,10 @@ fn features_test_build_success() {
             [..]Running cairo-test hello
             [..]Compiling test(hello_unittest) hello v1.0.0 ([..])
             [..]Finished `dev` profile target(s) in [..]
-            testing hello ...
+            [..]Testing hello
             running 1 test
             test hello::tests::it_works ... ok[..]
             test result: ok. 1 passed; 0 failed; 0 ignored; 0 filtered out;
-
         "#});
 }
 
@@ -237,16 +234,15 @@ fn integration_tests() {
             [..]Compiling test(hello_unittest) hello v1.0.0 ([..]Scarb.toml)
             [..]Compiling test(hello_integrationtest) hello_integrationtest v1.0.0 ([..]Scarb.toml)
             [..]Finished `dev` profile target(s) in [..]
-            testing hello ...
+            [..]Testing hello
             running 2 tests
             test hello_integrationtest::[..]::tests::it_works ... ok (gas usage est.: 43130)
             test hello_integrationtest::[..]::tests::it_works ... ok (gas usage est.: 43130)
             test result: ok. 2 passed; 0 failed; 0 ignored; 0 filtered out;
-
+            
             running 1 test
             test hello::tests::it_works ... ok (gas usage est.: 43130)
             test result: ok. 1 passed; 0 failed; 0 ignored; 0 filtered out;
-
         "#});
 }
 
@@ -284,10 +280,9 @@ fn warn_if_cairo_test_plugin_missing() {
 
             [..]Compiling test(hello_unittest) hello v1.0.0 ([..]Scarb.toml)
             [..]Finished `dev` profile target(s) in [..]
-            testing hello ...
+            [..]Testing hello
             running 0 tests
             test result: ok. 0 passed; 0 failed; 0 ignored; 0 filtered out;
-
        "#});
 }
 
@@ -367,11 +362,10 @@ fn can_choose_test_kind_to_run() {
         .stdout_matches(indoc! {r#"
             [..]Compiling test(hello_unittest) hello v1.0.0 ([..]Scarb.toml)
             [..]Finished `dev` profile target(s) in [..]
-            testing hello ...
+            [..]Testing hello
             running 1 test
             test hello::tests::it_works ... ok (gas usage est.: 43130)
             test result: ok. 1 passed; 0 failed; 0 ignored; 0 filtered out;
-
         "#});
     Scarb::quick_snapbox()
         .arg("cairo-test")
@@ -383,11 +377,10 @@ fn can_choose_test_kind_to_run() {
         .stdout_matches(indoc! {r#"
             [..]Compiling test(hello_integrationtest) hello_integrationtest v1.0.0 ([..]Scarb.toml)
             [..]Finished `dev` profile target(s) in [..]
-            testing hello ...
+            [..]Testing hello
             running 2 tests
             test hello_integrationtest::[..]::tests::it_works ... ok (gas usage est.: 43130)
             test hello_integrationtest::[..]::tests::it_works ... ok (gas usage est.: 43130)
             test result: ok. 2 passed; 0 failed; 0 ignored; 0 filtered out;
-            
         "#});
 }

--- a/extensions/scarb-execute/src/lib.rs
+++ b/extensions/scarb-execute/src/lib.rs
@@ -52,6 +52,11 @@ pub fn execute(
         ScarbCommand::new()
             .arg("build")
             .env("SCARB_PACKAGES_FILTER", filter.to_env())
+            .env_if(
+                "SCARB_UI_VERBOSITY",
+                ui.verbosity().to_string(),
+                !ui.verbosity().is_default(),
+            )
             .run()?;
     }
 

--- a/extensions/scarb-execute/src/lib.rs
+++ b/extensions/scarb-execute/src/lib.rs
@@ -52,11 +52,7 @@ pub fn execute(
         ScarbCommand::new()
             .arg("build")
             .env("SCARB_PACKAGES_FILTER", filter.to_env())
-            .env_if(
-                "SCARB_UI_VERBOSITY",
-                ui.verbosity().to_string(),
-                !ui.verbosity().is_default(),
-            )
+            .env("SCARB_UI_VERBOSITY", ui.verbosity().to_string())
             .run()?;
     }
 

--- a/extensions/scarb-execute/tests/build.rs
+++ b/extensions/scarb-execute/tests/build.rs
@@ -410,6 +410,30 @@ fn executable_must_be_chosen() {
     );
 }
 
+#[test]
+fn can_set_ui_verbosity() {
+    let t = build_executable_project();
+    Scarb::quick_snapbox()
+        .arg("execute")
+        .arg("--quiet")
+        .current_dir(&t)
+        .assert()
+        .success()
+        .stdout_eq("");
+}
+
+#[test]
+fn maintains_parent_verbosity() {
+    let t = build_executable_project();
+    Scarb::quick_snapbox()
+        .arg("--quiet")
+        .arg("execute")
+        .current_dir(&t)
+        .assert()
+        .success()
+        .stdout_eq("");
+}
+
 fn output_assert(output: OutputAssert, expected: &str) {
     #[cfg(windows)]
     output.stdout_matches(format!(

--- a/scarb-metadata/src/command/scarb_command.rs
+++ b/scarb-metadata/src/command/scarb_command.rs
@@ -78,19 +78,6 @@ impl ScarbCommand {
         self
     }
 
-    /// Inserts or updates an environment variable mapping, if `cond` is `true`.
-    pub fn env_if(
-        &mut self,
-        key: impl AsRef<OsStr>,
-        val: impl AsRef<OsStr>,
-        cond: bool,
-    ) -> &mut Self {
-        if cond {
-            self.inner.env(key, val);
-        }
-        self
-    }
-
     /// Adds or updates multiple environment variable mappings.
     pub fn envs<I, K, V>(&mut self, vars: I) -> &mut Self
     where

--- a/scarb-metadata/src/command/scarb_command.rs
+++ b/scarb-metadata/src/command/scarb_command.rs
@@ -78,6 +78,19 @@ impl ScarbCommand {
         self
     }
 
+    /// Inserts or updates an environment variable mapping, if `cond` is `true`.
+    pub fn env_if(
+        &mut self,
+        key: impl AsRef<OsStr>,
+        val: impl AsRef<OsStr>,
+        cond: bool,
+    ) -> &mut Self {
+        if cond {
+            self.inner.env(key, val);
+        }
+        self
+    }
+
     /// Adds or updates multiple environment variable mappings.
     pub fn envs<I, K, V>(&mut self, vars: I) -> &mut Self
     where

--- a/scarb/tests/build_cairo_plugin.rs
+++ b/scarb/tests/build_cairo_plugin.rs
@@ -1555,11 +1555,10 @@ fn can_expand_impl_inner_func_attrr() {
             [..] Compiling some v1.0.0 ([..]Scarb.toml)
             [..] Compiling test(hello_unittest) hello v1.0.0 ([..]Scarb.toml)
             [..]Finished `dev` profile target(s) in [..]
-            testing hello ...
+            [..]Testing hello
             running 1 test
             test hello::tests::test_flow ... ok (gas usage est.: [..])
             test result: ok. 1 passed; 0 failed; 0 ignored; 0 filtered out;
-
         "#});
 }
 

--- a/utils/scarb-ui/src/components/mod.rs
+++ b/utils/scarb-ui/src/components/mod.rs
@@ -2,12 +2,14 @@
 //! a [`Ui`][crate::Ui].
 
 pub use machine::*;
+pub use new_line::*;
 pub use spinner::*;
 pub use status::*;
 pub use typed::*;
 pub use value::*;
 
 mod machine;
+mod new_line;
 mod spinner;
 mod status;
 mod typed;

--- a/utils/scarb-ui/src/components/new_line.rs
+++ b/utils/scarb-ui/src/components/new_line.rs
@@ -1,0 +1,32 @@
+use crate::Message;
+
+/// A message that prints a new line.
+pub struct NewLine {}
+
+impl Default for NewLine {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl NewLine {
+    /// Create a new instance of `NewLine`.
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Message for NewLine {
+    fn print_text(self)
+    where
+        Self: Sized,
+    {
+        println!();
+    }
+
+    fn print_json(self)
+    where
+        Self: Sized,
+    {
+    }
+}

--- a/utils/scarb-ui/src/verbosity.rs
+++ b/utils/scarb-ui/src/verbosity.rs
@@ -64,6 +64,11 @@ impl Verbosity {
         let env_var = env::var(env_var_name)?;
         Self::from_str(env_var.as_str())
     }
+
+    /// Check if the verbosity level is the default one.
+    pub fn is_default(&self) -> bool {
+        *self == Verbosity::default()
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
fixes #1923 
- **Use scarb-ui in cairo-test**
- **Propagate verbosity level when calling ScarbCommand**
