### PR TITLE
Fix nightly/dev upload setting latest flag

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -202,7 +202,7 @@ jobs:
           gh release create \
             "${{ needs.prepare.outputs.nightly_tag }}" \
             --repo software-mansion/scarb-nightlies \
-            ${{ !inputs.is_dev && '--latest' || '' }} \
+            ${{ !inputs.is_dev && '--latest' || '--latest=false' }} \
             --title "${{ needs.prepare.outputs.nightly_tag }}" \
             --notes-file NIGHTLY_RELEASE_NOTES.md
         env:


### PR DESCRIPTION
Docs: https://cli.github.com/manual/gh_release_create
"Mark this release as "Latest" (default [automatic based on date and version]). --latest=false to explicitly NOT set as latest"
