### PR TITLE
Restore default mapping for v1 derives on expansion

### DIFF
--- a/scarb/tests/proc_macro_v1_and_v2_server.rs
+++ b/scarb/tests/proc_macro_v1_and_v2_server.rs
@@ -192,7 +192,13 @@ fn expand_derive() {
                 }]
             );
         } else {
-            assert_eq!(response.code_mappings, Some(vec![]));
+            assert_eq!(
+                response.code_mappings,
+                Some(vec![CodeMapping {
+                    span: TextSpan { start: 0, end: 29 },
+                    origin: Span(TextSpan { start: 0, end: 19 })
+                }])
+            );
         }
     }
 }


### PR DESCRIPTION
It was added on LS side, but was never actually used since the v1 and v2 macros can be expanded in tandem, this would always return an empty vector instead of `None`, thus the default mapping could not be constructed