### PR TITLE
Run proc macro expansion before executable plugin

### DIFF
--- a/scarb/src/compiler/plugin/builtin.rs
+++ b/scarb/src/compiler/plugin/builtin.rs
@@ -46,6 +46,10 @@ impl CairoPlugin for BuiltinExecutablePlugin {
     fn instantiate(&self) -> Result<Box<dyn CairoPluginInstance>> {
         Ok(Box::new(BuiltinExecutablePluginInstance))
     }
+
+    fn post_proc_macros(&self) -> bool {
+        true
+    }
 }
 
 struct BuiltinExecutablePluginInstance;

--- a/scarb/src/compiler/plugin/mod.rs
+++ b/scarb/src/compiler/plugin/mod.rs
@@ -46,6 +46,9 @@ pub fn fetch_cairo_plugin(package: &Package, ws: &Workspace<'_>) -> Result<()> {
 pub trait CairoPlugin: Sync {
     fn id(&self) -> PackageId;
     fn instantiate(&self) -> Result<Box<dyn CairoPluginInstance>>;
+    fn post_proc_macros(&self) -> bool {
+        false
+    }
 }
 
 pub trait CairoPluginInstance {

--- a/scarb/tests/proc_macro_v2_build.rs
+++ b/scarb/tests/proc_macro_v2_build.rs
@@ -273,30 +273,36 @@ fn can_define_multiple_macros() {
         .dep_starknet()
         .dep("some", &t)
         .dep("other", &w)
+        .dep_cairo_execute()
+        .manifest_extra(indoc! {r#"
+            [executable]
+
+            [cairo]
+            enable-gas = false
+        "#})
         .lib_cairo(indoc! {r#"
             #[hello]
             #[beautiful]
             #[world]
+            #[executable]
             fn main() -> felt252 { 12 + 56 + 90 }
         "#})
         .build(&project);
 
     Scarb::quick_snapbox()
-        .arg("cairo-run")
+        .arg("execute")
         // Disable output from Cargo.
         .env("CARGO_TERM_QUIET", "true")
         .current_dir(&project)
         .assert()
         .success()
         .stdout_matches(indoc! {r#"
-            warn: `scarb cairo-run` will be deprecated soon
-            help: use `scarb execute` instead
             [..]Compiling other v1.0.0 ([..]Scarb.toml)
             [..]Compiling some v1.0.0 ([..]Scarb.toml)
             [..]Compiling hello v1.0.0 ([..]Scarb.toml)
             [..]Finished `dev` profile target(s) in [..]
-            [..]Running hello
-            Run completed successfully, returning [121]
+            [..]Executing hello
+            Saving output to: target/execute/hello/execution1
         "#});
 }
 


### PR DESCRIPTION
Expanding a proc macro attribute on a function creates a virtual file with the expanded implementation and removes the old node. The executable plugin generates a new function - wrapper, which calls the original one. If we run executable plugin before proc macros, using a proc macro attribute on executable function would cause it to be duplicated (and thus fail with error).  