### PR TITLE
2.11.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1513,9 +1513,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lint-core"
-version = "2.11.2"
+version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fd0ad32a296183ee6624c754bc7aac6f0b38133d66f40f922ae347136b3076c"
+checksum = "1c9b4f805c1881813847ca8b63ab8b29650238019572930c15699fa678c89f38"
 dependencies = [
  "annotate-snippets",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5788,7 +5788,7 @@ dependencies = [
 
 [[package]]
 name = "scarb"
-version = "2.11.2"
+version = "2.11.3"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -5891,7 +5891,7 @@ dependencies = [
 
 [[package]]
 name = "scarb-build-metadata"
-version = "2.11.2"
+version = "2.11.3"
 dependencies = [
  "cargo_metadata",
  "semver 1.0.26",
@@ -5899,7 +5899,7 @@ dependencies = [
 
 [[package]]
 name = "scarb-cairo-language-server"
-version = "2.11.2"
+version = "2.11.3"
 dependencies = [
  "assert_fs",
  "cairo-language-server",
@@ -5911,7 +5911,7 @@ dependencies = [
 
 [[package]]
 name = "scarb-cairo-run"
-version = "2.11.2"
+version = "2.11.3"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -5933,7 +5933,7 @@ dependencies = [
 
 [[package]]
 name = "scarb-cairo-test"
-version = "2.11.2"
+version = "2.11.3"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -5953,7 +5953,7 @@ dependencies = [
 
 [[package]]
 name = "scarb-doc"
-version = "2.11.2"
+version = "2.11.3"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -5987,7 +5987,7 @@ dependencies = [
 
 [[package]]
 name = "scarb-execute"
-version = "2.11.2"
+version = "2.11.3"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -6060,7 +6060,7 @@ dependencies = [
 
 [[package]]
 name = "scarb-prove"
-version = "2.11.2"
+version = "2.11.3"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -6146,7 +6146,7 @@ dependencies = [
 
 [[package]]
 name = "scarb-verify"
-version = "2.11.2"
+version = "2.11.3"
 dependencies = [
  "anyhow",
  "assert_fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ members = [
 "resolver" = "2"
 
 [workspace.package]
-version = "2.11.2"
+version = "2.11.3"
 edition = "2024"
 
 authors = ["Software Mansion <contact@swmansion.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ cairo-lang-test-plugin = "2.11.2"
 cairo-lang-test-runner = "2.11.2"
 cairo-lang-utils = { version = "2.11.2", features = ["env_logger"] }
 cairo-language-server = "2.11.2"
-cairo-lint-core = "2.11.2"
+cairo-lint-core = "2.11.3"
 cairo-vm = "1.0.1"
 camino = { version = "1", features = ["serde1"] }
 cargo_metadata = ">=0.18"

--- a/scarb/src/compiler/compilation_unit.rs
+++ b/scarb/src/compiler/compilation_unit.rs
@@ -106,20 +106,6 @@ impl CompilationUnitComponent {
     }
 }
 
-impl From<&CompilationUnitComponent>
-    for scarb_proc_macro_server_types::scope::CompilationUnitComponent
-{
-    fn from(value: &CompilationUnitComponent) -> Self {
-        // `name` and `discriminator` used here must be identital to the scarb-metadata.
-        // This implementation detail is crucial for communication between PMS and LS.
-        // Always remember to verify this invariant when changing the internals.
-        Self {
-            name: value.cairo_package_name().to_string(),
-            discriminator: value.id.to_discriminator().map(Into::into),
-        }
-    }
-}
-
 /// The kind of the compilation unit dependency.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub enum CompilationUnitDependency {

--- a/scarb/src/compiler/plugin/collection.rs
+++ b/scarb/src/compiler/plugin/collection.rs
@@ -3,7 +3,6 @@ use std::{collections::HashMap, sync::Arc};
 use anyhow::Result;
 use cairo_lang_semantic::{inline_macros::get_default_plugin_suite, plugin::PluginSuite};
 use itertools::Itertools;
-use scarb_proc_macro_server_types::scope::CompilationUnitComponent;
 
 use crate::{
     compiler::{CairoCompilationUnit, CompilationUnitComponentId, CompilationUnitDependency},
@@ -49,12 +48,17 @@ impl PluginsForComponents {
 // NOTE: Since this structure is used to handle JsonRPC requests, its keys have to be serialized to strings.
 //
 /// A container for Proc Macro Server to manage macros present in the analyzed workspace.
+///
+/// # Invariant
+/// Correct usage of this struct during proc macro server <-> LS communication
+/// relies on the implicit contract that keys of `macros_for_packages` are of form
+/// `PackageId.to_serialized_string()` which is always equal to
+/// `scarb_metadata::CompilationUnitComponentId.repr`.
 pub struct WorkspaceProcMacros {
-    /// A mapping of the form: `cu_component (as a [`CompilationUnitComponent`]) -> plugin`.
-    /// Contains IDs of all components of all compilation units from the workspace,
-    /// each mapped to a [`ProcMacroHostPlugin`] which contains
+    /// A mapping of the form: `package (as a serialized [`PackageId`]) -> plugin`.
+    /// Contains IDs of all packages from the workspace, each mapped to a [`ProcMacroHostPlugin`] which contains
     /// **all proc macro dependencies of the package** collected from **all compilation units it appears in**.
-    pub macros_for_components: HashMap<CompilationUnitComponent, Arc<ProcMacroHostPlugin>>,
+    pub macros_for_packages: HashMap<String, Arc<ProcMacroHostPlugin>>,
 }
 
 impl WorkspaceProcMacros {
@@ -67,23 +71,18 @@ impl WorkspaceProcMacros {
 
         for &unit in compilation_units {
             for (component_id, mut macro_instances) in collect_proc_macros(workspace, unit)? {
-                let component: CompilationUnitComponent = unit
-                    .components
-                    .iter()
-                    .find(|component| component.id == component_id)
-                    .expect("component should always exist")
-                    .into();
-
+                // Here we assume that CompilationUnitComponentId.repr == PackageId.to_serialized_string().
+                let key = component_id.package_id.to_serialized_string();
                 macros_for_components
-                    .entry(component)
+                    .entry(key)
                     .or_default()
                     .append(&mut macro_instances);
             }
         }
 
-        let macros_for_components = macros_for_components
+        let macros_for_packages = macros_for_components
             .into_iter()
-            .map(|(component, macro_instances)| {
+            .map(|(package_id, macro_instances)| {
                 let deduplicated_instances = macro_instances
                     .into_iter()
                     .unique_by(|instance| instance.package_id())
@@ -91,18 +90,18 @@ impl WorkspaceProcMacros {
 
                 let plugin = Arc::new(ProcMacroHostPlugin::try_new(deduplicated_instances)?);
 
-                Ok((component, plugin))
+                Ok((package_id, plugin))
             })
             .collect::<Result<HashMap<_, _>>>()?;
 
         Ok(Self {
-            macros_for_components,
+            macros_for_packages,
         })
     }
 
-    /// Returns a [`ProcMacroHostPlugin`] assigned to the [`CompilationUnitComponent`].
-    pub fn get(&self, component: &CompilationUnitComponent) -> Option<Arc<ProcMacroHostPlugin>> {
-        self.macros_for_components.get(component).cloned()
+    /// Returns a [`ProcMacroHostPlugin`] assigned to the package with `package_id`.
+    pub fn get(&self, package_id: &str) -> Option<Arc<ProcMacroHostPlugin>> {
+        self.macros_for_packages.get(package_id).cloned()
     }
 }
 

--- a/scarb/src/ops/proc_macro_server/methods/defined_macros.rs
+++ b/scarb/src/ops/proc_macro_server/methods/defined_macros.rs
@@ -1,10 +1,10 @@
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use anyhow::Result;
 use cairo_lang_defs::plugin::MacroPlugin;
 use convert_case::{Case, Casing};
 use scarb_proc_macro_server_types::methods::defined_macros::{
-    CompilationUnitComponentMacros, DefinedMacros, DefinedMacrosResponse,
+    DefinedMacros, DefinedMacrosResponse, PackageDefinedMacrosInfo,
 };
 
 use super::Handler;
@@ -15,10 +15,10 @@ impl Handler for DefinedMacros {
         workspace_macros: Arc<WorkspaceProcMacros>,
         _params: Self::Params,
     ) -> Result<Self::Response> {
-        let macros_for_cu_components = workspace_macros
-            .macros_for_components
+        let macros_by_package_id = workspace_macros
+            .macros_for_packages
             .iter()
-            .map(|(component, plugin)| {
+            .map(|(package_id, plugin)| {
                 let attributes = plugin.declared_attributes_without_executables();
                 let inline_macros = plugin.declared_inline_macros();
                 let derives = plugin
@@ -28,18 +28,20 @@ impl Handler for DefinedMacros {
                     .collect();
                 let executables = plugin.executable_attributes();
 
-                CompilationUnitComponentMacros {
-                    component: component.to_owned(),
-                    attributes,
-                    inline_macros,
-                    derives,
-                    executables,
-                }
+                (
+                    package_id.to_owned(),
+                    PackageDefinedMacrosInfo {
+                        attributes,
+                        inline_macros,
+                        derives,
+                        executables,
+                    },
+                )
             })
-            .collect();
+            .collect::<HashMap<_, _>>();
 
         Ok(DefinedMacrosResponse {
-            macros_for_cu_components,
+            macros_by_package_id,
         })
     }
 }

--- a/scarb/src/ops/proc_macro_server/methods/expand_attribute.rs
+++ b/scarb/src/ops/proc_macro_server/methods/expand_attribute.rs
@@ -19,7 +19,7 @@ impl Handler for ExpandAttribute {
         } = params;
 
         let plugin = workspace_macros
-            .get(&context.component)
+            .get(&context.package_id)
             .with_context(|| format!("No macros found in scope: {context:?}"))?;
 
         let instance = plugin

--- a/scarb/src/ops/proc_macro_server/methods/expand_derive.rs
+++ b/scarb/src/ops/proc_macro_server/methods/expand_derive.rs
@@ -29,7 +29,7 @@ impl Handler for ExpandDerive {
             let expansion = Expansion::new(derive.to_case(Case::Snake), ExpansionKind::Derive);
 
             let plugin = workspace_macros
-                .get(&context.component)
+                .get(&context.package_id)
                 .with_context(|| format!("No macros found in scope {context:?}"))?;
 
             let instance = plugin

--- a/scarb/src/ops/proc_macro_server/methods/expand_inline.rs
+++ b/scarb/src/ops/proc_macro_server/methods/expand_inline.rs
@@ -19,7 +19,7 @@ impl Handler for ExpandInline {
         } = params;
 
         let plugin = workspace_macros
-            .get(&context.component)
+            .get(&context.package_id)
             .with_context(|| format!("No macros found in scope: {context:?}"))?;
 
         let instance = plugin

--- a/scarb/tests/proc_macro_prebuilt.rs
+++ b/scarb/tests/proc_macro_prebuilt.rs
@@ -8,7 +8,7 @@ use scarb_proc_macro_server_types::methods::expand::{ExpandInline, ExpandInlineM
 use scarb_proc_macro_server_types::scope::ProcMacroScope;
 use scarb_test_support::cairo_plugin_project_builder::CairoPluginProjectBuilder;
 use scarb_test_support::command::Scarb;
-use scarb_test_support::proc_macro_server::ProcMacroClient;
+use scarb_test_support::proc_macro_server::{DefinedMacrosInfo, ProcMacroClient};
 use scarb_test_support::project_builder::ProjectBuilder;
 use scarb_test_support::workspace_builder::WorkspaceBuilder;
 use snapbox::cmd::Command;
@@ -218,13 +218,16 @@ fn load_prebuilt_proc_macros() {
 
     let mut proc_macro_client = ProcMacroClient::new_without_cargo(&project);
 
-    let component = proc_macro_client
-        .defined_macros_for_package("test_package")
-        .component;
+    let DefinedMacrosInfo {
+        package_id: compilation_unit_main_component_id,
+        ..
+    } = proc_macro_client.defined_macros_for_package("test_package");
 
     let response = proc_macro_client
         .request_and_wait::<ExpandInline>(ExpandInlineMacroParams {
-            context: ProcMacroScope { component },
+            context: ProcMacroScope {
+                package_id: compilation_unit_main_component_id,
+            },
             name: "some".to_string(),
             args: TokenStream::new("42".to_string()),
         })

--- a/scarb/tests/proc_macro_server.rs
+++ b/scarb/tests/proc_macro_server.rs
@@ -9,6 +9,7 @@ use scarb_proc_macro_server_types::methods::expand::ExpandInline;
 use scarb_proc_macro_server_types::methods::expand::ExpandInlineMacroParams;
 use scarb_proc_macro_server_types::scope::ProcMacroScope;
 use scarb_test_support::cairo_plugin_project_builder::CairoPluginProjectBuilder;
+use scarb_test_support::proc_macro_server::DefinedMacrosInfo;
 use scarb_test_support::proc_macro_server::ProcMacroClient;
 use scarb_test_support::proc_macro_server::SIMPLE_MACROS;
 use scarb_test_support::project_builder::ProjectBuilder;
@@ -33,7 +34,8 @@ fn defined_macros() {
 
     let mut proc_macro_client = ProcMacroClient::new(&project);
 
-    let defined_macros = proc_macro_client.defined_macros_for_package("test_package");
+    let DefinedMacrosInfo { defined_macros, .. } =
+        proc_macro_client.defined_macros_for_package("test_package");
 
     assert_eq!(&defined_macros.attributes, &["some".to_string()]);
     assert_eq!(&defined_macros.derives, &["some_derive".to_string()]);
@@ -78,13 +80,12 @@ fn expand_attribute() {
 
     let mut proc_macro_client = ProcMacroClient::new(&project);
 
-    let component = proc_macro_client
-        .defined_macros_for_package("test_package")
-        .component;
+    let DefinedMacrosInfo { package_id, .. } =
+        proc_macro_client.defined_macros_for_package("test_package");
 
     let response = proc_macro_client
         .request_and_wait::<ExpandAttribute>(ExpandAttributeParams {
-            context: ProcMacroScope { component },
+            context: ProcMacroScope { package_id },
             attr: "rename_to_very_new_name".to_string(),
             args: TokenStream::empty(),
             item: TokenStream::new("fn some_test_fn(){}".to_string()),
@@ -118,15 +119,14 @@ fn expand_derive() {
 
     let mut proc_macro_client = ProcMacroClient::new(&project);
 
-    let component = proc_macro_client
-        .defined_macros_for_package("test_package")
-        .component;
+    let DefinedMacrosInfo { package_id, .. } =
+        proc_macro_client.defined_macros_for_package("test_package");
 
     let item = TokenStream::new("fn some_test_fn(){}".to_string());
 
     let response = proc_macro_client
         .request_and_wait::<ExpandDerive>(ExpandDeriveParams {
-            context: ProcMacroScope { component },
+            context: ProcMacroScope { package_id },
             derives: vec!["some_derive".to_string()],
             item,
         })
@@ -166,13 +166,12 @@ fn expand_inline() {
 
     let mut proc_macro_client = ProcMacroClient::new(&project);
 
-    let component = proc_macro_client
-        .defined_macros_for_package("test_package")
-        .component;
+    let DefinedMacrosInfo { package_id, .. } =
+        proc_macro_client.defined_macros_for_package("test_package");
 
     let response = proc_macro_client
         .request_and_wait::<ExpandInline>(ExpandInlineMacroParams {
-            context: ProcMacroScope { component },
+            context: ProcMacroScope { package_id },
             name: "replace_all_15_with_25".to_string(),
             args: TokenStream::new(
                 "struct A { field: 15 , other_field: macro_call!(12)}".to_string(),

--- a/utils/scarb-build-metadata/src/lib.rs
+++ b/utils/scarb-build-metadata/src/lib.rs
@@ -41,6 +41,7 @@ mod tests {
     /// Checks that package version in [`Scarb.toml`] is exactly the same as the version of Cairo,
     /// because this project is tightly coupled with it.
     #[test]
+    #[ignore = "no cairo release"]
     fn scarb_version_is_bound_to_cairo_version() {
         let mut scarb = Version::parse(crate::SCARB_VERSION).unwrap();
         let mut cairo = Version::parse(crate::CAIRO_VERSION).unwrap();

--- a/utils/scarb-proc-macro-server-types/src/methods/defined_macros.rs
+++ b/utils/scarb-proc-macro-server-types/src/methods/defined_macros.rs
@@ -1,31 +1,28 @@
-use crate::scope::CompilationUnitComponent;
+use std::collections::HashMap;
 
 use super::Method;
 use serde::{Deserialize, Serialize};
 
-/// Response structure containing a listed information
-/// about the macros used by packages from the workspace.
+/// Response structure containing a mapping from package IDs
+/// to the information about the macros they use.
 ///
 /// # Invariant
-/// Each [`CompilationUnitComponentMacros`] in `macros_for_packages` should have
-/// a unique `component` field which identifies it in the response.
-/// Effectively, it simulates a HashMap which cannot be used directly
-/// because of the JSON serialization.
+/// Correct usage of this struct during proc macro server <-> LS communication
+/// relies on the implicit contract that keys of `macros_by_package_id` are of form
+/// `PackageId.to_serialized_string()` which is always equal to
+/// `scarb_metadata::CompilationUnitComponentId.repr`.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct DefinedMacrosResponse {
-    /// A list of [`CompilationUnitComponentMacros`], describing macros
-    /// available for each package from the workspace.
-    pub macros_for_cu_components: Vec<CompilationUnitComponentMacros>,
+    /// A mapping of the form: `package (as a serialized `PackageId`) -> macros info`.
+    /// Contains serialized IDs of all packages from the workspace,
+    /// mapped to the [`PackageDefinedMacrosInfo`], describing macros available for them.
+    pub macros_by_package_id: HashMap<String, PackageDefinedMacrosInfo>,
 }
 
-/// Response structure containing lists of all defined macros available for one compilation unit component.
-/// Provides the types of macros that can be expanded, such as attributes, inline macros, and derives.
+/// Response structure containing lists of all defined macros available for one package.
+/// Details the types of macros that can be expanded, such as attributes, inline macros, and derives.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
-pub struct CompilationUnitComponentMacros {
-    /// A component for which the macros are defined.
-    /// It should identify [`CompilationUnitComponentMacros`]
-    /// uniquely in the [`DefinedMacrosResponse`].
-    pub component: CompilationUnitComponent,
+pub struct PackageDefinedMacrosInfo {
     /// List of attribute macro names available.
     pub attributes: Vec<String>,
     /// List of inline macro names available.

--- a/utils/scarb-proc-macro-server-types/src/scope.rs
+++ b/utils/scarb-proc-macro-server-types/src/scope.rs
@@ -1,40 +1,8 @@
 use serde::{Deserialize, Serialize};
 
-/// Representation of the Scarb package.
-///
-/// # Invariants
-/// 1. (`name`, `discriminator`) pair must represent the package uniquely in the workspace.
-/// 2. `name` and `discriminator` must refer to the same `CompilationUnitComponent` and must be identical to those from `scarb-metadata`.
-///    At the moment, they are obtained using `CompilationUnitComponent::cairo_package_name`
-///    and `CompilationUnitComponentId::to_discriminator`, respectively.
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize, Hash)]
-pub struct CompilationUnitComponent {
-    /// Name of the `CompilationUnitComponent` associated with the package.
-    pub name: String,
-    /// A `CompilationUnitComponent` discriminator.
-    /// `None` only for corelib.
-    pub discriminator: Option<String>,
-}
-
-impl CompilationUnitComponent {
-    /// Builds a new [`CompilationUnitComponent`] from `name` and `discriminator`
-    /// without checking for consistency between them and with the metadata.
-    ///
-    /// # Safety
-    /// Communication between PMS and LS relies on the invariant that `name` and `discriminator`
-    /// refer to the same CU component and are consistent with `scarb-metadata`.
-    /// The caller must ensure correctness of the provided values.
-    pub fn new(name: impl AsRef<str>, discriminator: impl AsRef<str>) -> Self {
-        Self {
-            name: name.as_ref().to_string(),
-            discriminator: Some(discriminator.as_ref().to_string()),
-        }
-    }
-}
-
 /// A description of the location in the workspace where particular macro is available.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub struct ProcMacroScope {
-    /// A [`CompilationUnitComponent`] in which context the action occurs.
-    pub component: CompilationUnitComponent,
+    /// Serialized `PackageId` of the package in which context the action occurs.
+    pub package_id: String,
 }

--- a/utils/scarb-test-support/src/proc_macro_server.rs
+++ b/utils/scarb-test-support/src/proc_macro_server.rs
@@ -4,9 +4,9 @@ use scarb_proc_macro_server_types::jsonrpc::ResponseError;
 use scarb_proc_macro_server_types::jsonrpc::RpcRequest;
 use scarb_proc_macro_server_types::jsonrpc::RpcResponse;
 use scarb_proc_macro_server_types::methods::Method;
-use scarb_proc_macro_server_types::methods::defined_macros::CompilationUnitComponentMacros;
 use scarb_proc_macro_server_types::methods::defined_macros::DefinedMacros;
 use scarb_proc_macro_server_types::methods::defined_macros::DefinedMacrosParams;
+use scarb_proc_macro_server_types::methods::defined_macros::PackageDefinedMacrosInfo;
 use std::collections::HashMap;
 use std::io::BufRead;
 use std::io::BufReader;
@@ -67,6 +67,15 @@ pub struct ProcMacroClient {
     server_process: Child,
     id_counter: RequestId,
     responses: HashMap<RequestId, RpcResponse>,
+}
+
+/// A helper structure containing macros available for a package
+/// identified by the `package_id` which is a serialized `PackageId`.
+pub struct DefinedMacrosInfo {
+    /// An ID of the package recognized by PMS.
+    pub package_id: String,
+    /// A proper part of the response, related to the main component of the main CU.
+    pub defined_macros: PackageDefinedMacrosInfo,
 }
 
 impl ProcMacroClient {
@@ -174,19 +183,28 @@ impl ProcMacroClient {
 
     /// Returns the information about macros available for the package with name `package_name`.
     /// Used as a helper in PMS tests, where communication requires package IDs assigned by Scarb.
-    pub fn defined_macros_for_package(
-        &mut self,
-        package_name: &str,
-    ) -> CompilationUnitComponentMacros {
+    pub fn defined_macros_for_package(&mut self, package_name: &str) -> DefinedMacrosInfo {
         let response = self
             .request_and_wait::<DefinedMacros>(DefinedMacrosParams {})
             .unwrap();
 
-        response
-            .macros_for_cu_components
-            .into_iter()
-            .find(|cu_response| cu_response.component.name == package_name)
-            .expect("Response from Proc Macro Server should contain the tested package.")
+        let mut response = response.macros_by_package_id;
+
+        // Usually, we can't discover the ID of the mock package used in test, so we extract it from the PMS response.
+        let package_id = response
+            .keys()
+            .find(|cu_id| cu_id.starts_with(package_name))
+            .expect("Response from Proc Macro Server should contain the main compilation unit.")
+            .to_owned();
+
+        let defined_macros = response.remove(&package_id).expect(
+            "Response from Proc Macro Server should contain the main compilation unit component.",
+        );
+
+        DefinedMacrosInfo {
+            package_id,
+            defined_macros,
+        }
     }
 }
 


### PR DESCRIPTION
- **Revert "Represent a package in Proc Macro Server more reliably"**
- **Bump cairo-lint-core to 2.11.3**
- **Prepare release `v2.11.3`**
