### PR TITLE
Fix dev-deps propagation of compiler plugins for ws members

### DIFF
--- a/scarb/src/core/resolver.rs
+++ b/scarb/src/core/resolver.rs
@@ -64,9 +64,10 @@ impl Resolve {
         &self,
         package_id: PackageId,
         target_kind: &TargetKind,
+        is_unit_root: bool,
     ) -> Vec<PackageId> {
-        let filtered_graph = EdgeFiltered::from_fn(&self.graph, move |(node_a, _node_b, edge)| {
-            edge.accepts_target(target_kind.clone(), node_a == package_id)
+        let filtered_graph = EdgeFiltered::from_fn(&self.graph, move |(_node_a, _node_b, edge)| {
+            edge.accepts_target(target_kind.clone(), is_unit_root)
         });
         filtered_graph
             .neighbors_directed(package_id, petgraph::Direction::Outgoing)
@@ -95,7 +96,8 @@ impl Resolve {
             if comp.iter().any(|x| allowed_prebuilds.check(&key(*x))) {
                 allowed_prebuilds.allow(comp.iter().map(|x| key(*x)));
                 for package in comp {
-                    let deps = self.package_dependencies_for_target_kind(*package, target_kind);
+                    let deps =
+                        self.package_dependencies_for_target_kind(*package, target_kind, true);
                     allowed_prebuilds.allow(deps.iter().map(|x| key(*x)));
                 }
             }

--- a/scarb/tests/metadata.rs
+++ b/scarb/tests/metadata.rs
@@ -46,6 +46,27 @@ fn units_and_components(meta: Metadata) -> BTreeMap<String, Vec<String>> {
         .collect::<BTreeMap<_, _>>()
 }
 
+fn units_and_plugins(meta: Metadata) -> BTreeMap<String, Vec<String>> {
+    meta.compilation_units
+        .iter()
+        .map(|cu| {
+            (
+                cu.target.name.clone(),
+                cu.cairo_plugins
+                    .iter()
+                    .map(|c| {
+                        meta.packages
+                            .iter()
+                            .find(|p| p.id == c.package)
+                            .map(|p| p.name.clone())
+                            .unwrap()
+                    })
+                    .collect_vec(),
+            )
+        })
+        .collect::<BTreeMap<_, _>>()
+}
+
 #[test]
 fn simple() {
     let t = TempDir::new().unwrap();
@@ -394,6 +415,96 @@ fn dev_deps_are_not_propagated_for_ws_members() {
                     "x".to_string()
                 ]
             ),
+        ])
+    );
+}
+
+#[test]
+fn dev_dep_plugins_are_not_propagated_for_ws_members() {
+    let t = TempDir::new().unwrap();
+
+    let dep2 = t.child("dep2");
+    ProjectBuilder::start()
+        .name("dep2")
+        .dep_cairo_test()
+        .build(&dep2);
+
+    let pkg = t.child("pkg");
+    ProjectBuilder::start()
+        .name("x")
+        .dep("dep2", &dep2)
+        .build(&pkg);
+
+    WorkspaceBuilder::start()
+        .add_member("dep2")
+        .add_member("pkg")
+        .build(&t);
+
+    let metadata = Scarb::quick_snapbox()
+        .arg("--json")
+        .arg("metadata")
+        .arg("--format-version")
+        .arg("1")
+        .current_dir(&t)
+        .stdout_json::<Metadata>();
+
+    assert_eq!(
+        units_and_plugins(metadata.clone()),
+        BTreeMap::from_iter(vec![
+            ("dep2".to_string(), vec![]),
+            ("dep2_unittest".to_string(), vec!["cairo_test".to_string()]),
+            ("x".to_string(), vec![]),
+            ("x_unittest".to_string(), vec![]),
+        ])
+    );
+
+    // Get the compilation unit of `x` unit tests.
+    let cu = metadata
+        .compilation_units
+        .iter()
+        .find(|unit| unit.target.name == "x_unittest")
+        .unwrap();
+    // Get dependencies of components in the compilation unit.
+    let component_deps = BTreeMap::from_iter(cu.components.iter().map(|component| {
+        (
+            component.name.clone(),
+            component
+                .dependencies
+                .as_ref()
+                .map(|deps| {
+                    deps.iter()
+                        .map(|dep| {
+                            metadata
+                                .packages
+                                .iter()
+                                .find(|p| p.id.to_string() == dep.id.clone().to_string())
+                                .map(|p| p.name.clone())
+                                .unwrap()
+                        })
+                        .collect::<Vec<_>>()
+                })
+                .unwrap(),
+        )
+    }));
+    assert_eq!(
+        component_deps,
+        BTreeMap::from_iter(vec![
+            ("core".to_string(), vec!["core".to_string()]),
+            (
+                "dep2".to_string(),
+                vec![
+                    "core".to_string(),
+                    "dep2".to_string(),
+                    // Note that `cairo_test` is indeed a dev dependency of `dep2`,
+                    // but it's not propagated to the unit tests of `x`.
+                    // Only dev dependencies of the main component should be enabled.
+                    // "cairo_test".to_string()
+                ]
+            ),
+            (
+                "x".to_string(),
+                vec!["core".to_string(), "dep2".to_string(), "x".to_string()]
+            )
         ])
     );
 }

--- a/scarb/tests/metadata.rs
+++ b/scarb/tests/metadata.rs
@@ -423,10 +423,14 @@ fn dev_deps_are_not_propagated_for_ws_members() {
 fn dev_dep_plugins_are_not_propagated_for_ws_members() {
     let t = TempDir::new().unwrap();
 
+    let m = t.child("m");
+    CairoPluginProjectBuilder::default().name("m").build(&m);
+
     let dep2 = t.child("dep2");
     ProjectBuilder::start()
         .name("dep2")
         .dep_cairo_test()
+        .dev_dep("m", &m)
         .build(&dep2);
 
     let pkg = t.child("pkg");
@@ -452,7 +456,11 @@ fn dev_dep_plugins_are_not_propagated_for_ws_members() {
         units_and_plugins(metadata.clone()),
         BTreeMap::from_iter(vec![
             ("dep2".to_string(), vec![]),
-            ("dep2_unittest".to_string(), vec!["cairo_test".to_string()]),
+            (
+                "dep2_unittest".to_string(),
+                vec!["cairo_test".to_string(), "m".to_string()]
+            ),
+            ("m".to_string(), vec![]),
             ("x".to_string(), vec![]),
             ("x_unittest".to_string(), vec![]),
         ])
@@ -498,7 +506,8 @@ fn dev_dep_plugins_are_not_propagated_for_ws_members() {
                     // Note that `cairo_test` is indeed a dev dependency of `dep2`,
                     // but it's not propagated to the unit tests of `x`.
                     // Only dev dependencies of the main component should be enabled.
-                    // "cairo_test".to_string()
+                    // "cairo_test".to_string(),
+                    // "m".to_string()
                 ]
             ),
             (


### PR DESCRIPTION
fixes #2118
This problem is analog to the https://github.com/software-mansion/scarb/issues/1535 (https://github.com/software-mansion/scarb/pull/1542). 
If a package (A) that is a ws member depends on another ws member (B), and (B) depends on some cairo plugin (C) as dev dependency, test CompilationUnit of (A) will include (C) as dependency of (B), although dev dependencies of (B) should not be propagated to the test compilation of (A) (both Cairo and Plugin dependencies).   


- **Add failing test for propagation of dev dep plugins from members of ws**
- **Do not propagate plugins that are dev dependencies of ws members to packages that depend on these ws members**
