### PR TITLE
feat: doc sematically sorted modules, interactive path

### DIFF
--- a/extensions/scarb-doc/src/docs_generation/markdown.rs
+++ b/extensions/scarb-doc/src/docs_generation/markdown.rs
@@ -40,7 +40,10 @@ impl MarkdownContent {
     pub fn from_crate(package_information: &PackageInformation) -> Result<Self> {
         let top_level_items = collect_all_top_level_items(&package_information.crate_);
 
-        let summary_file_content = generate_summary_file_content(&top_level_items)?;
+        let summary_file_content = generate_summary_file_content(
+            &package_information.crate_.root_module,
+            &top_level_items,
+        )?;
         let TopLevelItems {
             modules,
             constants,

--- a/extensions/scarb-doc/src/docs_generation/markdown/context.rs
+++ b/extensions/scarb-doc/src/docs_generation/markdown/context.rs
@@ -69,6 +69,6 @@ impl<'a> MarkdownGenerationContext<'a> {
     }
 }
 
-fn path_to_file_link(path: &str) -> String {
+pub fn path_to_file_link(path: &str) -> String {
     format!("./{}.md", path.replace("::", "-"))
 }

--- a/extensions/scarb-doc/src/docs_generation/markdown/traits.rs
+++ b/extensions/scarb-doc/src/docs_generation/markdown/traits.rs
@@ -205,8 +205,8 @@ impl MarkdownDocItem for Trait {
     }
 }
 
-/// Takes items, and appends for each of them a path, that was trimmed based on the common prefix of all of the items,
-/// cthat share the same name.
+/// Takes items, and appends for each of them a path, that was trimmed based on the common prefix of all the items,
+/// that share the same name.
 pub fn mark_duplicated_item_with_relative_path<'a, T: TopLevelMarkdownDocItem + 'a>(
     items: &'a [&'a T],
 ) -> Vec<(&'a &'a T, Option<String>)> {
@@ -327,8 +327,8 @@ fn generate_markdown_from_item_data(
 
     writeln!(
         &mut markdown,
-        "Fully qualified path: `{}`\n",
-        doc_item.full_path()
+        "Fully qualified path: {}\n",
+        get_linked_path(doc_item.full_path())
     )?;
 
     if let Some(sig) = &doc_item.signature() {
@@ -342,6 +342,21 @@ fn generate_markdown_from_item_data(
         }
     }
     Ok(markdown)
+}
+
+fn get_linked_path(full_path: &str) -> String {
+    let path_items = full_path.split("::").collect::<Vec<_>>();
+    let mut result: Vec<String> = Vec::new();
+    let mut current_path = String::new();
+    for element in path_items {
+        if !current_path.is_empty() {
+            current_path.push('-');
+        }
+        current_path.push_str(element);
+        let formatted = format!("[{}](./{}.md)", element, current_path);
+        result.push(formatted);
+    }
+    result.join("::")
 }
 
 fn format_signature(input: &str, links: &[DocLocationLink]) -> String {

--- a/extensions/scarb-doc/tests/data/duplicated_item_names/src/SUMMARY.md
+++ b/extensions/scarb-doc/tests/data/duplicated_item_names/src/SUMMARY.md
@@ -1,11 +1,10 @@
 # Summary
 
+---
 - [Modules](./modules.md)
-
   - [hello_world](./hello_world.md)
-
-  - [sub_module](./hello_world-sub_module.md)
-
+    - [sub_module](./hello_world-sub_module.md)
+---
 - [Free functions](./free_functions.md)
 
   - [main](./hello_world-main.md)
@@ -16,12 +15,14 @@
 
   - [sub_module::duplicated_function_name](./hello_world-sub_module-duplicated_function_name.md)
 
+---
 - [Enums](./enums.md)
 
   - [DuplicatedEnumName](./hello_world-DuplicatedEnumName.md)
 
   - [sub_module::DuplicatedEnumName](./hello_world-sub_module-DuplicatedEnumName.md)
 
+---
 - [Traits](./traits.md)
 
   - [DuplicatedTraitName](./hello_world-DuplicatedTraitName.md)

--- a/extensions/scarb-doc/tests/data/duplicated_item_names/src/hello_world-DuplicatedEnumName.md
+++ b/extensions/scarb-doc/tests/data/duplicated_item_names/src/hello_world-DuplicatedEnumName.md
@@ -1,6 +1,6 @@
 # DuplicatedEnumName
 
-Fully qualified path: `hello_world::DuplicatedEnumName`
+Fully qualified path: [hello_world](./hello_world.md)::[DuplicatedEnumName](./hello_world-DuplicatedEnumName.md)
 
 <pre><code class="language-rust">enum DuplicatedEnumName {}</code></pre>
 

--- a/extensions/scarb-doc/tests/data/duplicated_item_names/src/hello_world-DuplicatedTraitName.md
+++ b/extensions/scarb-doc/tests/data/duplicated_item_names/src/hello_world-DuplicatedTraitName.md
@@ -1,6 +1,6 @@
 # DuplicatedTraitName
 
-Fully qualified path: `hello_world::DuplicatedTraitName`
+Fully qualified path: [hello_world](./hello_world.md)::[DuplicatedTraitName](./hello_world-DuplicatedTraitName.md)
 
 <pre><code class="language-rust">trait DuplicatedTraitName</code></pre>
 

--- a/extensions/scarb-doc/tests/data/duplicated_item_names/src/hello_world-duplicated_function_name.md
+++ b/extensions/scarb-doc/tests/data/duplicated_item_names/src/hello_world-duplicated_function_name.md
@@ -1,6 +1,6 @@
 # duplicated_function_name
 
-Fully qualified path: `hello_world::duplicated_function_name`
+Fully qualified path: [hello_world](./hello_world.md)::[duplicated_function_name](./hello_world-duplicated_function_name.md)
 
 <pre><code class="language-rust">fn duplicated_function_name()</code></pre>
 

--- a/extensions/scarb-doc/tests/data/duplicated_item_names/src/hello_world-main.md
+++ b/extensions/scarb-doc/tests/data/duplicated_item_names/src/hello_world-main.md
@@ -1,6 +1,6 @@
 # main
 
-Fully qualified path: `hello_world::main`
+Fully qualified path: [hello_world](./hello_world.md)::[main](./hello_world-main.md)
 
 <pre><code class="language-rust">fn main()</code></pre>
 

--- a/extensions/scarb-doc/tests/data/duplicated_item_names/src/hello_world-sub_module-DuplicatedEnumName.md
+++ b/extensions/scarb-doc/tests/data/duplicated_item_names/src/hello_world-sub_module-DuplicatedEnumName.md
@@ -1,6 +1,6 @@
 # DuplicatedEnumName
 
-Fully qualified path: `hello_world::sub_module::DuplicatedEnumName`
+Fully qualified path: [hello_world](./hello_world.md)::[sub_module](./hello_world-sub_module.md)::[DuplicatedEnumName](./hello_world-sub_module-DuplicatedEnumName.md)
 
 <pre><code class="language-rust">enum DuplicatedEnumName {}</code></pre>
 

--- a/extensions/scarb-doc/tests/data/duplicated_item_names/src/hello_world-sub_module-DuplicatedTraitName.md
+++ b/extensions/scarb-doc/tests/data/duplicated_item_names/src/hello_world-sub_module-DuplicatedTraitName.md
@@ -1,6 +1,6 @@
 # DuplicatedTraitName
 
-Fully qualified path: `hello_world::sub_module::DuplicatedTraitName`
+Fully qualified path: [hello_world](./hello_world.md)::[sub_module](./hello_world-sub_module.md)::[DuplicatedTraitName](./hello_world-sub_module-DuplicatedTraitName.md)
 
 <pre><code class="language-rust">trait DuplicatedTraitName</code></pre>
 

--- a/extensions/scarb-doc/tests/data/duplicated_item_names/src/hello_world-sub_module-duplicated_function_name.md
+++ b/extensions/scarb-doc/tests/data/duplicated_item_names/src/hello_world-sub_module-duplicated_function_name.md
@@ -1,6 +1,6 @@
 # duplicated_function_name
 
-Fully qualified path: `hello_world::sub_module::duplicated_function_name`
+Fully qualified path: [hello_world](./hello_world.md)::[sub_module](./hello_world-sub_module.md)::[duplicated_function_name](./hello_world-sub_module-duplicated_function_name.md)
 
 <pre><code class="language-rust">fn duplicated_function_name()</code></pre>
 

--- a/extensions/scarb-doc/tests/data/duplicated_item_names/src/hello_world-sub_module.md
+++ b/extensions/scarb-doc/tests/data/duplicated_item_names/src/hello_world-sub_module.md
@@ -1,6 +1,6 @@
 # sub_module
 
-Fully qualified path: `hello_world::sub_module`
+Fully qualified path: [hello_world](./hello_world.md)::[sub_module](./hello_world-sub_module.md)
 
 ## Free functions
 

--- a/extensions/scarb-doc/tests/data/duplicated_item_names/src/hello_world-unique_function_name.md
+++ b/extensions/scarb-doc/tests/data/duplicated_item_names/src/hello_world-unique_function_name.md
@@ -1,6 +1,6 @@
 # unique_function_name
 
-Fully qualified path: `hello_world::unique_function_name`
+Fully qualified path: [hello_world](./hello_world.md)::[unique_function_name](./hello_world-unique_function_name.md)
 
 <pre><code class="language-rust">fn unique_function_name()</code></pre>
 

--- a/extensions/scarb-doc/tests/data/duplicated_item_names/src/hello_world.md
+++ b/extensions/scarb-doc/tests/data/duplicated_item_names/src/hello_world.md
@@ -1,6 +1,6 @@
 # hello_world
 
-Fully qualified path: `hello_world`
+Fully qualified path: [hello_world](./hello_world.md)
 
 ## Modules
 

--- a/extensions/scarb-doc/tests/data/hello_world_no_features/src/SUMMARY.md
+++ b/extensions/scarb-doc/tests/data/hello_world_no_features/src/SUMMARY.md
@@ -1,15 +1,15 @@
 # Summary
 
+---
 - [Modules](./modules.md)
-
   - [hello_world](./hello_world.md)
-
-  - [tests](./hello_world-tests.md)
-
+    - [tests](./hello_world-tests.md)
+---
 - [Constants](./constants.md)
 
   - [FOO](./hello_world-FOO.md)
 
+---
 - [Free functions](./free_functions.md)
 
   - [main](./hello_world-main.md)
@@ -18,22 +18,27 @@
 
   - [it_works](./hello_world-tests-it_works.md)
 
+---
 - [Structs](./structs.md)
 
   - [Circle](./hello_world-Circle.md)
 
+---
 - [Enums](./enums.md)
 
   - [Color](./hello_world-Color.md)
 
+---
 - [Type aliases](./type_aliases.md)
 
   - [Pair](./hello_world-Pair.md)
 
+---
 - [Traits](./traits.md)
 
   - [Shape](./hello_world-Shape.md)
 
+---
 - [Impls](./impls.md)
 
   - [CircleShape](./hello_world-CircleShape.md)

--- a/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-Circle.md
+++ b/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-Circle.md
@@ -2,7 +2,7 @@
 
 Circle struct with radius field
 
-Fully qualified path: `hello_world::Circle`
+Fully qualified path: [hello_world](./hello_world.md)::[Circle](./hello_world-Circle.md)
 
 <pre><code class="language-rust">#[derive(Drop, Serde, PartialEq)]
 struct Circle {
@@ -15,7 +15,7 @@ struct Circle {
 
 Radius of the circle
 
-Fully qualified path: `hello_world::Circle::radius`
+Fully qualified path: [hello_world](./hello_world.md)::[Circle](./hello_world-Circle.md)::[radius](./hello_world-Circle-radius.md)
 
 <pre><code class="language-rust">radius: u32</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-CircleDrop.md
+++ b/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-CircleDrop.md
@@ -1,6 +1,6 @@
 # CircleDrop
 
-Fully qualified path: `hello_world::CircleDrop`
+Fully qualified path: [hello_world](./hello_world.md)::[CircleDrop](./hello_world-CircleDrop.md)
 
 <pre><code class="language-rust">impl CircleDrop of Drop&lt;<a href="hello_world-Circle.html">Circle</a>&gt;;</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-CirclePartialEq.md
+++ b/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-CirclePartialEq.md
@@ -1,6 +1,6 @@
 # CirclePartialEq
 
-Fully qualified path: `hello_world::CirclePartialEq`
+Fully qualified path: [hello_world](./hello_world.md)::[CirclePartialEq](./hello_world-CirclePartialEq.md)
 
 <pre><code class="language-rust">impl CirclePartialEq of PartialEq&lt;<a href="hello_world-Circle.html">Circle</a>&gt;;</code></pre>
 
@@ -8,7 +8,7 @@ Fully qualified path: `hello_world::CirclePartialEq`
 
 ### eq
 
-Fully qualified path: `hello_world::CirclePartialEq::eq`
+Fully qualified path: [hello_world](./hello_world.md)::[CirclePartialEq](./hello_world-CirclePartialEq.md)::[eq](./hello_world-CirclePartialEq-eq.md)
 
 <pre><code class="language-rust">fn eq(lhs: Circle, rhs: Circle) -&gt; bool</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-CircleSerde.md
+++ b/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-CircleSerde.md
@@ -1,6 +1,6 @@
 # CircleSerde
 
-Fully qualified path: `hello_world::CircleSerde`
+Fully qualified path: [hello_world](./hello_world.md)::[CircleSerde](./hello_world-CircleSerde.md)
 
 <pre><code class="language-rust">impl CircleSerde of Serde&lt;<a href="hello_world-Circle.html">Circle</a>&gt;;</code></pre>
 
@@ -8,14 +8,14 @@ Fully qualified path: `hello_world::CircleSerde`
 
 ### serialize
 
-Fully qualified path: `hello_world::CircleSerde::serialize`
+Fully qualified path: [hello_world](./hello_world.md)::[CircleSerde](./hello_world-CircleSerde.md)::[serialize](./hello_world-CircleSerde-serialize.md)
 
 <pre><code class="language-rust">fn serialize(self: Circle, ref output: Array&lt;felt252&gt;)</code></pre>
 
 
 ### deserialize
 
-Fully qualified path: `hello_world::CircleSerde::deserialize`
+Fully qualified path: [hello_world](./hello_world.md)::[CircleSerde](./hello_world-CircleSerde.md)::[deserialize](./hello_world-CircleSerde-deserialize.md)
 
 <pre><code class="language-rust">fn deserialize(ref serialized: Span&lt;felt252&gt;) -&gt; Option&lt;Circle&gt;</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-CircleShape.md
+++ b/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-CircleShape.md
@@ -2,7 +2,7 @@
 
 Implementation of the Shape trait for Circle
 
-Fully qualified path: `hello_world::CircleShape`
+Fully qualified path: [hello_world](./hello_world.md)::[CircleShape](./hello_world-CircleShape.md)
 
 <pre><code class="language-rust">impl CircleShape of Shape&lt;<a href="hello_world-Circle.html">Circle</a>&gt;;</code></pre>
 
@@ -12,7 +12,7 @@ Fully qualified path: `hello_world::CircleShape`
 
 Shape constant
 
-Fully qualified path: `hello_world::CircleShape::SHAPE_CONST`
+Fully qualified path: [hello_world](./hello_world.md)::[CircleShape](./hello_world-CircleShape.md)::[SHAPE_CONST](./hello_world-CircleShape-SHAPE_CONST.md)
 
 <pre><code class="language-rust">const SHAPE_CONST: felt252 = &apos;xyz&apos;;</code></pre>
 
@@ -23,7 +23,7 @@ Fully qualified path: `hello_world::CircleShape::SHAPE_CONST`
 
 Implementation of the area method for Circle
 
-Fully qualified path: `hello_world::CircleShape::area`
+Fully qualified path: [hello_world](./hello_world.md)::[CircleShape](./hello_world-CircleShape.md)::[area](./hello_world-CircleShape-area.md)
 
 <pre><code class="language-rust">fn area(self: <a href="hello_world-Circle.html">Circle</a>) -&gt; u32</code></pre>
 
@@ -34,7 +34,7 @@ Fully qualified path: `hello_world::CircleShape::area`
 
 Type alias for a pair of circles
 
-Fully qualified path: `hello_world::CircleShape::ShapePair`
+Fully qualified path: [hello_world](./hello_world.md)::[CircleShape](./hello_world-CircleShape.md)::[ShapePair](./hello_world-CircleShape-ShapePair.md)
 
 <pre><code class="language-rust">type ShapePair = (Circle, Circle);</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-Color.md
+++ b/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-Color.md
@@ -2,7 +2,7 @@
 
 Color enum with Red, Green, and Blue variants
 
-Fully qualified path: `hello_world::Color`
+Fully qualified path: [hello_world](./hello_world.md)::[Color](./hello_world-Color.md)
 
 <pre><code class="language-rust">enum Color {
     Red,
@@ -16,7 +16,7 @@ Fully qualified path: `hello_world::Color`
 
 Red color
 
-Fully qualified path: `hello_world::Color::Red`
+Fully qualified path: [hello_world](./hello_world.md)::[Color](./hello_world-Color.md)::[Red](./hello_world-Color-Red.md)
 
 <pre><code class="language-rust">Red</code></pre>
 
@@ -25,7 +25,7 @@ Fully qualified path: `hello_world::Color::Red`
 
 Green color
 
-Fully qualified path: `hello_world::Color::Green`
+Fully qualified path: [hello_world](./hello_world.md)::[Color](./hello_world-Color.md)::[Green](./hello_world-Color-Green.md)
 
 <pre><code class="language-rust">Green</code></pre>
 
@@ -34,7 +34,7 @@ Fully qualified path: `hello_world::Color::Green`
 
 Blue color
 
-Fully qualified path: `hello_world::Color::Blue`
+Fully qualified path: [hello_world](./hello_world.md)::[Color](./hello_world-Color.md)::[Blue](./hello_world-Color-Blue.md)
 
 <pre><code class="language-rust">Blue</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-FOO.md
+++ b/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-FOO.md
@@ -2,7 +2,7 @@
 
 FOO constant with value 42
 
-Fully qualified path: `hello_world::FOO`
+Fully qualified path: [hello_world](./hello_world.md)::[FOO](./hello_world-FOO.md)
 
 <pre><code class="language-rust">const FOO: u32 = 42;</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-Pair.md
+++ b/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-Pair.md
@@ -2,7 +2,7 @@
 
 Pair type alias for a tuple of two u32 values
 
-Fully qualified path: `hello_world::Pair`
+Fully qualified path: [hello_world](./hello_world.md)::[Pair](./hello_world-Pair.md)
 
 <pre><code class="language-rust">type Pair = (u32, u32);</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-Shape.md
+++ b/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-Shape.md
@@ -2,7 +2,7 @@
 
 Shape trait for objects that have an area
 
-Fully qualified path: `hello_world::Shape`
+Fully qualified path: [hello_world](./hello_world.md)::[Shape](./hello_world-Shape.md)
 
 <pre><code class="language-rust">trait Shape&lt;<a href="hello_world-Shape.html">T</a>&gt;</code></pre>
 
@@ -12,7 +12,7 @@ Fully qualified path: `hello_world::Shape`
 
 Constant for the shape type
 
-Fully qualified path: `hello_world::Shape::SHAPE_CONST`
+Fully qualified path: [hello_world](./hello_world.md)::[Shape](./hello_world-Shape.md)::[SHAPE_CONST](./hello_world-Shape-SHAPE_CONST.md)
 
 <pre><code class="language-rust">const SHAPE_CONST: felt252;</code></pre>
 
@@ -23,7 +23,7 @@ Fully qualified path: `hello_world::Shape::SHAPE_CONST`
 
 Calculate the area of the shape
 
-Fully qualified path: `hello_world::Shape::area`
+Fully qualified path: [hello_world](./hello_world.md)::[Shape](./hello_world-Shape.md)::[area](./hello_world-Shape-area.md)
 
 <pre><code class="language-rust">fn area&lt;T, T&gt;(self: T) -&gt; u32</code></pre>
 
@@ -34,7 +34,7 @@ Fully qualified path: `hello_world::Shape::area`
 
 Type alias for a pair of shapes
 
-Fully qualified path: `hello_world::Shape::ShapePair`
+Fully qualified path: [hello_world](./hello_world.md)::[Shape](./hello_world-Shape.md)::[ShapePair](./hello_world-Shape-ShapePair.md)
 
 <pre><code class="language-rust">type ShapePair;</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-fib.md
+++ b/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-fib.md
@@ -2,7 +2,7 @@
 
 Calculate the nth Fibonacci number  # Arguments * `n` - The index of the Fibonacci number to calculate
 
-Fully qualified path: `hello_world::fib`
+Fully qualified path: [hello_world](./hello_world.md)::[fib](./hello_world-fib.md)
 
 <pre><code class="language-rust">fn fib(mut n: u32) -&gt; u32</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-main.md
+++ b/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-main.md
@@ -2,7 +2,7 @@
 
 Main function that calculates the 16th Fibonacci number
 
-Fully qualified path: `hello_world::main`
+Fully qualified path: [hello_world](./hello_world.md)::[main](./hello_world-main.md)
 
 <pre><code class="language-rust">fn main() -&gt; u32</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-tests-it_works.md
+++ b/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-tests-it_works.md
@@ -2,7 +2,7 @@
 
 Really works.
 
-Fully qualified path: `hello_world::tests::it_works`
+Fully qualified path: [hello_world](./hello_world.md)::[tests](./hello_world-tests.md)::[it_works](./hello_world-tests-it_works.md)
 
 <pre><code class="language-rust">fn it_works()</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-tests.md
+++ b/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-tests.md
@@ -2,7 +2,7 @@
 
 Tests module
 
-Fully qualified path: `hello_world::tests`
+Fully qualified path: [hello_world](./hello_world.md)::[tests](./hello_world-tests.md)
 
 ## Free functions
 

--- a/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world.md
+++ b/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world.md
@@ -2,7 +2,7 @@
 
 Fibonacci sequence calculator
 
-Fully qualified path: `hello_world`
+Fully qualified path: [hello_world](./hello_world.md)
 
 ## Modules
 

--- a/extensions/scarb-doc/tests/data/hello_world_sub_package_no_features/src/SUMMARY.md
+++ b/extensions/scarb-doc/tests/data/hello_world_sub_package_no_features/src/SUMMARY.md
@@ -1,9 +1,9 @@
 # Summary
 
+---
 - [Modules](./modules.md)
-
   - [hello_world_sub_package](./hello_world_sub_package.md)
-
+---
 - [Free functions](./free_functions.md)
 
   - [test](./hello_world_sub_package-test.md)

--- a/extensions/scarb-doc/tests/data/hello_world_sub_package_no_features/src/hello_world_sub_package-main.md
+++ b/extensions/scarb-doc/tests/data/hello_world_sub_package_no_features/src/hello_world_sub_package-main.md
@@ -2,7 +2,7 @@
 
 Main function that cairo runs as a binary entrypoint.
 
-Fully qualified path: `hello_world_sub_package::main`
+Fully qualified path: [hello_world_sub_package](./hello_world_sub_package.md)::[main](./hello_world_sub_package-main.md)
 
 <pre><code class="language-rust">fn main()</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_sub_package_no_features/src/hello_world_sub_package-test.md
+++ b/extensions/scarb-doc/tests/data/hello_world_sub_package_no_features/src/hello_world_sub_package-test.md
@@ -7,7 +7,7 @@ Function that prints "test" to stdout with endline. Can invoke it like that:
     }
 ```
 
-Fully qualified path: `hello_world_sub_package::test`
+Fully qualified path: [hello_world_sub_package](./hello_world_sub_package.md)::[test](./hello_world_sub_package-test.md)
 
 <pre><code class="language-rust">fn test()</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_sub_package_no_features/src/hello_world_sub_package.md
+++ b/extensions/scarb-doc/tests/data/hello_world_sub_package_no_features/src/hello_world_sub_package.md
@@ -2,7 +2,7 @@
 
 Sub-package code (without feature)
 
-Fully qualified path: `hello_world_sub_package`
+Fully qualified path: [hello_world_sub_package](./hello_world_sub_package.md)
 
 ## Free functions
 

--- a/extensions/scarb-doc/tests/data/hello_world_sub_package_with_features/src/SUMMARY.md
+++ b/extensions/scarb-doc/tests/data/hello_world_sub_package_with_features/src/SUMMARY.md
@@ -1,9 +1,9 @@
 # Summary
 
+---
 - [Modules](./modules.md)
-
   - [hello_world_sub_package](./hello_world_sub_package.md)
-
+---
 - [Free functions](./free_functions.md)
 
   - [test](./hello_world_sub_package-test.md)

--- a/extensions/scarb-doc/tests/data/hello_world_sub_package_with_features/src/hello_world_sub_package-main.md
+++ b/extensions/scarb-doc/tests/data/hello_world_sub_package_with_features/src/hello_world_sub_package-main.md
@@ -2,7 +2,7 @@
 
 Main function that cairo runs as a binary entrypoint.
 
-Fully qualified path: `hello_world_sub_package::main`
+Fully qualified path: [hello_world_sub_package](./hello_world_sub_package.md)::[main](./hello_world_sub_package-main.md)
 
 <pre><code class="language-rust">fn main()</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_sub_package_with_features/src/hello_world_sub_package-test.md
+++ b/extensions/scarb-doc/tests/data/hello_world_sub_package_with_features/src/hello_world_sub_package-test.md
@@ -8,7 +8,7 @@ Function that prints "test" to stdout with endline. Can invoke it like that:
 ```
 This is a under feature attribute comment.
 
-Fully qualified path: `hello_world_sub_package::test`
+Fully qualified path: [hello_world_sub_package](./hello_world_sub_package.md)::[test](./hello_world_sub_package-test.md)
 
 <pre><code class="language-rust">fn test()</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_sub_package_with_features/src/hello_world_sub_package.md
+++ b/extensions/scarb-doc/tests/data/hello_world_sub_package_with_features/src/hello_world_sub_package.md
@@ -2,7 +2,7 @@
 
 Sub-package code (with feature)
 
-Fully qualified path: `hello_world_sub_package`
+Fully qualified path: [hello_world_sub_package](./hello_world_sub_package.md)
 
 ## Free functions
 

--- a/extensions/scarb-doc/tests/data/hello_world_with_features/src/SUMMARY.md
+++ b/extensions/scarb-doc/tests/data/hello_world_with_features/src/SUMMARY.md
@@ -1,15 +1,15 @@
 # Summary
 
+---
 - [Modules](./modules.md)
-
   - [hello_world](./hello_world.md)
-
-  - [tests](./hello_world-tests.md)
-
+    - [tests](./hello_world-tests.md)
+---
 - [Constants](./constants.md)
 
   - [FOO](./hello_world-FOO.md)
 
+---
 - [Free functions](./free_functions.md)
 
   - [main](./hello_world-main.md)
@@ -20,22 +20,27 @@
 
   - [it_works](./hello_world-tests-it_works.md)
 
+---
 - [Structs](./structs.md)
 
   - [Circle](./hello_world-Circle.md)
 
+---
 - [Enums](./enums.md)
 
   - [Color](./hello_world-Color.md)
 
+---
 - [Type aliases](./type_aliases.md)
 
   - [Pair](./hello_world-Pair.md)
 
+---
 - [Traits](./traits.md)
 
   - [Shape](./hello_world-Shape.md)
 
+---
 - [Impls](./impls.md)
 
   - [CircleShape](./hello_world-CircleShape.md)

--- a/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-Circle.md
+++ b/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-Circle.md
@@ -2,7 +2,7 @@
 
 Circle struct with radius field
 
-Fully qualified path: `hello_world::Circle`
+Fully qualified path: [hello_world](./hello_world.md)::[Circle](./hello_world-Circle.md)
 
 <pre><code class="language-rust">#[derive(Drop, Serde, PartialEq)]
 struct Circle {
@@ -15,7 +15,7 @@ struct Circle {
 
 Radius of the circle
 
-Fully qualified path: `hello_world::Circle::radius`
+Fully qualified path: [hello_world](./hello_world.md)::[Circle](./hello_world-Circle.md)::[radius](./hello_world-Circle-radius.md)
 
 <pre><code class="language-rust">radius: u32</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-CircleDrop.md
+++ b/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-CircleDrop.md
@@ -1,6 +1,6 @@
 # CircleDrop
 
-Fully qualified path: `hello_world::CircleDrop`
+Fully qualified path: [hello_world](./hello_world.md)::[CircleDrop](./hello_world-CircleDrop.md)
 
 <pre><code class="language-rust">impl CircleDrop of Drop&lt;<a href="hello_world-Circle.html">Circle</a>&gt;;</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-CirclePartialEq.md
+++ b/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-CirclePartialEq.md
@@ -1,6 +1,6 @@
 # CirclePartialEq
 
-Fully qualified path: `hello_world::CirclePartialEq`
+Fully qualified path: [hello_world](./hello_world.md)::[CirclePartialEq](./hello_world-CirclePartialEq.md)
 
 <pre><code class="language-rust">impl CirclePartialEq of PartialEq&lt;<a href="hello_world-Circle.html">Circle</a>&gt;;</code></pre>
 
@@ -8,7 +8,7 @@ Fully qualified path: `hello_world::CirclePartialEq`
 
 ### eq
 
-Fully qualified path: `hello_world::CirclePartialEq::eq`
+Fully qualified path: [hello_world](./hello_world.md)::[CirclePartialEq](./hello_world-CirclePartialEq.md)::[eq](./hello_world-CirclePartialEq-eq.md)
 
 <pre><code class="language-rust">fn eq(lhs: Circle, rhs: Circle) -&gt; bool</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-CircleSerde.md
+++ b/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-CircleSerde.md
@@ -1,6 +1,6 @@
 # CircleSerde
 
-Fully qualified path: `hello_world::CircleSerde`
+Fully qualified path: [hello_world](./hello_world.md)::[CircleSerde](./hello_world-CircleSerde.md)
 
 <pre><code class="language-rust">impl CircleSerde of Serde&lt;<a href="hello_world-Circle.html">Circle</a>&gt;;</code></pre>
 
@@ -8,14 +8,14 @@ Fully qualified path: `hello_world::CircleSerde`
 
 ### serialize
 
-Fully qualified path: `hello_world::CircleSerde::serialize`
+Fully qualified path: [hello_world](./hello_world.md)::[CircleSerde](./hello_world-CircleSerde.md)::[serialize](./hello_world-CircleSerde-serialize.md)
 
 <pre><code class="language-rust">fn serialize(self: Circle, ref output: Array&lt;felt252&gt;)</code></pre>
 
 
 ### deserialize
 
-Fully qualified path: `hello_world::CircleSerde::deserialize`
+Fully qualified path: [hello_world](./hello_world.md)::[CircleSerde](./hello_world-CircleSerde.md)::[deserialize](./hello_world-CircleSerde-deserialize.md)
 
 <pre><code class="language-rust">fn deserialize(ref serialized: Span&lt;felt252&gt;) -&gt; Option&lt;Circle&gt;</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-CircleShape.md
+++ b/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-CircleShape.md
@@ -2,7 +2,7 @@
 
 Implementation of the Shape trait for Circle
 
-Fully qualified path: `hello_world::CircleShape`
+Fully qualified path: [hello_world](./hello_world.md)::[CircleShape](./hello_world-CircleShape.md)
 
 <pre><code class="language-rust">impl CircleShape of Shape&lt;<a href="hello_world-Circle.html">Circle</a>&gt;;</code></pre>
 
@@ -12,7 +12,7 @@ Fully qualified path: `hello_world::CircleShape`
 
 Shape constant
 
-Fully qualified path: `hello_world::CircleShape::SHAPE_CONST`
+Fully qualified path: [hello_world](./hello_world.md)::[CircleShape](./hello_world-CircleShape.md)::[SHAPE_CONST](./hello_world-CircleShape-SHAPE_CONST.md)
 
 <pre><code class="language-rust">const SHAPE_CONST: felt252 = &apos;xyz&apos;;</code></pre>
 
@@ -23,7 +23,7 @@ Fully qualified path: `hello_world::CircleShape::SHAPE_CONST`
 
 Implementation of the area method for Circle
 
-Fully qualified path: `hello_world::CircleShape::area`
+Fully qualified path: [hello_world](./hello_world.md)::[CircleShape](./hello_world-CircleShape.md)::[area](./hello_world-CircleShape-area.md)
 
 <pre><code class="language-rust">fn area(self: <a href="hello_world-Circle.html">Circle</a>) -&gt; u32</code></pre>
 
@@ -34,7 +34,7 @@ Fully qualified path: `hello_world::CircleShape::area`
 
 Type alias for a pair of circles
 
-Fully qualified path: `hello_world::CircleShape::ShapePair`
+Fully qualified path: [hello_world](./hello_world.md)::[CircleShape](./hello_world-CircleShape.md)::[ShapePair](./hello_world-CircleShape-ShapePair.md)
 
 <pre><code class="language-rust">type ShapePair = (Circle, Circle);</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-Color.md
+++ b/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-Color.md
@@ -2,7 +2,7 @@
 
 Color enum with Red, Green, and Blue variants
 
-Fully qualified path: `hello_world::Color`
+Fully qualified path: [hello_world](./hello_world.md)::[Color](./hello_world-Color.md)
 
 <pre><code class="language-rust">enum Color {
     Red,
@@ -16,7 +16,7 @@ Fully qualified path: `hello_world::Color`
 
 Red color
 
-Fully qualified path: `hello_world::Color::Red`
+Fully qualified path: [hello_world](./hello_world.md)::[Color](./hello_world-Color.md)::[Red](./hello_world-Color-Red.md)
 
 <pre><code class="language-rust">Red</code></pre>
 
@@ -25,7 +25,7 @@ Fully qualified path: `hello_world::Color::Red`
 
 Green color
 
-Fully qualified path: `hello_world::Color::Green`
+Fully qualified path: [hello_world](./hello_world.md)::[Color](./hello_world-Color.md)::[Green](./hello_world-Color-Green.md)
 
 <pre><code class="language-rust">Green</code></pre>
 
@@ -34,7 +34,7 @@ Fully qualified path: `hello_world::Color::Green`
 
 Blue color
 
-Fully qualified path: `hello_world::Color::Blue`
+Fully qualified path: [hello_world](./hello_world.md)::[Color](./hello_world-Color.md)::[Blue](./hello_world-Color-Blue.md)
 
 <pre><code class="language-rust">Blue</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-FOO.md
+++ b/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-FOO.md
@@ -2,7 +2,7 @@
 
 FOO constant with value 42
 
-Fully qualified path: `hello_world::FOO`
+Fully qualified path: [hello_world](./hello_world.md)::[FOO](./hello_world-FOO.md)
 
 <pre><code class="language-rust">const FOO: u32 = 42;</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-Pair.md
+++ b/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-Pair.md
@@ -2,7 +2,7 @@
 
 Pair type alias for a tuple of two u32 values
 
-Fully qualified path: `hello_world::Pair`
+Fully qualified path: [hello_world](./hello_world.md)::[Pair](./hello_world-Pair.md)
 
 <pre><code class="language-rust">type Pair = (u32, u32);</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-Shape.md
+++ b/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-Shape.md
@@ -2,7 +2,7 @@
 
 Shape trait for objects that have an area
 
-Fully qualified path: `hello_world::Shape`
+Fully qualified path: [hello_world](./hello_world.md)::[Shape](./hello_world-Shape.md)
 
 <pre><code class="language-rust">trait Shape&lt;<a href="hello_world-Shape.html">T</a>&gt;</code></pre>
 
@@ -12,7 +12,7 @@ Fully qualified path: `hello_world::Shape`
 
 Constant for the shape type
 
-Fully qualified path: `hello_world::Shape::SHAPE_CONST`
+Fully qualified path: [hello_world](./hello_world.md)::[Shape](./hello_world-Shape.md)::[SHAPE_CONST](./hello_world-Shape-SHAPE_CONST.md)
 
 <pre><code class="language-rust">const SHAPE_CONST: felt252;</code></pre>
 
@@ -23,7 +23,7 @@ Fully qualified path: `hello_world::Shape::SHAPE_CONST`
 
 Calculate the area of the shape
 
-Fully qualified path: `hello_world::Shape::area`
+Fully qualified path: [hello_world](./hello_world.md)::[Shape](./hello_world-Shape.md)::[area](./hello_world-Shape-area.md)
 
 <pre><code class="language-rust">fn area&lt;T, T&gt;(self: T) -&gt; u32</code></pre>
 
@@ -34,7 +34,7 @@ Fully qualified path: `hello_world::Shape::area`
 
 Type alias for a pair of shapes
 
-Fully qualified path: `hello_world::Shape::ShapePair`
+Fully qualified path: [hello_world](./hello_world.md)::[Shape](./hello_world-Shape.md)::[ShapePair](./hello_world-Shape-ShapePair.md)
 
 <pre><code class="language-rust">type ShapePair;</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-fib.md
+++ b/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-fib.md
@@ -2,7 +2,7 @@
 
 Calculate the nth Fibonacci number  # Arguments * `n` - The index of the Fibonacci number to calculate
 
-Fully qualified path: `hello_world::fib`
+Fully qualified path: [hello_world](./hello_world.md)::[fib](./hello_world-fib.md)
 
 <pre><code class="language-rust">fn fib(mut n: u32) -&gt; u32</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-main.md
+++ b/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-main.md
@@ -2,7 +2,7 @@
 
 Main function that calculates the 16th Fibonacci number
 
-Fully qualified path: `hello_world::main`
+Fully qualified path: [hello_world](./hello_world.md)::[main](./hello_world-main.md)
 
 <pre><code class="language-rust">fn main() -&gt; u32</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-test.md
+++ b/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-test.md
@@ -7,7 +7,7 @@ Function that prints "test" to stdout with endline. Can invoke it like that:
     }
 ```
 
-Fully qualified path: `hello_world::test`
+Fully qualified path: [hello_world](./hello_world.md)::[test](./hello_world-test.md)
 
 <pre><code class="language-rust">fn test()</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-tests-it_works.md
+++ b/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-tests-it_works.md
@@ -2,7 +2,7 @@
 
 Really works.
 
-Fully qualified path: `hello_world::tests::it_works`
+Fully qualified path: [hello_world](./hello_world.md)::[tests](./hello_world-tests.md)::[it_works](./hello_world-tests-it_works.md)
 
 <pre><code class="language-rust">fn it_works()</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-tests.md
+++ b/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-tests.md
@@ -2,7 +2,7 @@
 
 Tests module
 
-Fully qualified path: `hello_world::tests`
+Fully qualified path: [hello_world](./hello_world.md)::[tests](./hello_world-tests.md)
 
 ## Free functions
 

--- a/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world.md
+++ b/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world.md
@@ -2,7 +2,7 @@
 
 Fibonacci sequence calculator
 
-Fully qualified path: `hello_world`
+Fully qualified path: [hello_world](./hello_world.md)
 
 ## Modules
 


### PR DESCRIPTION
closes https://github.com/software-mansion/scarb/issues/2096

- Created nested modules navbar, but i did leave the rest of the elements (free functions, structs, traits etc) as they were. The reason is summary file format restrictions.  Prefix chapters cannot be nested - because of that if we did create a nested structure the elements contained by a module couldn't be distinct by type and we'd end up with a confusing list of mixed types items. 
Imo, the presented way is good enough but there is a possibility of using some custom backend that handles nested prefixed chapters (I assume one exists). So let me know if you'd like to see it instead and I will research our options. 
- added links to `Fully qualified path`
