### PR TITLE
Inform about the source packages for proc macros in PMS

### DIFF
--- a/utils/scarb-proc-macro-server-types/src/methods/defined_macros.rs
+++ b/utils/scarb-proc-macro-server-types/src/methods/defined_macros.rs
@@ -34,6 +34,16 @@ pub struct CompilationUnitComponentMacros {
     pub derives: Vec<String>,
     /// List of executable attributes available.
     pub executables: Vec<String>,
+    /// Additional debug information.
+    pub debug_info: DebugInfo,
+}
+
+/// Stores extra information about the macros managed by the server.
+/// Used for debugging on the LS side.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct DebugInfo {
+    /// Serialized `PackageId`s of Rust packages which define the procedural macros.
+    pub source_packages: Vec<String>,
 }
 
 /// Parameters for the request to retrieve all defined macros.


### PR DESCRIPTION
## Changes
* `DefinedMacrosResponse` from `proc-macro-server-types` contains an additional field `debug_info: DebugInfo`.
* `DebugInfo` contains a field `source_packages` which informs about the proc macro packages loaded by the server.