### PR TITLE
Revert proc macro server to support only v1 macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5962,7 +5962,7 @@ dependencies = [
 name = "scarb-proc-macro-server-types"
 version = "0.2.0"
 dependencies = [
- "cairo-lang-macro 0.2.0",
+ "cairo-lang-macro 0.1.1",
  "serde",
  "serde_json",
 ]

--- a/scarb/src/ops/proc_macro_server/methods/defined_macros.rs
+++ b/scarb/src/ops/proc_macro_server/methods/defined_macros.rs
@@ -9,7 +9,7 @@ use scarb_proc_macro_server_types::methods::defined_macros::{
 
 use super::Handler;
 use crate::compiler::plugin::collection::WorkspaceProcMacros;
-use crate::compiler::plugin::proc_macro::DeclaredProcMacroInstances;
+use crate::compiler::plugin::proc_macro::{DeclaredProcMacroInstances, ProcMacroApiVersion};
 
 impl Handler for DefinedMacros {
     fn handle(
@@ -22,6 +22,7 @@ impl Handler for DefinedMacros {
             .flat_map(|(component, plugin)| {
                 plugin
                     .iter()
+                    .filter(|p| p.api_version() == ProcMacroApiVersion::V1)
                     .map(|plugin| {
                         let attributes = plugin.declared_attributes_without_executables();
                         let inline_macros = plugin.declared_inline_macros();

--- a/scarb/src/ops/proc_macro_server/methods/expand_derive.rs
+++ b/scarb/src/ops/proc_macro_server/methods/expand_derive.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use cairo_lang_macro::TokenStream;
+use cairo_lang_macro_v1::TokenStream;
 use convert_case::{Case, Casing};
 use scarb_proc_macro_server_types::methods::{ProcMacroResult, expand::ExpandDerive};
 
@@ -21,10 +21,9 @@ impl Handler for ExpandDerive {
             context,
             derives,
             item,
-            call_site,
         } = params;
 
-        let mut derived_code = TokenStream::empty();
+        let mut derived_code = String::new();
         let mut all_diagnostics = vec![];
 
         for derive in derives {
@@ -35,9 +34,9 @@ impl Handler for ExpandDerive {
                 .as_ref()
                 .and_then(|v| {
                     v.iter()
-                        .find(|a| a.api_version() == ProcMacroApiVersion::V2)
+                        .find(|a| a.api_version() == ProcMacroApiVersion::V1)
                 })
-                .with_context(|| format!("No macros found in scope: {context:?}"))?;
+                .with_context(|| format!("No macros found in scope {context:?}"))?;
 
             let instance = plugin
                 .instances()
@@ -46,23 +45,18 @@ impl Handler for ExpandDerive {
                 .with_context(|| format!("Unsupported derive macro: {derive}"))?;
 
             let result = instance
-                .try_v2()
-                .expect("procedural macro using v1 api used in a context expecting v2 api")
-                .generate_code(
-                    expansion.name.clone(),
-                    call_site.clone(),
-                    TokenStream::empty(),
-                    item.clone(),
-                );
+                .try_v1()
+                .expect("procedural macro using v2 api used in a context expecting v1 api")
+                .generate_code(expansion.name.clone(), TokenStream::empty(), item.clone());
 
             // Register diagnostics.
             all_diagnostics.extend(result.diagnostics);
             // Add generated code.
-            derived_code.tokens.extend(result.token_stream.tokens);
+            derived_code.push_str(&result.token_stream.to_string());
         }
 
         Ok(ProcMacroResult {
-            token_stream: derived_code,
+            token_stream: TokenStream::new(derived_code),
             diagnostics: all_diagnostics,
         })
     }

--- a/scarb/src/ops/proc_macro_server/methods/expand_inline.rs
+++ b/scarb/src/ops/proc_macro_server/methods/expand_inline.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use cairo_lang_macro::TokenStream;
+use cairo_lang_macro_v1::TokenStream;
 use scarb_proc_macro_server_types::methods::{ProcMacroResult, expand::ExpandInline};
 
 use super::Handler;
@@ -17,7 +17,6 @@ impl Handler for ExpandInline {
             context,
             name,
             args,
-            call_site,
         } = params;
 
         let plugin = workspace_macros.get(&context.component);
@@ -25,7 +24,7 @@ impl Handler for ExpandInline {
             .as_ref()
             .and_then(|v| {
                 v.iter()
-                    .find(|a| a.api_version() == ProcMacroApiVersion::V2)
+                    .find(|a| a.api_version() == ProcMacroApiVersion::V1)
             })
             .with_context(|| format!("No macros found in scope: {context:?}"))?;
 
@@ -42,9 +41,9 @@ impl Handler for ExpandInline {
             .with_context(|| format!("Unsupported inline macro: {name}"))?;
 
         let result = instance
-            .try_v2()
-            .expect("procedural macro using v1 api used in a context expecting v2 api")
-            .generate_code(name.into(), call_site, TokenStream::empty(), args);
+            .try_v1()
+            .expect("procedural macro using v2 api used in a context expecting v1 api")
+            .generate_code(name.into(), TokenStream::empty(), args);
 
         Ok(ProcMacroResult {
             token_stream: result.token_stream,

--- a/scarb/tests/proc_macro_v1_prebuilt.rs
+++ b/scarb/tests/proc_macro_v1_prebuilt.rs
@@ -1,10 +1,14 @@
 use assert_fs::TempDir;
 use assert_fs::fixture::{ChildPath, FileWriteStr, PathCreateDir};
 use assert_fs::prelude::PathChild;
+use cairo_lang_macro_v1::TokenStream;
 use indoc::indoc;
 use libloading::library_filename;
+use scarb_proc_macro_server_types::methods::expand::{ExpandInline, ExpandInlineMacroParams};
+use scarb_proc_macro_server_types::scope::ProcMacroScope;
 use scarb_test_support::cairo_plugin_project_builder::CairoPluginProjectBuilder;
 use scarb_test_support::command::Scarb;
+use scarb_test_support::proc_macro_server::ProcMacroClient;
 use scarb_test_support::project_builder::ProjectBuilder;
 use scarb_test_support::workspace_builder::WorkspaceBuilder;
 use snapbox::cmd::Command;
@@ -192,4 +196,40 @@ fn compile_with_invalid_prebuilt_plugins() {
             [..]Compiling hello v1.0.0 ([..]Scarb.toml)
             [..] Finished `dev` profile target(s) in [..]
         "#});
+}
+
+#[test]
+fn load_prebuilt_proc_macros() {
+    let t = TempDir::new().unwrap();
+    proc_macro_example(&t.child("dep"));
+
+    let project = t.child("test_package");
+
+    ProjectBuilder::start()
+        .name("test_package")
+        .version("1.0.0")
+        .lib_cairo("")
+        .dep("proc_macro_example", t.child("dep"))
+        .manifest_extra(indoc! {r#"
+            [tool.scarb]
+            allow-prebuilt-plugins = ["proc_macro_example"]
+        "#})
+        .build(&project);
+
+    let mut proc_macro_client = ProcMacroClient::new_without_cargo(&project);
+
+    let component = proc_macro_client
+        .defined_macros_for_package("test_package")
+        .component;
+
+    let response = proc_macro_client
+        .request_and_wait::<ExpandInline>(ExpandInlineMacroParams {
+            context: ProcMacroScope { component },
+            name: "some".to_string(),
+            args: TokenStream::new("42".to_string()),
+        })
+        .unwrap();
+
+    assert_eq!(response.diagnostics, vec![]);
+    assert_eq!(response.token_stream, TokenStream::new("42".to_string()));
 }

--- a/scarb/tests/proc_macro_v1_server.rs
+++ b/scarb/tests/proc_macro_v1_server.rs
@@ -148,7 +148,6 @@ fn expand_inline() {
         #[inline_macro]
         pub fn replace_all_15_with_25(token_stream: TokenStream) -> ProcMacroResult {
             let content = token_stream.to_string().replace("15", "25");
-            let span = TextSpan { start: 0, end: content.len() as u32 };
             ProcMacroResult::new(TokenStream::new(content))
         }
     "#;

--- a/scarb/tests/proc_macro_v1_server.rs
+++ b/scarb/tests/proc_macro_v1_server.rs
@@ -1,6 +1,6 @@
 use assert_fs::TempDir;
 use assert_fs::prelude::PathChild;
-use cairo_lang_macro::{TextSpan, Token, TokenStream, TokenTree};
+use cairo_lang_macro_v1::TokenStream;
 use scarb_proc_macro_server_types::methods::expand::ExpandAttribute;
 use scarb_proc_macro_server_types::methods::expand::ExpandAttributeParams;
 use scarb_proc_macro_server_types::methods::expand::ExpandDerive;
@@ -10,7 +10,7 @@ use scarb_proc_macro_server_types::methods::expand::ExpandInlineMacroParams;
 use scarb_proc_macro_server_types::scope::ProcMacroScope;
 use scarb_test_support::cairo_plugin_project_builder::CairoPluginProjectBuilder;
 use scarb_test_support::proc_macro_server::ProcMacroClient;
-use scarb_test_support::proc_macro_server::SIMPLE_MACROS_V2;
+use scarb_test_support::proc_macro_server::SIMPLE_MACROS_V1;
 use scarb_test_support::project_builder::ProjectBuilder;
 
 #[test]
@@ -18,8 +18,8 @@ fn defined_macros() {
     let t = TempDir::new().unwrap();
     let plugin_package = t.child("some");
 
-    CairoPluginProjectBuilder::default()
-        .lib_rs(SIMPLE_MACROS_V2)
+    CairoPluginProjectBuilder::default_v1()
+        .lib_rs(SIMPLE_MACROS_V1)
         .build(&plugin_package);
 
     let project = t.child("test_package");
@@ -58,19 +58,12 @@ fn expand_attribute() {
 
             let output = input.replace(name, "very_new_name");
 
-            let span = TextSpan { start: 0, end: output.len() as u32 };
-            ProcMacroResult::new(
-                TokenStream::new(vec![
-                    TokenTree::Ident(
-                        Token::new(output, span)
-                    )
-                ])
-            )
+            ProcMacroResult::new(TokenStream::new(output))
         }}
     "##;
 
-    CairoPluginProjectBuilder::default()
-        .lib_rs(format!("{SIMPLE_MACROS_V2}\n{rename_to_very_new_name}"))
+    CairoPluginProjectBuilder::default_v1()
+        .lib_rs(format!("{SIMPLE_MACROS_V1}\n{rename_to_very_new_name}"))
         .add_dep(r#"regex = "1.11.1""#)
         .build(&plugin_package);
 
@@ -94,11 +87,7 @@ fn expand_attribute() {
             context: ProcMacroScope { component },
             attr: "rename_to_very_new_name".to_string(),
             args: TokenStream::empty(),
-            call_site: TextSpan::new(0, 0),
-            item: TokenStream::new(vec![TokenTree::Ident(Token::new(
-                "fn some_test_fn(){}",
-                TextSpan::new(0, 0),
-            ))]),
+            item: TokenStream::new("fn some_test_fn(){}".to_string()),
         })
         .unwrap();
 
@@ -114,8 +103,8 @@ fn expand_derive() {
     let t = TempDir::new().unwrap();
     let plugin_package = t.child("some");
 
-    CairoPluginProjectBuilder::default()
-        .lib_rs(SIMPLE_MACROS_V2)
+    CairoPluginProjectBuilder::default_v1()
+        .lib_rs(SIMPLE_MACROS_V1)
         .build(&plugin_package);
 
     let project = t.child("test_package");
@@ -133,16 +122,12 @@ fn expand_derive() {
         .defined_macros_for_package("test_package")
         .component;
 
-    let item = TokenStream::new(vec![TokenTree::Ident(Token::new(
-        "fn some_test_fn(){}",
-        TextSpan::new(0, 0),
-    ))]);
+    let item = TokenStream::new("fn some_test_fn(){}".to_string());
 
     let response = proc_macro_client
         .request_and_wait::<ExpandDerive>(ExpandDeriveParams {
             context: ProcMacroScope { component },
             derives: vec!["some_derive".to_string()],
-            call_site: TextSpan::new(0, 0),
             item,
         })
         .unwrap();
@@ -164,18 +149,12 @@ fn expand_inline() {
         pub fn replace_all_15_with_25(token_stream: TokenStream) -> ProcMacroResult {
             let content = token_stream.to_string().replace("15", "25");
             let span = TextSpan { start: 0, end: content.len() as u32 };
-            ProcMacroResult::new(
-                TokenStream::new(vec![
-                    TokenTree::Ident(
-                        Token::new(content, span)
-                    )
-                ])
-            )
+            ProcMacroResult::new(TokenStream::new(content))
         }
     "#;
 
-    CairoPluginProjectBuilder::default()
-        .lib_rs(format!("{SIMPLE_MACROS_V2}\n{replace_all_15_with_25}"))
+    CairoPluginProjectBuilder::default_v1()
+        .lib_rs(format!("{SIMPLE_MACROS_V1}\n{replace_all_15_with_25}"))
         .build(&plugin_package);
 
     let project = t.child("test_package");
@@ -197,11 +176,9 @@ fn expand_inline() {
         .request_and_wait::<ExpandInline>(ExpandInlineMacroParams {
             context: ProcMacroScope { component },
             name: "replace_all_15_with_25".to_string(),
-            call_site: TextSpan::new(0, 0),
-            args: TokenStream::new(vec![TokenTree::Ident(Token::new(
-                "struct A { field: 15 , other_field: macro_call!(12)}",
-                TextSpan::new(0, 0),
-            ))]),
+            args: TokenStream::new(
+                "struct A { field: 15 , other_field: macro_call!(12)}".to_string(),
+            ),
         })
         .unwrap();
 

--- a/utils/scarb-proc-macro-server-types/Cargo.toml
+++ b/utils/scarb-proc-macro-server-types/Cargo.toml
@@ -10,6 +10,6 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-cairo-lang-macro = { path = "../../plugins/cairo-lang-macro", version = "0.2", features = ["serde"] }
+cairo-lang-macro = { version = "0.1", features = ["serde"] }
 serde.workspace = true
 serde_json.workspace = true

--- a/utils/scarb-proc-macro-server-types/src/methods/expand.rs
+++ b/utils/scarb-proc-macro-server-types/src/methods/expand.rs
@@ -2,7 +2,7 @@ use crate::scope::ProcMacroScope;
 
 use super::Method;
 use super::ProcMacroResult;
-use cairo_lang_macro::{TextSpan, TokenStream};
+use cairo_lang_macro::TokenStream;
 use serde::{Deserialize, Serialize};
 
 /// Parameters for expanding a specific attribute macro.
@@ -19,8 +19,6 @@ pub struct ExpandAttributeParams {
     pub args: TokenStream,
     /// The token stream representing the item on which the macro is applied.
     pub item: TokenStream,
-    // Call site span.
-    pub call_site: TextSpan,
 }
 
 /// Represents a request to expand a single attribute macro.
@@ -44,8 +42,6 @@ pub struct ExpandDeriveParams {
     pub derives: Vec<String>,
     /// The token stream of the item to which the derive macros are applied.
     pub item: TokenStream,
-    // Call site span.
-    pub call_site: TextSpan,
 }
 
 /// Represents a request to expand derive macros.
@@ -69,8 +65,6 @@ pub struct ExpandInlineMacroParams {
     pub name: String,
     /// The token stream representing arguments passed to the macro.
     pub args: TokenStream,
-    // Call site span.
-    pub call_site: TextSpan,
 }
 
 /// Represents a request to expand a single inline macro.

--- a/utils/scarb-test-support/src/proc_macro_server.rs
+++ b/utils/scarb-test-support/src/proc_macro_server.rs
@@ -19,6 +19,34 @@ use std::process::ChildStdin;
 use std::process::ChildStdout;
 use std::process::Stdio;
 
+pub const SIMPLE_MACROS_V1: &str = r#"
+use cairo_lang_macro::{
+    ProcMacroResult,
+    TokenStream,
+    attribute_macro,
+    inline_macro,
+    derive_macro,
+    executable_attribute
+};
+
+executable_attribute!("some_executable");
+
+#[attribute_macro]
+pub fn some(_attr: TokenStream, token_stream: TokenStream) -> ProcMacroResult {
+    ProcMacroResult::new(token_stream)
+}
+
+#[inline_macro]
+pub fn inline_some(token_stream: TokenStream) -> ProcMacroResult {
+    ProcMacroResult::new(token_stream)
+}
+
+#[derive_macro]
+fn some_derive(_token_stream: TokenStream)-> ProcMacroResult {
+    ProcMacroResult::new(TokenStream::new("impl SomeImpl of SomeTrait {}".to_string()))
+}
+"#;
+
 pub const SIMPLE_MACROS_V2: &str = r#"
 use cairo_lang_macro::{
     ProcMacroResult,


### PR DESCRIPTION
This way we can merge support for v2 macros into main without waiting for @Arcticae changes in LS.

Add v1 macro server tests

Revert proc macro server to support only v1 macros