### PR TITLE
Add docs for prebuilt plugins and inlining strategy by weight

### DIFF
--- a/website/docs/reference/manifest.md
+++ b/website/docs/reference/manifest.md
@@ -430,6 +430,30 @@ exit-first = true
 No fields in this section are required or defined by Scarb.
 Each field can accept any valid toml value including a table.
 
+### `[tool.scarb]` section
+
+Scarb defines own tool section, called `[tool.scarb]`, which can be used to store Scarb specific configuration.
+
+As of now, only one key is supported in this section: `allow-prebuilt-plugins`.
+This field accepts a list of names of packages from the dependencies of the package.
+It can accept both direct and transient dependencies.
+Adding a package name to this list means, that Scarb can load prebuilt plugins for this package and all of its dependencies.
+
+Example usage:
+
+```toml
+[tool.scarb]
+allow-prebuilt-plugins = ["snforge_std"]
+```
+
+> [!WARNING]
+> Since loading a prebuilt plugin means loading and executing a binary file distributed with the dependency,
+> only mark packages as allowed if you trust the source of the package and the package itself.
+> Executing bytecode from untrusted sources can lead to security vulnerabilities.
+
+This field is only read from the package that is currently build by Scarb.
+Sections defined in dependencies will be ignored.
+
 ## `[workspace]`
 
 See [Workspaces](./workspaces) page.

--- a/website/docs/reference/manifest.md
+++ b/website/docs/reference/manifest.md
@@ -454,6 +454,12 @@ allow-prebuilt-plugins = ["snforge_std"]
 This field is only read from the package that is currently build by Scarb.
 Sections defined in dependencies will be ignored.
 
+The prebuilt binaries are used in a best-effort manner - if it's not possible to load a prebuilt binary for any reason,
+it will attempt to compile the macro source code instead.
+No errors will be emitted if the prebuilt binary is not found or cannot be loaded.
+
+See [prebuilt procedural macros](./procedural-macro.md#prebuilt-procedural-macros) for more information.
+
 ## `[workspace]`
 
 See [Workspaces](./workspaces) page.

--- a/website/docs/reference/manifest.md
+++ b/website/docs/reference/manifest.md
@@ -344,7 +344,7 @@ inlining-strategy = "avoid"
 ```
 
 If numerical value is set, the compiler will inline functions up to the given weight.
-Note, that the weight exact definition is subject to change.
+Note, that the weight exact definition is a compiler implementation detail and is subject to changes with every release.
 Example usage:
 
 ```toml

--- a/website/docs/reference/manifest.md
+++ b/website/docs/reference/manifest.md
@@ -334,8 +334,23 @@ This flag cannot be set to `false` while compiling the `starknet-contract` targe
 ### `inlining-strategy`
 
 This field is responsible for setting the inlining strategy to be used by compiler when building the package.
-The possible values are `default` or `avoid`.
+The possible values are `default`, `avoid` or a numerical value.
 If `avoid` strategy is set, the compiler will only inline function annotated with `#[inline(always)]` attribute.
+Example usage:
+
+```toml
+[cairo]
+inlining-strategy = "avoid"
+```
+
+If numerical value is set, the compiler will inline functions up to the given weight.
+Note, that the weight exact definition is subject to change.
+Example usage:
+
+```toml
+[cairo]
+inlining-strategy = 18
+```
 
 > [!WARNING]
 > Using the `avoid` strategy may result in a slower execution of the compiled code.

--- a/website/docs/reference/procedural-macro.md
+++ b/website/docs/reference/procedural-macro.md
@@ -353,3 +353,37 @@ pub fn callback(context: PostProcessContext) {
     println!("{:?}", aux_data);
 }
 ```
+
+#### Prebuilt procedural macros
+
+By default, all procedural macros are compiled on the user system before being used by Scarb.
+This means that programmers that wanted to depend on a package utilizing a procedural macro have to install Rust compiler
+(and Cargo) on their system.
+Prebuilt macros is an opt-in feature, that enables the user to request a pre-compiled procedural macro to be used instead
+of compiling it on their system themselves.
+
+For this to be possible, two conditions need to be met:
+
+- The procedural macro package has to be published with the precompiled macros included.
+- Usage of the precompiled macro binaries needs to be explicitly allowed in the top-level Scarb toml manifest file.
+
+To include a precompiled macro binaries in your package, you need to place the binary files in `target/scarb/cairo-plugin`
+directory of the package, with names adhering to following convention: `{package_name}_v{version}_{target_name}.{dll_extension}`,
+where target name describes the target OS in [Cargo conventions](https://doc.rust-lang.org/rustc/platform-support.html#tier-1-with-host-tools).
+For publishing, [the `include` field](./manifest.md#include) of the package manifest may be useful, as it can be used
+to instruct Scarb to include this directory when packaging Scarb package with `scarb package`/`scarb publish`.
+
+To allow usage of precompiled procedural macros, you need to add a list of package names under `allow-prebuilt-plugins`
+name in the `[tool.scarb]` section of Scarb manifest of the compiled (top-level) package.
+Only the section defined in top level package will be considered and sections defined in dependencies will be ignored.
+Note this allow list works recursively, so adding a package names allow usage of precompiled macros in the dependency
+tree of this package.
+
+```toml
+[tool.scarb]
+allow-prebuilt-plugins = ["snforge_std"]
+```
+
+The prebuilt binaries are used in a best-effort manner - if it's not possible to load a prebuilt binary for any reason,
+it will attempt to compile the macro source code instead.
+No errors will be emitted if the prebuilt binary is not found or cannot be loaded.


### PR DESCRIPTION
fixes #2063 

- **Doc inlining strategy as weight parameter**
- **Add allow-prebuilt-plugins docs to manifest reference**
- **Document prebuilt macro plugins**
