### PR TITLE
Mark code blocks as Cairo not Rust

### DIFF
--- a/extensions/scarb-doc/src/docs_generation/markdown/traits.rs
+++ b/extensions/scarb-doc/src/docs_generation/markdown/traits.rs
@@ -374,10 +374,9 @@ fn generate_markdown_from_item_data(
 
     if let Some(sig) = &doc_item.signature() {
         if !sig.is_empty() {
-            // TODO(#1525) add cairo support to mdbook
             writeln!(
                 &mut markdown,
-                "<pre><code class=\"language-rust\">{}</code></pre>\n",
+                "<pre><code class=\"language-cairo\">{}</code></pre>\n",
                 format_signature(sig, doc_item.doc_location_links())
             )?;
         }

--- a/extensions/scarb-doc/tests/data/duplicated_item_names/src/hello_world-DuplicatedEnumName.md
+++ b/extensions/scarb-doc/tests/data/duplicated_item_names/src/hello_world-DuplicatedEnumName.md
@@ -2,5 +2,5 @@
 
 Fully qualified path: [hello_world](./hello_world.md)::[DuplicatedEnumName](./hello_world-DuplicatedEnumName.md)
 
-<pre><code class="language-rust">enum DuplicatedEnumName {}</code></pre>
+<pre><code class="language-cairo">enum DuplicatedEnumName {}</code></pre>
 

--- a/extensions/scarb-doc/tests/data/duplicated_item_names/src/hello_world-DuplicatedTraitName.md
+++ b/extensions/scarb-doc/tests/data/duplicated_item_names/src/hello_world-DuplicatedTraitName.md
@@ -2,5 +2,5 @@
 
 Fully qualified path: [hello_world](./hello_world.md)::[DuplicatedTraitName](./hello_world-DuplicatedTraitName.md)
 
-<pre><code class="language-rust">trait DuplicatedTraitName</code></pre>
+<pre><code class="language-cairo">trait DuplicatedTraitName</code></pre>
 

--- a/extensions/scarb-doc/tests/data/duplicated_item_names/src/hello_world-duplicated_function_name.md
+++ b/extensions/scarb-doc/tests/data/duplicated_item_names/src/hello_world-duplicated_function_name.md
@@ -2,5 +2,5 @@
 
 Fully qualified path: [hello_world](./hello_world.md)::[duplicated_function_name](./hello_world-duplicated_function_name.md)
 
-<pre><code class="language-rust">fn duplicated_function_name()</code></pre>
+<pre><code class="language-cairo">fn duplicated_function_name()</code></pre>
 

--- a/extensions/scarb-doc/tests/data/duplicated_item_names/src/hello_world-main.md
+++ b/extensions/scarb-doc/tests/data/duplicated_item_names/src/hello_world-main.md
@@ -2,5 +2,5 @@
 
 Fully qualified path: [hello_world](./hello_world.md)::[main](./hello_world-main.md)
 
-<pre><code class="language-rust">fn main()</code></pre>
+<pre><code class="language-cairo">fn main()</code></pre>
 

--- a/extensions/scarb-doc/tests/data/duplicated_item_names/src/hello_world-sub_module-DuplicatedEnumName.md
+++ b/extensions/scarb-doc/tests/data/duplicated_item_names/src/hello_world-sub_module-DuplicatedEnumName.md
@@ -2,5 +2,5 @@
 
 Fully qualified path: [hello_world](./hello_world.md)::[sub_module](./hello_world-sub_module.md)::[DuplicatedEnumName](./hello_world-sub_module-DuplicatedEnumName.md)
 
-<pre><code class="language-rust">enum DuplicatedEnumName {}</code></pre>
+<pre><code class="language-cairo">enum DuplicatedEnumName {}</code></pre>
 

--- a/extensions/scarb-doc/tests/data/duplicated_item_names/src/hello_world-sub_module-DuplicatedTraitName.md
+++ b/extensions/scarb-doc/tests/data/duplicated_item_names/src/hello_world-sub_module-DuplicatedTraitName.md
@@ -2,5 +2,5 @@
 
 Fully qualified path: [hello_world](./hello_world.md)::[sub_module](./hello_world-sub_module.md)::[DuplicatedTraitName](./hello_world-sub_module-DuplicatedTraitName.md)
 
-<pre><code class="language-rust">trait DuplicatedTraitName</code></pre>
+<pre><code class="language-cairo">trait DuplicatedTraitName</code></pre>
 

--- a/extensions/scarb-doc/tests/data/duplicated_item_names/src/hello_world-sub_module-duplicated_function_name.md
+++ b/extensions/scarb-doc/tests/data/duplicated_item_names/src/hello_world-sub_module-duplicated_function_name.md
@@ -2,5 +2,5 @@
 
 Fully qualified path: [hello_world](./hello_world.md)::[sub_module](./hello_world-sub_module.md)::[duplicated_function_name](./hello_world-sub_module-duplicated_function_name.md)
 
-<pre><code class="language-rust">fn duplicated_function_name()</code></pre>
+<pre><code class="language-cairo">fn duplicated_function_name()</code></pre>
 

--- a/extensions/scarb-doc/tests/data/duplicated_item_names/src/hello_world-unique_function_name.md
+++ b/extensions/scarb-doc/tests/data/duplicated_item_names/src/hello_world-unique_function_name.md
@@ -2,5 +2,5 @@
 
 Fully qualified path: [hello_world](./hello_world.md)::[unique_function_name](./hello_world-unique_function_name.md)
 
-<pre><code class="language-rust">fn unique_function_name()</code></pre>
+<pre><code class="language-cairo">fn unique_function_name()</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-Circle.md
+++ b/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-Circle.md
@@ -4,7 +4,7 @@ Circle struct with radius field
 
 Fully qualified path: [hello_world](./hello_world.md)::[Circle](./hello_world-Circle.md)
 
-<pre><code class="language-rust">#[derive(Drop, Serde, PartialEq)]
+<pre><code class="language-cairo">#[derive(Drop, Serde, PartialEq)]
 struct Circle {
     radius: u32,
 }</code></pre>
@@ -17,6 +17,6 @@ Radius of the circle
 
 Fully qualified path: [hello_world](./hello_world.md)::[Circle](./hello_world-Circle.md)::[radius](./hello_world-Circle-radius.md)
 
-<pre><code class="language-rust">radius: u32</code></pre>
+<pre><code class="language-cairo">radius: u32</code></pre>
 
 

--- a/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-CircleDrop.md
+++ b/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-CircleDrop.md
@@ -2,5 +2,5 @@
 
 Fully qualified path: [hello_world](./hello_world.md)::[CircleDrop](./hello_world-CircleDrop.md)
 
-<pre><code class="language-rust">impl CircleDrop of Drop&lt;<a href="hello_world-Circle.html">Circle</a>&gt;;</code></pre>
+<pre><code class="language-cairo">impl CircleDrop of Drop&lt;<a href="hello_world-Circle.html">Circle</a>&gt;;</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-CirclePartialEq.md
+++ b/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-CirclePartialEq.md
@@ -2,7 +2,7 @@
 
 Fully qualified path: [hello_world](./hello_world.md)::[CirclePartialEq](./hello_world-CirclePartialEq.md)
 
-<pre><code class="language-rust">impl CirclePartialEq of PartialEq&lt;<a href="hello_world-Circle.html">Circle</a>&gt;;</code></pre>
+<pre><code class="language-cairo">impl CirclePartialEq of PartialEq&lt;<a href="hello_world-Circle.html">Circle</a>&gt;;</code></pre>
 
 ## Impl functions
 
@@ -10,6 +10,6 @@ Fully qualified path: [hello_world](./hello_world.md)::[CirclePartialEq](./hello
 
 Fully qualified path: [hello_world](./hello_world.md)::[CirclePartialEq](./hello_world-CirclePartialEq.md)::[eq](./hello_world-CirclePartialEq-eq.md)
 
-<pre><code class="language-rust">fn eq(lhs: Circle, rhs: Circle) -&gt; bool</code></pre>
+<pre><code class="language-cairo">fn eq(lhs: Circle, rhs: Circle) -&gt; bool</code></pre>
 
 

--- a/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-CircleSerde.md
+++ b/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-CircleSerde.md
@@ -2,7 +2,7 @@
 
 Fully qualified path: [hello_world](./hello_world.md)::[CircleSerde](./hello_world-CircleSerde.md)
 
-<pre><code class="language-rust">impl CircleSerde of Serde&lt;<a href="hello_world-Circle.html">Circle</a>&gt;;</code></pre>
+<pre><code class="language-cairo">impl CircleSerde of Serde&lt;<a href="hello_world-Circle.html">Circle</a>&gt;;</code></pre>
 
 ## Impl functions
 
@@ -10,13 +10,13 @@ Fully qualified path: [hello_world](./hello_world.md)::[CircleSerde](./hello_wor
 
 Fully qualified path: [hello_world](./hello_world.md)::[CircleSerde](./hello_world-CircleSerde.md)::[serialize](./hello_world-CircleSerde-serialize.md)
 
-<pre><code class="language-rust">fn serialize(self: Circle, ref output: Array&lt;felt252&gt;)</code></pre>
+<pre><code class="language-cairo">fn serialize(self: Circle, ref output: Array&lt;felt252&gt;)</code></pre>
 
 
 ### deserialize
 
 Fully qualified path: [hello_world](./hello_world.md)::[CircleSerde](./hello_world-CircleSerde.md)::[deserialize](./hello_world-CircleSerde-deserialize.md)
 
-<pre><code class="language-rust">fn deserialize(ref serialized: Span&lt;felt252&gt;) -&gt; Option&lt;Circle&gt;</code></pre>
+<pre><code class="language-cairo">fn deserialize(ref serialized: Span&lt;felt252&gt;) -&gt; Option&lt;Circle&gt;</code></pre>
 
 

--- a/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-CircleShape.md
+++ b/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-CircleShape.md
@@ -4,7 +4,7 @@ Implementation of the Shape trait for Circle
 
 Fully qualified path: [hello_world](./hello_world.md)::[CircleShape](./hello_world-CircleShape.md)
 
-<pre><code class="language-rust">impl CircleShape of Shape&lt;<a href="hello_world-Circle.html">Circle</a>&gt;;</code></pre>
+<pre><code class="language-cairo">impl CircleShape of Shape&lt;<a href="hello_world-Circle.html">Circle</a>&gt;;</code></pre>
 
 ## Impl constants
 
@@ -14,7 +14,7 @@ Shape constant
 
 Fully qualified path: [hello_world](./hello_world.md)::[CircleShape](./hello_world-CircleShape.md)::[SHAPE_CONST](./hello_world-CircleShape-SHAPE_CONST.md)
 
-<pre><code class="language-rust">const SHAPE_CONST: felt252 = &apos;xyz&apos;;</code></pre>
+<pre><code class="language-cairo">const SHAPE_CONST: felt252 = &apos;xyz&apos;;</code></pre>
 
 
 ## Impl functions
@@ -25,7 +25,7 @@ Implementation of the area method for Circle
 
 Fully qualified path: [hello_world](./hello_world.md)::[CircleShape](./hello_world-CircleShape.md)::[area](./hello_world-CircleShape-area.md)
 
-<pre><code class="language-rust">fn area(self: <a href="hello_world-Circle.html">Circle</a>) -&gt; u32</code></pre>
+<pre><code class="language-cairo">fn area(self: <a href="hello_world-Circle.html">Circle</a>) -&gt; u32</code></pre>
 
 
 ## Impl types
@@ -36,6 +36,6 @@ Type alias for a pair of circles
 
 Fully qualified path: [hello_world](./hello_world.md)::[CircleShape](./hello_world-CircleShape.md)::[ShapePair](./hello_world-CircleShape-ShapePair.md)
 
-<pre><code class="language-rust">type ShapePair = (Circle, Circle);</code></pre>
+<pre><code class="language-cairo">type ShapePair = (Circle, Circle);</code></pre>
 
 

--- a/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-Color.md
+++ b/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-Color.md
@@ -4,7 +4,7 @@ Color enum with Red, Green, and Blue variants
 
 Fully qualified path: [hello_world](./hello_world.md)::[Color](./hello_world-Color.md)
 
-<pre><code class="language-rust">enum Color {
+<pre><code class="language-cairo">enum Color {
     Red,
     Green,
     Blue,
@@ -18,7 +18,7 @@ Red color
 
 Fully qualified path: [hello_world](./hello_world.md)::[Color](./hello_world-Color.md)::[Red](./hello_world-Color-Red.md)
 
-<pre><code class="language-rust">Red</code></pre>
+<pre><code class="language-cairo">Red</code></pre>
 
 
 ### Green
@@ -27,7 +27,7 @@ Green color
 
 Fully qualified path: [hello_world](./hello_world.md)::[Color](./hello_world-Color.md)::[Green](./hello_world-Color-Green.md)
 
-<pre><code class="language-rust">Green</code></pre>
+<pre><code class="language-cairo">Green</code></pre>
 
 
 ### Blue
@@ -36,6 +36,6 @@ Blue color
 
 Fully qualified path: [hello_world](./hello_world.md)::[Color](./hello_world-Color.md)::[Blue](./hello_world-Color-Blue.md)
 
-<pre><code class="language-rust">Blue</code></pre>
+<pre><code class="language-cairo">Blue</code></pre>
 
 

--- a/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-FOO.md
+++ b/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-FOO.md
@@ -4,5 +4,5 @@ FOO constant with value 42
 
 Fully qualified path: [hello_world](./hello_world.md)::[FOO](./hello_world-FOO.md)
 
-<pre><code class="language-rust">const FOO: u32 = 42;</code></pre>
+<pre><code class="language-cairo">const FOO: u32 = 42;</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-Pair.md
+++ b/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-Pair.md
@@ -4,5 +4,5 @@ Pair type alias for a tuple of two u32 values
 
 Fully qualified path: [hello_world](./hello_world.md)::[Pair](./hello_world-Pair.md)
 
-<pre><code class="language-rust">type Pair = (u32, u32);</code></pre>
+<pre><code class="language-cairo">type Pair = (u32, u32);</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-Shape.md
+++ b/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-Shape.md
@@ -4,7 +4,7 @@ Shape trait for objects that have an area
 
 Fully qualified path: [hello_world](./hello_world.md)::[Shape](./hello_world-Shape.md)
 
-<pre><code class="language-rust">trait Shape&lt;T&gt;</code></pre>
+<pre><code class="language-cairo">trait Shape&lt;T&gt;</code></pre>
 
 ## Trait constants
 
@@ -14,7 +14,7 @@ Constant for the shape type
 
 Fully qualified path: [hello_world](./hello_world.md)::[Shape](./hello_world-Shape.md)::[SHAPE_CONST](./hello_world-Shape-SHAPE_CONST.md)
 
-<pre><code class="language-rust">const SHAPE_CONST: felt252;</code></pre>
+<pre><code class="language-cairo">const SHAPE_CONST: felt252;</code></pre>
 
 
 ## Trait functions
@@ -25,7 +25,7 @@ Calculate the area of the shape
 
 Fully qualified path: [hello_world](./hello_world.md)::[Shape](./hello_world-Shape.md)::[area](./hello_world-Shape-area.md)
 
-<pre><code class="language-rust">fn area&lt;T, T&gt;(self: T) -&gt; u32</code></pre>
+<pre><code class="language-cairo">fn area&lt;T, T&gt;(self: T) -&gt; u32</code></pre>
 
 
 ## Trait types
@@ -36,6 +36,6 @@ Type alias for a pair of shapes
 
 Fully qualified path: [hello_world](./hello_world.md)::[Shape](./hello_world-Shape.md)::[ShapePair](./hello_world-Shape-ShapePair.md)
 
-<pre><code class="language-rust">type ShapePair;</code></pre>
+<pre><code class="language-cairo">type ShapePair;</code></pre>
 
 

--- a/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-fib.md
+++ b/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-fib.md
@@ -7,5 +7,5 @@ Calculate the nth Fibonacci number
 
 Fully qualified path: [hello_world](./hello_world.md)::[fib](./hello_world-fib.md)
 
-<pre><code class="language-rust">fn fib(mut n: u32) -&gt; u32</code></pre>
+<pre><code class="language-cairo">fn fib(mut n: u32) -&gt; u32</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-main.md
+++ b/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-main.md
@@ -4,5 +4,5 @@ Main function that calculates the 16th Fibonacci number
 
 Fully qualified path: [hello_world](./hello_world.md)::[main](./hello_world-main.md)
 
-<pre><code class="language-rust">fn main() -&gt; u32</code></pre>
+<pre><code class="language-cairo">fn main() -&gt; u32</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-tests-it_works.md
+++ b/extensions/scarb-doc/tests/data/hello_world_no_features/src/hello_world-tests-it_works.md
@@ -5,5 +5,5 @@ works.
 
 Fully qualified path: [hello_world](./hello_world.md)::[tests](./hello_world-tests.md)::[it_works](./hello_world-tests-it_works.md)
 
-<pre><code class="language-rust">fn it_works()</code></pre>
+<pre><code class="language-cairo">fn it_works()</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_sub_package_no_features/src/hello_world_sub_package-main.md
+++ b/extensions/scarb-doc/tests/data/hello_world_sub_package_no_features/src/hello_world_sub_package-main.md
@@ -4,5 +4,5 @@ Main function that cairo runs as a binary entrypoint.
 
 Fully qualified path: [hello_world_sub_package](./hello_world_sub_package.md)::[main](./hello_world_sub_package-main.md)
 
-<pre><code class="language-rust">fn main()</code></pre>
+<pre><code class="language-cairo">fn main()</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_sub_package_no_features/src/hello_world_sub_package-test.md
+++ b/extensions/scarb-doc/tests/data/hello_world_sub_package_no_features/src/hello_world_sub_package-test.md
@@ -10,5 +10,5 @@ Can invoke it like that:
 
 Fully qualified path: [hello_world_sub_package](./hello_world_sub_package.md)::[test](./hello_world_sub_package-test.md)
 
-<pre><code class="language-rust">fn test()</code></pre>
+<pre><code class="language-cairo">fn test()</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_sub_package_with_features/src/hello_world_sub_package-main.md
+++ b/extensions/scarb-doc/tests/data/hello_world_sub_package_with_features/src/hello_world_sub_package-main.md
@@ -4,5 +4,5 @@ Main function that cairo runs as a binary entrypoint.
 
 Fully qualified path: [hello_world_sub_package](./hello_world_sub_package.md)::[main](./hello_world_sub_package-main.md)
 
-<pre><code class="language-rust">fn main()</code></pre>
+<pre><code class="language-cairo">fn main()</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_sub_package_with_features/src/hello_world_sub_package-test.md
+++ b/extensions/scarb-doc/tests/data/hello_world_sub_package_with_features/src/hello_world_sub_package-test.md
@@ -12,5 +12,5 @@ This is a under feature attribute comment.
 
 Fully qualified path: [hello_world_sub_package](./hello_world_sub_package.md)::[test](./hello_world_sub_package-test.md)
 
-<pre><code class="language-rust">fn test()</code></pre>
+<pre><code class="language-cairo">fn test()</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-Circle.md
+++ b/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-Circle.md
@@ -4,7 +4,7 @@ Circle struct with radius field
 
 Fully qualified path: [hello_world](./hello_world.md)::[Circle](./hello_world-Circle.md)
 
-<pre><code class="language-rust">#[derive(Drop, Serde, PartialEq)]
+<pre><code class="language-cairo">#[derive(Drop, Serde, PartialEq)]
 struct Circle {
     radius: u32,
 }</code></pre>
@@ -17,6 +17,6 @@ Radius of the circle
 
 Fully qualified path: [hello_world](./hello_world.md)::[Circle](./hello_world-Circle.md)::[radius](./hello_world-Circle-radius.md)
 
-<pre><code class="language-rust">radius: u32</code></pre>
+<pre><code class="language-cairo">radius: u32</code></pre>
 
 

--- a/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-CircleDrop.md
+++ b/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-CircleDrop.md
@@ -2,5 +2,5 @@
 
 Fully qualified path: [hello_world](./hello_world.md)::[CircleDrop](./hello_world-CircleDrop.md)
 
-<pre><code class="language-rust">impl CircleDrop of Drop&lt;<a href="hello_world-Circle.html">Circle</a>&gt;;</code></pre>
+<pre><code class="language-cairo">impl CircleDrop of Drop&lt;<a href="hello_world-Circle.html">Circle</a>&gt;;</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-CirclePartialEq.md
+++ b/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-CirclePartialEq.md
@@ -2,7 +2,7 @@
 
 Fully qualified path: [hello_world](./hello_world.md)::[CirclePartialEq](./hello_world-CirclePartialEq.md)
 
-<pre><code class="language-rust">impl CirclePartialEq of PartialEq&lt;<a href="hello_world-Circle.html">Circle</a>&gt;;</code></pre>
+<pre><code class="language-cairo">impl CirclePartialEq of PartialEq&lt;<a href="hello_world-Circle.html">Circle</a>&gt;;</code></pre>
 
 ## Impl functions
 
@@ -10,6 +10,6 @@ Fully qualified path: [hello_world](./hello_world.md)::[CirclePartialEq](./hello
 
 Fully qualified path: [hello_world](./hello_world.md)::[CirclePartialEq](./hello_world-CirclePartialEq.md)::[eq](./hello_world-CirclePartialEq-eq.md)
 
-<pre><code class="language-rust">fn eq(lhs: Circle, rhs: Circle) -&gt; bool</code></pre>
+<pre><code class="language-cairo">fn eq(lhs: Circle, rhs: Circle) -&gt; bool</code></pre>
 
 

--- a/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-CircleSerde.md
+++ b/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-CircleSerde.md
@@ -2,7 +2,7 @@
 
 Fully qualified path: [hello_world](./hello_world.md)::[CircleSerde](./hello_world-CircleSerde.md)
 
-<pre><code class="language-rust">impl CircleSerde of Serde&lt;<a href="hello_world-Circle.html">Circle</a>&gt;;</code></pre>
+<pre><code class="language-cairo">impl CircleSerde of Serde&lt;<a href="hello_world-Circle.html">Circle</a>&gt;;</code></pre>
 
 ## Impl functions
 
@@ -10,13 +10,13 @@ Fully qualified path: [hello_world](./hello_world.md)::[CircleSerde](./hello_wor
 
 Fully qualified path: [hello_world](./hello_world.md)::[CircleSerde](./hello_world-CircleSerde.md)::[serialize](./hello_world-CircleSerde-serialize.md)
 
-<pre><code class="language-rust">fn serialize(self: Circle, ref output: Array&lt;felt252&gt;)</code></pre>
+<pre><code class="language-cairo">fn serialize(self: Circle, ref output: Array&lt;felt252&gt;)</code></pre>
 
 
 ### deserialize
 
 Fully qualified path: [hello_world](./hello_world.md)::[CircleSerde](./hello_world-CircleSerde.md)::[deserialize](./hello_world-CircleSerde-deserialize.md)
 
-<pre><code class="language-rust">fn deserialize(ref serialized: Span&lt;felt252&gt;) -&gt; Option&lt;Circle&gt;</code></pre>
+<pre><code class="language-cairo">fn deserialize(ref serialized: Span&lt;felt252&gt;) -&gt; Option&lt;Circle&gt;</code></pre>
 
 

--- a/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-CircleShape.md
+++ b/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-CircleShape.md
@@ -4,7 +4,7 @@ Implementation of the Shape trait for Circle
 
 Fully qualified path: [hello_world](./hello_world.md)::[CircleShape](./hello_world-CircleShape.md)
 
-<pre><code class="language-rust">impl CircleShape of Shape&lt;<a href="hello_world-Circle.html">Circle</a>&gt;;</code></pre>
+<pre><code class="language-cairo">impl CircleShape of Shape&lt;<a href="hello_world-Circle.html">Circle</a>&gt;;</code></pre>
 
 ## Impl constants
 
@@ -14,7 +14,7 @@ Shape constant
 
 Fully qualified path: [hello_world](./hello_world.md)::[CircleShape](./hello_world-CircleShape.md)::[SHAPE_CONST](./hello_world-CircleShape-SHAPE_CONST.md)
 
-<pre><code class="language-rust">const SHAPE_CONST: felt252 = &apos;xyz&apos;;</code></pre>
+<pre><code class="language-cairo">const SHAPE_CONST: felt252 = &apos;xyz&apos;;</code></pre>
 
 
 ## Impl functions
@@ -25,7 +25,7 @@ Implementation of the area method for Circle
 
 Fully qualified path: [hello_world](./hello_world.md)::[CircleShape](./hello_world-CircleShape.md)::[area](./hello_world-CircleShape-area.md)
 
-<pre><code class="language-rust">fn area(self: <a href="hello_world-Circle.html">Circle</a>) -&gt; u32</code></pre>
+<pre><code class="language-cairo">fn area(self: <a href="hello_world-Circle.html">Circle</a>) -&gt; u32</code></pre>
 
 
 ## Impl types
@@ -36,6 +36,6 @@ Type alias for a pair of circles
 
 Fully qualified path: [hello_world](./hello_world.md)::[CircleShape](./hello_world-CircleShape.md)::[ShapePair](./hello_world-CircleShape-ShapePair.md)
 
-<pre><code class="language-rust">type ShapePair = (Circle, Circle);</code></pre>
+<pre><code class="language-cairo">type ShapePair = (Circle, Circle);</code></pre>
 
 

--- a/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-Color.md
+++ b/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-Color.md
@@ -4,7 +4,7 @@ Color enum with Red, Green, and Blue variants
 
 Fully qualified path: [hello_world](./hello_world.md)::[Color](./hello_world-Color.md)
 
-<pre><code class="language-rust">enum Color {
+<pre><code class="language-cairo">enum Color {
     Red,
     Green,
     Blue,
@@ -18,7 +18,7 @@ Red color
 
 Fully qualified path: [hello_world](./hello_world.md)::[Color](./hello_world-Color.md)::[Red](./hello_world-Color-Red.md)
 
-<pre><code class="language-rust">Red</code></pre>
+<pre><code class="language-cairo">Red</code></pre>
 
 
 ### Green
@@ -27,7 +27,7 @@ Green color
 
 Fully qualified path: [hello_world](./hello_world.md)::[Color](./hello_world-Color.md)::[Green](./hello_world-Color-Green.md)
 
-<pre><code class="language-rust">Green</code></pre>
+<pre><code class="language-cairo">Green</code></pre>
 
 
 ### Blue
@@ -36,6 +36,6 @@ Blue color
 
 Fully qualified path: [hello_world](./hello_world.md)::[Color](./hello_world-Color.md)::[Blue](./hello_world-Color-Blue.md)
 
-<pre><code class="language-rust">Blue</code></pre>
+<pre><code class="language-cairo">Blue</code></pre>
 
 

--- a/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-FOO.md
+++ b/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-FOO.md
@@ -4,5 +4,5 @@ FOO constant with value 42
 
 Fully qualified path: [hello_world](./hello_world.md)::[FOO](./hello_world-FOO.md)
 
-<pre><code class="language-rust">const FOO: u32 = 42;</code></pre>
+<pre><code class="language-cairo">const FOO: u32 = 42;</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-Pair.md
+++ b/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-Pair.md
@@ -4,5 +4,5 @@ Pair type alias for a tuple of two u32 values
 
 Fully qualified path: [hello_world](./hello_world.md)::[Pair](./hello_world-Pair.md)
 
-<pre><code class="language-rust">type Pair = (u32, u32);</code></pre>
+<pre><code class="language-cairo">type Pair = (u32, u32);</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-Shape.md
+++ b/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-Shape.md
@@ -4,7 +4,7 @@ Shape trait for objects that have an area
 
 Fully qualified path: [hello_world](./hello_world.md)::[Shape](./hello_world-Shape.md)
 
-<pre><code class="language-rust">trait Shape&lt;T&gt;</code></pre>
+<pre><code class="language-cairo">trait Shape&lt;T&gt;</code></pre>
 
 ## Trait constants
 
@@ -14,7 +14,7 @@ Constant for the shape type
 
 Fully qualified path: [hello_world](./hello_world.md)::[Shape](./hello_world-Shape.md)::[SHAPE_CONST](./hello_world-Shape-SHAPE_CONST.md)
 
-<pre><code class="language-rust">const SHAPE_CONST: felt252;</code></pre>
+<pre><code class="language-cairo">const SHAPE_CONST: felt252;</code></pre>
 
 
 ## Trait functions
@@ -25,7 +25,7 @@ Calculate the area of the shape
 
 Fully qualified path: [hello_world](./hello_world.md)::[Shape](./hello_world-Shape.md)::[area](./hello_world-Shape-area.md)
 
-<pre><code class="language-rust">fn area&lt;T, T&gt;(self: T) -&gt; u32</code></pre>
+<pre><code class="language-cairo">fn area&lt;T, T&gt;(self: T) -&gt; u32</code></pre>
 
 
 ## Trait types
@@ -36,6 +36,6 @@ Type alias for a pair of shapes
 
 Fully qualified path: [hello_world](./hello_world.md)::[Shape](./hello_world-Shape.md)::[ShapePair](./hello_world-Shape-ShapePair.md)
 
-<pre><code class="language-rust">type ShapePair;</code></pre>
+<pre><code class="language-cairo">type ShapePair;</code></pre>
 
 

--- a/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-fib.md
+++ b/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-fib.md
@@ -7,5 +7,5 @@ Calculate the nth Fibonacci number
 
 Fully qualified path: [hello_world](./hello_world.md)::[fib](./hello_world-fib.md)
 
-<pre><code class="language-rust">fn fib(mut n: u32) -&gt; u32</code></pre>
+<pre><code class="language-cairo">fn fib(mut n: u32) -&gt; u32</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-main.md
+++ b/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-main.md
@@ -4,5 +4,5 @@ Main function that calculates the 16th Fibonacci number
 
 Fully qualified path: [hello_world](./hello_world.md)::[main](./hello_world-main.md)
 
-<pre><code class="language-rust">fn main() -&gt; u32</code></pre>
+<pre><code class="language-cairo">fn main() -&gt; u32</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-test.md
+++ b/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-test.md
@@ -10,5 +10,5 @@ Can invoke it like that:
 
 Fully qualified path: [hello_world](./hello_world.md)::[test](./hello_world-test.md)
 
-<pre><code class="language-rust">fn test()</code></pre>
+<pre><code class="language-cairo">fn test()</code></pre>
 

--- a/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-tests-it_works.md
+++ b/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-tests-it_works.md
@@ -5,5 +5,5 @@ works.
 
 Fully qualified path: [hello_world](./hello_world.md)::[tests](./hello_world-tests.md)::[it_works](./hello_world-tests-it_works.md)
 
-<pre><code class="language-rust">fn it_works()</code></pre>
+<pre><code class="language-cairo">fn it_works()</code></pre>
 

--- a/extensions/scarb-doc/tests/mdbook.rs
+++ b/extensions/scarb-doc/tests/mdbook.rs
@@ -1,0 +1,43 @@
+use assert_fs::TempDir;
+use scarb_test_support::command::Scarb;
+use scarb_test_support::project_builder::ProjectBuilder;
+
+const FIBONACCI_CODE_WITHOUT_FEATURE: &str = include_str!("code/code_1.cairo");
+
+#[test]
+fn can_build_mdbook_with_build_arg() {
+    let t = TempDir::new().unwrap();
+    ProjectBuilder::start()
+        .name("hello_world")
+        .edition("2023_01")
+        .lib_cairo(FIBONACCI_CODE_WITHOUT_FEATURE)
+        .build(&t);
+
+    Scarb::quick_snapbox()
+        .arg("doc")
+        .arg("--build")
+        .current_dir(&t)
+        .assert()
+        .success();
+
+    assert!(
+        t.path().join("target/doc/hello_world/book").exists(),
+        "book dir not found"
+    );
+    assert!(
+        t.path().join("target/doc/hello_world/book").is_dir(),
+        "book dir not a directory"
+    );
+    assert!(
+        t.path()
+            .join("target/doc/hello_world/book/index.html")
+            .exists(),
+        "index.html not found"
+    );
+    assert!(
+        t.path()
+            .join("target/doc/hello_world/book/hello_world.html")
+            .exists(),
+        "hello_world.html not found"
+    );
+}

--- a/website/docs/extensions/documentation-generation.md
+++ b/website/docs/extensions/documentation-generation.md
@@ -25,12 +25,15 @@ Currenctly we support only those types of links:
 
 ## mdBook
 
-Generated markdown can be used to create a documentation book.
-Requirements:
+Generated markdown can be used to build a [mdBook](https://rust-lang.github.io/mdBook) documentation.
+You can do this directly from Scarb by running `scarb doc` with `--build` argument.
+
+Alternatively, you can do this manually with the following steps:
 
 - Install [mdBook](https://rust-lang.github.io/mdBook/guide/installation.html) by running `cargo install mdbook`.
 - Run `scarb doc` inside the project root.
 - Run `mdbook build` (or `mdbook serve`) inside the generated documentation target (`/target/doc/<PACKAGE-NAME>`).
+  By default, mdBook generated documentation doesn't support Cairo code highlighting. To make it work, just replace the generated `book/highlight.js` with [this](https://github.com/software-mansion/scarb/tree/main/extensions/scarb-mdbook/theme) one.
 
 ## Examples
 
@@ -85,7 +88,3 @@ After running `scarb doc`, inside the target directory, you will see the generat
 - The `book.toml` which contains contains settings for describing how to build your book.
 
 Running `scarb doc --output-format json` will result in a single JSON file inside the target directory with collected documentation inside.
-
-## Cairo code highlighting using mdBook
-
-By default, mdBook generated documentation doesn't support Cairo code highlighting. To make it work, just replace the generated `book/highlight.js` with [this](https://github.com/software-mansion/scarb/tree/main/extensions/scarb-mdbook/theme) one.


### PR DESCRIPTION
Mark code blocks as Cairo not Rust

Add option to build straight from scarb-doc