### PR TITLE
fix: linking doc items

### DIFF
--- a/extensions/scarb-doc/src/docs_generation.rs
+++ b/extensions/scarb-doc/src/docs_generation.rs
@@ -33,15 +33,18 @@ impl PrimitiveDocItem for ExternFunction {}
 impl PrimitiveDocItem for ExternType {}
 impl PrimitiveDocItem for FreeFunction {}
 impl PrimitiveDocItem for ImplAlias {}
-impl PrimitiveDocItem for ImplConstant {}
-impl PrimitiveDocItem for ImplFunction {}
-impl PrimitiveDocItem for ImplType {}
-impl PrimitiveDocItem for Member {}
-impl PrimitiveDocItem for TraitConstant {}
-impl PrimitiveDocItem for TraitFunction {}
-impl PrimitiveDocItem for TraitType {}
 impl PrimitiveDocItem for TypeAlias {}
-impl PrimitiveDocItem for Variant {}
+
+trait SubPathDocItem: DocItem {}
+
+impl SubPathDocItem for Member {}
+impl SubPathDocItem for Variant {}
+impl SubPathDocItem for TraitFunction {}
+impl SubPathDocItem for ImplFunction {}
+impl SubPathDocItem for ImplType {}
+impl SubPathDocItem for ImplConstant {}
+impl SubPathDocItem for TraitConstant {}
+impl SubPathDocItem for TraitType {}
 
 // Trait for items that have their own documentation page.
 // Used to enforce constraints on generic implementations of traits like `TopLevelMarkdownDocItem`.

--- a/extensions/scarb-doc/src/docs_generation/markdown/context.rs
+++ b/extensions/scarb-doc/src/docs_generation/markdown/context.rs
@@ -26,7 +26,7 @@ impl<'a> MarkdownGenerationContext<'a> {
         }
     }
 
-    pub fn resolve_markdown_file_path_from_link(&self, link: &CommentLinkToken) -> String {
+    pub fn resolve_markdown_file_path_from_link(&self, link: &CommentLinkToken) -> Option<String> {
         match link.resolved_item {
             Some(resolved_item_id) => match self.included_items.get(&resolved_item_id) {
                 Some(resolved_item) => match resolved_item_id {
@@ -49,22 +49,20 @@ impl<'a> MarkdownGenerationContext<'a> {
                         ImplItemId::Constant(_),
                     )) => {
                         match resolved_item.parent_full_path() {
-                            Some(parent_path) => {
-                                format!(
-                                    "{}#{}",
-                                    path_to_file_link(&parent_path),
-                                    resolved_item.name().to_lowercase()
-                                )
-                            }
+                            Some(parent_path) => Some(format!(
+                                "{}#{}",
+                                path_to_file_link(&parent_path),
+                                resolved_item.name().to_lowercase()
+                            )),
                             // Only root_module / crate doesn't have the parent.
-                            _ => SUMMARY_FILENAME.to_string(),
+                            _ => Some(SUMMARY_FILENAME.to_string()),
                         }
                     }
-                    _ => path_to_file_link(&resolved_item.full_path()),
+                    _ => Some(path_to_file_link(&resolved_item.full_path())),
                 },
-                None => link.path.clone().unwrap_or(link.label.clone()),
+                None => None,
             },
-            None => link.path.clone().unwrap_or(link.label.clone()),
+            None => None,
         }
     }
 }

--- a/extensions/scarb-doc/src/docs_generation/markdown/summary.rs
+++ b/extensions/scarb-doc/src/docs_generation/markdown/summary.rs
@@ -22,7 +22,7 @@ pub fn generate_summary_file_content(crate_: &Crate) -> Result<(String, Vec<(Str
         crate_.root_module.filename(),
         crate_
             .root_module
-            .generate_markdown(&context, BASE_HEADER_LEVEL)?,
+            .generate_markdown(&context, BASE_HEADER_LEVEL, None)?,
     )];
     let (sub_markdown, module_item_summaries) =
         &generate_modules_summary_content(&crate_.root_module, 0, &context)?;
@@ -358,7 +358,7 @@ fn generate_top_level_docs_contents(
         .iter()
         .map(|item| {
             let filename = item.filename();
-            item.generate_markdown(context, BASE_HEADER_LEVEL)
+            item.generate_markdown(context, BASE_HEADER_LEVEL, None)
                 .map(|markdown| (filename, markdown))
         })
         .collect()

--- a/extensions/scarb-doc/tests/code/code_6.cairo
+++ b/extensions/scarb-doc/tests/code/code_6.cairo
@@ -1,0 +1,28 @@
+trait Uganda<T> {
+    const RWANDA: felt252;
+    const UGANDA: felt252;
+    type Rwanda;
+    type Uganda;
+    fn burundi(self: T) -> u32;
+    fn rwanda(self: T) -> u32;
+    fn uganda();
+}
+
+struct Congo {
+    pub Congo: felt252;
+}
+
+enum Guinea {
+    Guinea: (),
+    Equatorial: (),
+}
+
+impl CongoUganda of Uganda<Congo> {
+    const RWANDA: felt252 = 'Central Africa';
+    const UGANDA: felt252 = 'neighbour country';
+    type Rwanda = (Guinea, Congo);
+    type Uganda = (Congo, Congo);
+    fn burundi(self: Congo) -> u32;
+    fn rwanda(self: Congo) -> u32;
+    fn uganda() {};
+}

--- a/extensions/scarb-doc/tests/data/hello_world_linked_items/book.toml
+++ b/extensions/scarb-doc/tests/data/hello_world_linked_items/book.toml
@@ -1,0 +1,19 @@
+[book]
+authors = ["<unknown>"]
+language = "en"
+multilingual = false
+src = "src"
+title = "hello_world - Cairo"
+
+[output.html]
+no-section-label = true
+
+[output.html.playground]
+runnable = false
+
+[output.html.fold]
+enable = true
+level = 0
+
+[output.html.code.hidelines]
+cairo = "#"

--- a/extensions/scarb-doc/tests/data/hello_world_linked_items/src/SUMMARY.md
+++ b/extensions/scarb-doc/tests/data/hello_world_linked_items/src/SUMMARY.md
@@ -1,0 +1,11 @@
+# Summary
+
+- [hello_world](./hello_world.md)
+  - [Structs](./hello_world-structs.md)
+      - [Congo](./hello_world-Congo.md)
+  - [Enums](./hello_world-enums.md)
+      - [Guinea](./hello_world-Guinea.md)
+  - [Traits](./hello_world-traits.md)
+      - [Uganda](./hello_world-Uganda.md)
+  - [Impls](./hello_world-impls.md)
+      - [CongoUganda](./hello_world-CongoUganda.md)

--- a/extensions/scarb-doc/tests/data/hello_world_linked_items/src/hello_world-Congo.md
+++ b/extensions/scarb-doc/tests/data/hello_world_linked_items/src/hello_world-Congo.md
@@ -1,0 +1,17 @@
+# Congo
+
+Fully qualified path: [hello_world](./hello_world.md)::[Congo](./hello_world-Congo.md)
+
+<pre><code class="language-cairo">struct Congo {
+    pub Congo: felt252,
+}</code></pre>
+
+## Members
+
+### Congo
+
+Fully qualified path: [hello_world](./hello_world.md)::[Congo](./hello_world-Congo.md)::[Congo](./hello_world-Congo.md#congo-1)
+
+<pre><code class="language-cairo">pub Congo: felt252</code></pre>
+
+

--- a/extensions/scarb-doc/tests/data/hello_world_linked_items/src/hello_world-CongoUganda.md
+++ b/extensions/scarb-doc/tests/data/hello_world_linked_items/src/hello_world-CongoUganda.md
@@ -1,0 +1,61 @@
+# CongoUganda
+
+Fully qualified path: [hello_world](./hello_world.md)::[CongoUganda](./hello_world-CongoUganda.md)
+
+<pre><code class="language-cairo">impl CongoUganda of Uganda&lt;<a href="hello_world-Congo.html">Congo</a>&gt;;</code></pre>
+
+## Impl constants
+
+### RWANDA
+
+Fully qualified path: [hello_world](./hello_world.md)::[CongoUganda](./hello_world-CongoUganda.md)::[RWANDA](./hello_world-CongoUganda.md#rwanda)
+
+<pre><code class="language-cairo">const RWANDA: felt252 = &apos;Central Africa&apos;;</code></pre>
+
+
+### UGANDA
+
+Fully qualified path: [hello_world](./hello_world.md)::[CongoUganda](./hello_world-CongoUganda.md)::[UGANDA](./hello_world-CongoUganda.md#uganda)
+
+<pre><code class="language-cairo">const UGANDA: felt252 = &apos;neighbour country&apos;;</code></pre>
+
+
+## Impl functions
+
+### burundi
+
+Fully qualified path: [hello_world](./hello_world.md)::[CongoUganda](./hello_world-CongoUganda.md)::[burundi](./hello_world-CongoUganda.md#burundi)
+
+<pre><code class="language-cairo">fn burundi(self: <a href="hello_world-Congo.html">Congo</a>) -&gt; u32</code></pre>
+
+
+### rwanda
+
+Fully qualified path: [hello_world](./hello_world.md)::[CongoUganda](./hello_world-CongoUganda.md)::[rwanda](./hello_world-CongoUganda.md#rwanda-1)
+
+<pre><code class="language-cairo">fn rwanda(self: <a href="hello_world-Congo.html">Congo</a>) -&gt; u32</code></pre>
+
+
+### uganda
+
+Fully qualified path: [hello_world](./hello_world.md)::[CongoUganda](./hello_world-CongoUganda.md)::[uganda](./hello_world-CongoUganda.md#uganda-1)
+
+<pre><code class="language-cairo">fn uganda()</code></pre>
+
+
+## Impl types
+
+### Rwanda
+
+Fully qualified path: [hello_world](./hello_world.md)::[CongoUganda](./hello_world-CongoUganda.md)::[Rwanda](./hello_world-CongoUganda.md#rwanda-2)
+
+<pre><code class="language-cairo">type Rwanda = (Guinea, Congo);</code></pre>
+
+
+### Uganda
+
+Fully qualified path: [hello_world](./hello_world.md)::[CongoUganda](./hello_world-CongoUganda.md)::[Uganda](./hello_world-CongoUganda.md#uganda-2)
+
+<pre><code class="language-cairo">type Uganda = (Congo, Congo);</code></pre>
+
+

--- a/extensions/scarb-doc/tests/data/hello_world_linked_items/src/hello_world-Guinea.md
+++ b/extensions/scarb-doc/tests/data/hello_world_linked_items/src/hello_world-Guinea.md
@@ -1,0 +1,25 @@
+# Guinea
+
+Fully qualified path: [hello_world](./hello_world.md)::[Guinea](./hello_world-Guinea.md)
+
+<pre><code class="language-cairo">enum Guinea {
+    Guinea,
+    Equatorial,
+}</code></pre>
+
+## Variants
+
+### Guinea
+
+Fully qualified path: [hello_world](./hello_world.md)::[Guinea](./hello_world-Guinea.md)::[Guinea](./hello_world-Guinea.md#guinea-1)
+
+<pre><code class="language-cairo">Guinea</code></pre>
+
+
+### Equatorial
+
+Fully qualified path: [hello_world](./hello_world.md)::[Guinea](./hello_world-Guinea.md)::[Equatorial](./hello_world-Guinea.md#equatorial)
+
+<pre><code class="language-cairo">Equatorial</code></pre>
+
+

--- a/extensions/scarb-doc/tests/data/hello_world_linked_items/src/hello_world-Uganda.md
+++ b/extensions/scarb-doc/tests/data/hello_world_linked_items/src/hello_world-Uganda.md
@@ -1,0 +1,61 @@
+# Uganda
+
+Fully qualified path: [hello_world](./hello_world.md)::[Uganda](./hello_world-Uganda.md)
+
+<pre><code class="language-cairo">trait Uganda&lt;T&gt;</code></pre>
+
+## Trait constants
+
+### RWANDA
+
+Fully qualified path: [hello_world](./hello_world.md)::[Uganda](./hello_world-Uganda.md)::[RWANDA](./hello_world-Uganda.md#rwanda)
+
+<pre><code class="language-cairo">const RWANDA: felt252;</code></pre>
+
+
+### UGANDA
+
+Fully qualified path: [hello_world](./hello_world.md)::[Uganda](./hello_world-Uganda.md)::[UGANDA](./hello_world-Uganda.md#uganda-1)
+
+<pre><code class="language-cairo">const UGANDA: felt252;</code></pre>
+
+
+## Trait functions
+
+### burundi
+
+Fully qualified path: [hello_world](./hello_world.md)::[Uganda](./hello_world-Uganda.md)::[burundi](./hello_world-Uganda.md#burundi)
+
+<pre><code class="language-cairo">fn burundi&lt;T, T&gt;(self: T) -&gt; u32</code></pre>
+
+
+### rwanda
+
+Fully qualified path: [hello_world](./hello_world.md)::[Uganda](./hello_world-Uganda.md)::[rwanda](./hello_world-Uganda.md#rwanda-1)
+
+<pre><code class="language-cairo">fn rwanda&lt;T, T&gt;(self: T) -&gt; u32</code></pre>
+
+
+### uganda
+
+Fully qualified path: [hello_world](./hello_world.md)::[Uganda](./hello_world-Uganda.md)::[uganda](./hello_world-Uganda.md#uganda-2)
+
+<pre><code class="language-cairo">fn uganda&lt;T, T&gt;()</code></pre>
+
+
+## Trait types
+
+### Rwanda
+
+Fully qualified path: [hello_world](./hello_world.md)::[Uganda](./hello_world-Uganda.md)::[Rwanda](./hello_world-Uganda.md#rwanda-2)
+
+<pre><code class="language-cairo">type Rwanda;</code></pre>
+
+
+### Uganda
+
+Fully qualified path: [hello_world](./hello_world.md)::[Uganda](./hello_world-Uganda.md)::[Uganda](./hello_world-Uganda.md#uganda-3)
+
+<pre><code class="language-cairo">type Uganda;</code></pre>
+
+

--- a/extensions/scarb-doc/tests/data/hello_world_linked_items/src/hello_world-enums.md
+++ b/extensions/scarb-doc/tests/data/hello_world_linked_items/src/hello_world-enums.md
@@ -1,0 +1,6 @@
+
+[Enums](./hello_world-enums.md)
+ ---
+| | |
+|:---|:---|
+| [Guinea](./hello_world-Guinea.md) | [...](./hello_world-Guinea.md) |

--- a/extensions/scarb-doc/tests/data/hello_world_linked_items/src/hello_world-impls.md
+++ b/extensions/scarb-doc/tests/data/hello_world_linked_items/src/hello_world-impls.md
@@ -1,0 +1,6 @@
+
+[Impls](./hello_world-impls.md)
+ ---
+| | |
+|:---|:---|
+| [CongoUganda](./hello_world-CongoUganda.md) | [...](./hello_world-CongoUganda.md) |

--- a/extensions/scarb-doc/tests/data/hello_world_linked_items/src/hello_world-structs.md
+++ b/extensions/scarb-doc/tests/data/hello_world_linked_items/src/hello_world-structs.md
@@ -1,0 +1,6 @@
+
+[Structs](./hello_world-structs.md)
+ ---
+| | |
+|:---|:---|
+| [Congo](./hello_world-Congo.md) | [...](./hello_world-Congo.md) |

--- a/extensions/scarb-doc/tests/data/hello_world_linked_items/src/hello_world-traits.md
+++ b/extensions/scarb-doc/tests/data/hello_world_linked_items/src/hello_world-traits.md
@@ -1,0 +1,6 @@
+
+[Traits](./hello_world-traits.md)
+ ---
+| | |
+|:---|:---|
+| [Uganda](./hello_world-Uganda.md) | [...](./hello_world-Uganda.md) |

--- a/extensions/scarb-doc/tests/data/hello_world_linked_items/src/hello_world.md
+++ b/extensions/scarb-doc/tests/data/hello_world_linked_items/src/hello_world.md
@@ -1,0 +1,28 @@
+# hello_world
+
+Fully qualified path: [hello_world](./hello_world.md)
+
+
+[Structs](./hello_world-structs.md)
+ ---
+| | |
+|:---|:---|
+| [Congo](./hello_world-Congo.md) | [...](./hello_world-Congo.md) |
+
+[Enums](./hello_world-enums.md)
+ ---
+| | |
+|:---|:---|
+| [Guinea](./hello_world-Guinea.md) | [...](./hello_world-Guinea.md) |
+
+[Traits](./hello_world-traits.md)
+ ---
+| | |
+|:---|:---|
+| [Uganda](./hello_world-Uganda.md) | [...](./hello_world-Uganda.md) |
+
+[Impls](./hello_world-impls.md)
+ ---
+| | |
+|:---|:---|
+| [CongoUganda](./hello_world-CongoUganda.md) | [...](./hello_world-CongoUganda.md) |

--- a/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-Circle.md
+++ b/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-Circle.md
@@ -15,7 +15,7 @@ struct Circle {
 
 Radius of the circle
 
-Fully qualified path: [hello_world](./hello_world.md)::[Circle](./hello_world-Circle.md)::[radius](./hello_world-Circle-radius.md)
+Fully qualified path: [hello_world](./hello_world.md)::[Circle](./hello_world-Circle.md)::[radius](./hello_world-Circle.md#radius)
 
 <pre><code class="language-cairo">radius: u32</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-CirclePartialEq.md
+++ b/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-CirclePartialEq.md
@@ -8,7 +8,7 @@ Fully qualified path: [hello_world](./hello_world.md)::[CirclePartialEq](./hello
 
 ### eq
 
-Fully qualified path: [hello_world](./hello_world.md)::[CirclePartialEq](./hello_world-CirclePartialEq.md)::[eq](./hello_world-CirclePartialEq-eq.md)
+Fully qualified path: [hello_world](./hello_world.md)::[CirclePartialEq](./hello_world-CirclePartialEq.md)::[eq](./hello_world-CirclePartialEq.md#eq)
 
 <pre><code class="language-cairo">fn eq(lhs: Circle, rhs: Circle) -&gt; bool</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-CircleSerde.md
+++ b/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-CircleSerde.md
@@ -8,14 +8,14 @@ Fully qualified path: [hello_world](./hello_world.md)::[CircleSerde](./hello_wor
 
 ### serialize
 
-Fully qualified path: [hello_world](./hello_world.md)::[CircleSerde](./hello_world-CircleSerde.md)::[serialize](./hello_world-CircleSerde-serialize.md)
+Fully qualified path: [hello_world](./hello_world.md)::[CircleSerde](./hello_world-CircleSerde.md)::[serialize](./hello_world-CircleSerde.md#serialize)
 
 <pre><code class="language-cairo">fn serialize(self: Circle, ref output: Array&lt;felt252&gt;)</code></pre>
 
 
 ### deserialize
 
-Fully qualified path: [hello_world](./hello_world.md)::[CircleSerde](./hello_world-CircleSerde.md)::[deserialize](./hello_world-CircleSerde-deserialize.md)
+Fully qualified path: [hello_world](./hello_world.md)::[CircleSerde](./hello_world-CircleSerde.md)::[deserialize](./hello_world-CircleSerde.md#deserialize)
 
 <pre><code class="language-cairo">fn deserialize(ref serialized: Span&lt;felt252&gt;) -&gt; Option&lt;Circle&gt;</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-CircleShape.md
+++ b/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-CircleShape.md
@@ -12,7 +12,7 @@ Fully qualified path: [hello_world](./hello_world.md)::[CircleShape](./hello_wor
 
 Shape constant
 
-Fully qualified path: [hello_world](./hello_world.md)::[CircleShape](./hello_world-CircleShape.md)::[SHAPE_CONST](./hello_world-CircleShape-SHAPE_CONST.md)
+Fully qualified path: [hello_world](./hello_world.md)::[CircleShape](./hello_world-CircleShape.md)::[SHAPE_CONST](./hello_world-CircleShape.md#shape_const)
 
 <pre><code class="language-cairo">const SHAPE_CONST: felt252 = &apos;xyz&apos;;</code></pre>
 
@@ -23,7 +23,7 @@ Fully qualified path: [hello_world](./hello_world.md)::[CircleShape](./hello_wor
 
 Implementation of the area method for Circle
 
-Fully qualified path: [hello_world](./hello_world.md)::[CircleShape](./hello_world-CircleShape.md)::[area](./hello_world-CircleShape-area.md)
+Fully qualified path: [hello_world](./hello_world.md)::[CircleShape](./hello_world-CircleShape.md)::[area](./hello_world-CircleShape.md#area)
 
 <pre><code class="language-cairo">fn area(self: <a href="hello_world-Circle.html">Circle</a>) -&gt; u32</code></pre>
 
@@ -34,7 +34,7 @@ Fully qualified path: [hello_world](./hello_world.md)::[CircleShape](./hello_wor
 
 Type alias for a pair of circles
 
-Fully qualified path: [hello_world](./hello_world.md)::[CircleShape](./hello_world-CircleShape.md)::[ShapePair](./hello_world-CircleShape-ShapePair.md)
+Fully qualified path: [hello_world](./hello_world.md)::[CircleShape](./hello_world-CircleShape.md)::[ShapePair](./hello_world-CircleShape.md#shapepair)
 
 <pre><code class="language-cairo">type ShapePair = (Circle, Circle);</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-Color.md
+++ b/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-Color.md
@@ -16,7 +16,7 @@ Fully qualified path: [hello_world](./hello_world.md)::[Color](./hello_world-Col
 
 Red color
 
-Fully qualified path: [hello_world](./hello_world.md)::[Color](./hello_world-Color.md)::[Red](./hello_world-Color-Red.md)
+Fully qualified path: [hello_world](./hello_world.md)::[Color](./hello_world-Color.md)::[Red](./hello_world-Color.md#red)
 
 <pre><code class="language-cairo">Red</code></pre>
 
@@ -25,7 +25,7 @@ Fully qualified path: [hello_world](./hello_world.md)::[Color](./hello_world-Col
 
 Green color
 
-Fully qualified path: [hello_world](./hello_world.md)::[Color](./hello_world-Color.md)::[Green](./hello_world-Color-Green.md)
+Fully qualified path: [hello_world](./hello_world.md)::[Color](./hello_world-Color.md)::[Green](./hello_world-Color.md#green)
 
 <pre><code class="language-cairo">Green</code></pre>
 
@@ -34,7 +34,7 @@ Fully qualified path: [hello_world](./hello_world.md)::[Color](./hello_world-Col
 
 Blue color
 
-Fully qualified path: [hello_world](./hello_world.md)::[Color](./hello_world-Color.md)::[Blue](./hello_world-Color-Blue.md)
+Fully qualified path: [hello_world](./hello_world.md)::[Color](./hello_world-Color.md)::[Blue](./hello_world-Color.md#blue)
 
 <pre><code class="language-cairo">Blue</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-Shape.md
+++ b/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-Shape.md
@@ -12,7 +12,7 @@ Fully qualified path: [hello_world](./hello_world.md)::[Shape](./hello_world-Sha
 
 Constant for the shape type
 
-Fully qualified path: [hello_world](./hello_world.md)::[Shape](./hello_world-Shape.md)::[SHAPE_CONST](./hello_world-Shape-SHAPE_CONST.md)
+Fully qualified path: [hello_world](./hello_world.md)::[Shape](./hello_world-Shape.md)::[SHAPE_CONST](./hello_world-Shape.md#shape_const)
 
 <pre><code class="language-cairo">const SHAPE_CONST: felt252;</code></pre>
 
@@ -23,7 +23,7 @@ Fully qualified path: [hello_world](./hello_world.md)::[Shape](./hello_world-Sha
 
 Calculate the area of the shape
 
-Fully qualified path: [hello_world](./hello_world.md)::[Shape](./hello_world-Shape.md)::[area](./hello_world-Shape-area.md)
+Fully qualified path: [hello_world](./hello_world.md)::[Shape](./hello_world-Shape.md)::[area](./hello_world-Shape.md#area)
 
 <pre><code class="language-cairo">fn area&lt;T, T&gt;(self: T) -&gt; u32</code></pre>
 
@@ -34,7 +34,7 @@ Fully qualified path: [hello_world](./hello_world.md)::[Shape](./hello_world-Sha
 
 Type alias for a pair of shapes
 
-Fully qualified path: [hello_world](./hello_world.md)::[Shape](./hello_world-Shape.md)::[ShapePair](./hello_world-Shape-ShapePair.md)
+Fully qualified path: [hello_world](./hello_world.md)::[Shape](./hello_world-Shape.md)::[ShapePair](./hello_world-Shape.md#shapepair)
 
 <pre><code class="language-cairo">type ShapePair;</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-Circle.md
+++ b/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-Circle.md
@@ -15,7 +15,7 @@ struct Circle {
 
 Radius of the circle
 
-Fully qualified path: [hello_world](./hello_world.md)::[Circle](./hello_world-Circle.md)::[radius](./hello_world-Circle-radius.md)
+Fully qualified path: [hello_world](./hello_world.md)::[Circle](./hello_world-Circle.md)::[radius](./hello_world-Circle.md#radius)
 
 <pre><code class="language-cairo">radius: u32</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-CirclePartialEq.md
+++ b/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-CirclePartialEq.md
@@ -8,7 +8,7 @@ Fully qualified path: [hello_world](./hello_world.md)::[CirclePartialEq](./hello
 
 ### eq
 
-Fully qualified path: [hello_world](./hello_world.md)::[CirclePartialEq](./hello_world-CirclePartialEq.md)::[eq](./hello_world-CirclePartialEq-eq.md)
+Fully qualified path: [hello_world](./hello_world.md)::[CirclePartialEq](./hello_world-CirclePartialEq.md)::[eq](./hello_world-CirclePartialEq.md#eq)
 
 <pre><code class="language-cairo">fn eq(lhs: Circle, rhs: Circle) -&gt; bool</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-CircleSerde.md
+++ b/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-CircleSerde.md
@@ -8,14 +8,14 @@ Fully qualified path: [hello_world](./hello_world.md)::[CircleSerde](./hello_wor
 
 ### serialize
 
-Fully qualified path: [hello_world](./hello_world.md)::[CircleSerde](./hello_world-CircleSerde.md)::[serialize](./hello_world-CircleSerde-serialize.md)
+Fully qualified path: [hello_world](./hello_world.md)::[CircleSerde](./hello_world-CircleSerde.md)::[serialize](./hello_world-CircleSerde.md#serialize)
 
 <pre><code class="language-cairo">fn serialize(self: Circle, ref output: Array&lt;felt252&gt;)</code></pre>
 
 
 ### deserialize
 
-Fully qualified path: [hello_world](./hello_world.md)::[CircleSerde](./hello_world-CircleSerde.md)::[deserialize](./hello_world-CircleSerde-deserialize.md)
+Fully qualified path: [hello_world](./hello_world.md)::[CircleSerde](./hello_world-CircleSerde.md)::[deserialize](./hello_world-CircleSerde.md#deserialize)
 
 <pre><code class="language-cairo">fn deserialize(ref serialized: Span&lt;felt252&gt;) -&gt; Option&lt;Circle&gt;</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-CircleShape.md
+++ b/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-CircleShape.md
@@ -12,7 +12,7 @@ Fully qualified path: [hello_world](./hello_world.md)::[CircleShape](./hello_wor
 
 Shape constant
 
-Fully qualified path: [hello_world](./hello_world.md)::[CircleShape](./hello_world-CircleShape.md)::[SHAPE_CONST](./hello_world-CircleShape-SHAPE_CONST.md)
+Fully qualified path: [hello_world](./hello_world.md)::[CircleShape](./hello_world-CircleShape.md)::[SHAPE_CONST](./hello_world-CircleShape.md#shape_const)
 
 <pre><code class="language-cairo">const SHAPE_CONST: felt252 = &apos;xyz&apos;;</code></pre>
 
@@ -23,7 +23,7 @@ Fully qualified path: [hello_world](./hello_world.md)::[CircleShape](./hello_wor
 
 Implementation of the area method for Circle
 
-Fully qualified path: [hello_world](./hello_world.md)::[CircleShape](./hello_world-CircleShape.md)::[area](./hello_world-CircleShape-area.md)
+Fully qualified path: [hello_world](./hello_world.md)::[CircleShape](./hello_world-CircleShape.md)::[area](./hello_world-CircleShape.md#area)
 
 <pre><code class="language-cairo">fn area(self: <a href="hello_world-Circle.html">Circle</a>) -&gt; u32</code></pre>
 
@@ -34,7 +34,7 @@ Fully qualified path: [hello_world](./hello_world.md)::[CircleShape](./hello_wor
 
 Type alias for a pair of circles
 
-Fully qualified path: [hello_world](./hello_world.md)::[CircleShape](./hello_world-CircleShape.md)::[ShapePair](./hello_world-CircleShape-ShapePair.md)
+Fully qualified path: [hello_world](./hello_world.md)::[CircleShape](./hello_world-CircleShape.md)::[ShapePair](./hello_world-CircleShape.md#shapepair)
 
 <pre><code class="language-cairo">type ShapePair = (Circle, Circle);</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-Color.md
+++ b/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-Color.md
@@ -16,7 +16,7 @@ Fully qualified path: [hello_world](./hello_world.md)::[Color](./hello_world-Col
 
 Red color
 
-Fully qualified path: [hello_world](./hello_world.md)::[Color](./hello_world-Color.md)::[Red](./hello_world-Color-Red.md)
+Fully qualified path: [hello_world](./hello_world.md)::[Color](./hello_world-Color.md)::[Red](./hello_world-Color.md#red)
 
 <pre><code class="language-cairo">Red</code></pre>
 
@@ -25,7 +25,7 @@ Fully qualified path: [hello_world](./hello_world.md)::[Color](./hello_world-Col
 
 Green color
 
-Fully qualified path: [hello_world](./hello_world.md)::[Color](./hello_world-Color.md)::[Green](./hello_world-Color-Green.md)
+Fully qualified path: [hello_world](./hello_world.md)::[Color](./hello_world-Color.md)::[Green](./hello_world-Color.md#green)
 
 <pre><code class="language-cairo">Green</code></pre>
 
@@ -34,7 +34,7 @@ Fully qualified path: [hello_world](./hello_world.md)::[Color](./hello_world-Col
 
 Blue color
 
-Fully qualified path: [hello_world](./hello_world.md)::[Color](./hello_world-Color.md)::[Blue](./hello_world-Color-Blue.md)
+Fully qualified path: [hello_world](./hello_world.md)::[Color](./hello_world-Color.md)::[Blue](./hello_world-Color.md#blue)
 
 <pre><code class="language-cairo">Blue</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-Shape.md
+++ b/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-Shape.md
@@ -12,7 +12,7 @@ Fully qualified path: [hello_world](./hello_world.md)::[Shape](./hello_world-Sha
 
 Constant for the shape type
 
-Fully qualified path: [hello_world](./hello_world.md)::[Shape](./hello_world-Shape.md)::[SHAPE_CONST](./hello_world-Shape-SHAPE_CONST.md)
+Fully qualified path: [hello_world](./hello_world.md)::[Shape](./hello_world-Shape.md)::[SHAPE_CONST](./hello_world-Shape.md#shape_const)
 
 <pre><code class="language-cairo">const SHAPE_CONST: felt252;</code></pre>
 
@@ -23,7 +23,7 @@ Fully qualified path: [hello_world](./hello_world.md)::[Shape](./hello_world-Sha
 
 Calculate the area of the shape
 
-Fully qualified path: [hello_world](./hello_world.md)::[Shape](./hello_world-Shape.md)::[area](./hello_world-Shape-area.md)
+Fully qualified path: [hello_world](./hello_world.md)::[Shape](./hello_world-Shape.md)::[area](./hello_world-Shape.md#area)
 
 <pre><code class="language-cairo">fn area&lt;T, T&gt;(self: T) -&gt; u32</code></pre>
 
@@ -34,7 +34,7 @@ Fully qualified path: [hello_world](./hello_world.md)::[Shape](./hello_world-Sha
 
 Type alias for a pair of shapes
 
-Fully qualified path: [hello_world](./hello_world.md)::[Shape](./hello_world-Shape.md)::[ShapePair](./hello_world-Shape-ShapePair.md)
+Fully qualified path: [hello_world](./hello_world.md)::[Shape](./hello_world-Shape.md)::[ShapePair](./hello_world-Shape.md#shapepair)
 
 <pre><code class="language-cairo">type ShapePair;</code></pre>
 

--- a/extensions/scarb-doc/tests/markdown_links.rs
+++ b/extensions/scarb-doc/tests/markdown_links.rs
@@ -1,0 +1,40 @@
+//! Run `UPDATE_EXPECT=1 cargo test` to fix the tests.
+
+use assert_fs::TempDir;
+use scarb_test_support::workspace_builder::WorkspaceBuilder;
+mod markdown_target;
+use markdown_target::MarkdownTargetChecker;
+use scarb_test_support::command::Scarb;
+use scarb_test_support::project_builder::ProjectBuilder;
+
+const EXPECTED_LINKED_ITEMS: &str = "tests/data/hello_world_linked_items";
+const LINKED_ITEMS_CODE: &str = include_str!("code/code_6.cairo");
+
+#[test]
+fn test_markdown_linked_items() {
+    let root_dir = TempDir::new().unwrap();
+
+    let root = ProjectBuilder::start()
+        .name("hello_world")
+        .lib_cairo(LINKED_ITEMS_CODE);
+
+    WorkspaceBuilder::start().package(root).build(&root_dir);
+
+    Scarb::quick_snapbox()
+        .arg("doc")
+        .arg("--document-private-items")
+        .current_dir(&root_dir)
+        .assert()
+        .success();
+
+    MarkdownTargetChecker::default()
+        .actual(
+            root_dir
+                .path()
+                .join("target/doc/hello_world")
+                .to_str()
+                .unwrap(),
+        )
+        .expected(EXPECTED_LINKED_ITEMS)
+        .assert_all_files_match();
+}


### PR DESCRIPTION
closes https://github.com/software-mansion/scarb/issues/2129

- When linked item cannot be successfully connected with any _DocumentableItemId_ scarb-doc will not format it as a link but as a regular text.
- fix _Fully qualified path_ for _Variant_ and _Member_.
