### PR TITLE
Add `panic-backtrace` flag

### DIFF
--- a/scarb/src/compiler/db.rs
+++ b/scarb/src/compiler/db.rs
@@ -59,6 +59,9 @@ pub(crate) fn build_scarb_root_database(
     if !unit.compiler_config.enable_gas {
         b.skip_auto_withdraw_gas();
     }
+    if unit.compiler_config.panic_backtrace {
+        b.with_panic_backtrace();
+    }
     let mut db = b.build()?;
 
     apply_plugins(&mut db, plugins);

--- a/scarb/src/core/manifest/compiler_config.rs
+++ b/scarb/src/core/manifest/compiler_config.rs
@@ -32,6 +32,8 @@ pub struct ManifestCompilerConfig {
     /// Used by [cairo-coverage](https://github.com/software-mansion/cairo-coverage).
     /// This feature is unstable and is subject to change.
     pub unstable_add_statements_code_locations_debug_info: bool,
+    /// Whether to add panic backtrace handling to the generated code.
+    pub panic_backtrace: bool,
     // Inlining strategy.
     pub inlining_strategy: InliningStrategy,
 }
@@ -105,6 +107,7 @@ impl DefaultForProfile for ManifestCompilerConfig {
             enable_gas: true,
             unstable_add_statements_functions_debug_info: false,
             unstable_add_statements_code_locations_debug_info: false,
+            panic_backtrace: false,
             inlining_strategy: InliningStrategy::default(),
         }
     }
@@ -122,6 +125,7 @@ impl From<ManifestCompilerConfig> for TomlCairo {
             unstable_add_statements_code_locations_debug_info: Some(
                 config.unstable_add_statements_code_locations_debug_info,
             ),
+            panic_backtrace: Some(config.panic_backtrace),
             inlining_strategy: Some(config.inlining_strategy),
         }
     }

--- a/scarb/src/core/manifest/toml_manifest.rs
+++ b/scarb/src/core/manifest/toml_manifest.rs
@@ -346,6 +346,8 @@ pub struct TomlCairo {
     /// Used by [cairo-coverage](https://github.com/software-mansion/cairo-coverage).
     /// This feature is unstable and is subject to change.
     pub unstable_add_statements_code_locations_debug_info: Option<bool>,
+    /// Whether to add panic backtrace handling to the generated code.
+    pub panic_backtrace: Option<bool>,
     /// Inlining strategy.
     pub inlining_strategy: Option<InliningStrategy>,
 }
@@ -923,6 +925,9 @@ impl TomlManifest {
             {
                 compiler_config.unstable_add_statements_code_locations_debug_info =
                     unstable_add_statements_code_locations_debug_info;
+            }
+            if let Some(panic_backtrace) = cairo.panic_backtrace {
+                compiler_config.panic_backtrace = panic_backtrace;
             }
         }
         Ok(compiler_config)

--- a/scarb/tests/metadata.rs
+++ b/scarb/tests/metadata.rs
@@ -1700,7 +1700,8 @@ fn compiler_config_collected_properly() {
             "inlining_strategy": "avoid",
             "sierra_replace_ids": false,
             "unstable_add_statements_code_locations_debug_info": false,
-            "unstable_add_statements_functions_debug_info": false
+            "unstable_add_statements_functions_debug_info": false,
+            "panic_backtrace": false
         })
     );
 }
@@ -1755,7 +1756,8 @@ fn compiler_config_collected_properly_in_workspace() {
             "inlining_strategy": "avoid",
             "sierra_replace_ids": true,
             "unstable_add_statements_code_locations_debug_info": false,
-            "unstable_add_statements_functions_debug_info": false
+            "unstable_add_statements_functions_debug_info": false,
+            "panic_backtrace": false
         })
     );
 }
@@ -1797,7 +1799,8 @@ fn profile_can_override_cairo_section() {
             "inlining_strategy": "default",
             "sierra_replace_ids": true,
             "unstable_add_statements_code_locations_debug_info": false,
-            "unstable_add_statements_functions_debug_info": false
+            "unstable_add_statements_functions_debug_info": false,
+            "panic_backtrace": false
         })
     );
 }
@@ -1839,7 +1842,8 @@ fn cairo_section_overrides_profile_defaults() {
             "inlining_strategy": "default",
             "sierra_replace_ids": true,
             "unstable_add_statements_code_locations_debug_info": false,
-            "unstable_add_statements_functions_debug_info": false
+            "unstable_add_statements_functions_debug_info": false,
+            "panic_backtrace": false
         })
     );
 }
@@ -1878,7 +1882,8 @@ fn can_specify_inlining_strategy_by_weight() {
             "inlining_strategy": 12,
             "sierra_replace_ids": true,
             "unstable_add_statements_code_locations_debug_info": false,
-            "unstable_add_statements_functions_debug_info": false
+            "unstable_add_statements_functions_debug_info": false,
+            "panic_backtrace": false
         })
     );
 }

--- a/website/docs/reference/manifest.md
+++ b/website/docs/reference/manifest.md
@@ -357,6 +357,17 @@ inlining-strategy = 18
 > Please use with caution, only if your tooling requires that.
 > You can use profile settings overwriting, for more granular control of which builds use the avoid strategy.
 
+### `panic-backtrace`
+
+If enabled, during the project compilation Scarb will add panic backtrace handling to the generated code.
+This can be useful for debugging purposes.
+By default, this flag is set to `false`, as it won't be available on StarkNet.
+
+```toml
+[cairo]
+panic-backtrace = true
+```
+
 ### `unstable-add-statements-functions-debug-info`
 
 > [!WARNING]

--- a/website/docs/reference/manifest.md
+++ b/website/docs/reference/manifest.md
@@ -365,7 +365,7 @@ By default, this flag is set to `false`, as it won't be available on StarkNet.
 
 ```toml
 [cairo]
-panic-backtrace = true
+panic-backtrace = false
 ```
 
 ### `unstable-add-statements-functions-debug-info`

--- a/website/docs/reference/manifest.md
+++ b/website/docs/reference/manifest.md
@@ -361,7 +361,7 @@ inlining-strategy = 18
 
 If enabled, during the project compilation Scarb will add panic backtrace handling to the generated code.
 This can be useful for debugging purposes.
-By default, this flag is set to `false`, as it won't be available on StarkNet.
+By default, this flag is set to `false`, as it won't be available on Starknet.
 
 ```toml
 [cairo]


### PR DESCRIPTION
Related https://github.com/foundry-rs/starknet-foundry/issues/3070

This PR allows enabling `panic-backtrace`, which was added in [#7377](https://github.com/starkware-libs/cairo/pull/7377).  
This new hint is foundational for `forge backtrace` when handling panics in Cairo.