### PR TITLE
ref: document pub uses

### DIFF
--- a/extensions/scarb-doc/src/docs_generation/markdown/summary.rs
+++ b/extensions/scarb-doc/src/docs_generation/markdown/summary.rs
@@ -61,6 +61,7 @@ pub fn generate_modules_summary_content(
         impls,
         extern_types,
         extern_functions,
+        ..
     } = &module;
 
     top_level_items.modules.extend(submodules);

--- a/extensions/scarb-doc/src/lib.rs
+++ b/extensions/scarb-doc/src/lib.rs
@@ -87,8 +87,9 @@ pub fn generate_packages_information(
             setup_diagnostics_reporter(&db, main_crate_id, package_compilation_unit, &ui)
                 .skip_lowering_diagnostics();
 
-        let crate_ = Crate::new(&db, main_crate_id, should_document_private_items)
-            .map_err(|_| DiagnosticError(package_metadata.name.clone()));
+        let crate_ =
+            Crate::new_with_virtual_modules(&db, main_crate_id, should_document_private_items)
+                .map_err(|_| DiagnosticError(package_metadata.name.clone()));
 
         if crate_.is_err() {
             diagnostics_reporter.ensure(&db)?;

--- a/extensions/scarb-doc/tests/data/json_doc_hidden.json
+++ b/extensions/scarb-doc/tests/data/json_doc_hidden.json
@@ -29,7 +29,20 @@
           "traits": [],
           "impls": [],
           "extern_types": [],
-          "extern_functions": []
+          "extern_functions": [],
+          "pub_uses": {
+            "use_constants": [],
+            "use_free_functions": [],
+            "use_structs": [],
+            "use_enums": [],
+            "use_module_type_aliases": [],
+            "use_impl_aliases": [],
+            "use_traits": [],
+            "use_impl_defs": [],
+            "use_extern_types": [],
+            "use_extern_functions": [],
+            "use_submodules": []
+          }
         }
       },
       "metadata": {

--- a/extensions/scarb-doc/tests/data/json_doc_hidden_impls.json
+++ b/extensions/scarb-doc/tests/data/json_doc_hidden_impls.json
@@ -76,7 +76,20 @@
             }
           ],
           "extern_types": [],
-          "extern_functions": []
+          "extern_functions": [],
+          "pub_uses": {
+            "use_constants": [],
+            "use_free_functions": [],
+            "use_structs": [],
+            "use_enums": [],
+            "use_module_type_aliases": [],
+            "use_impl_aliases": [],
+            "use_traits": [],
+            "use_impl_defs": [],
+            "use_extern_types": [],
+            "use_extern_functions": [],
+            "use_submodules": []
+          }
         }
       },
       "metadata": {

--- a/extensions/scarb-doc/tests/data/json_output_test_data.json
+++ b/extensions/scarb-doc/tests/data/json_output_test_data.json
@@ -20,7 +20,20 @@
           "traits": [],
           "impls": [],
           "extern_types": [],
-          "extern_functions": []
+          "extern_functions": [],
+          "pub_uses": {
+            "use_constants": [],
+            "use_free_functions": [],
+            "use_structs": [],
+            "use_enums": [],
+            "use_module_type_aliases": [],
+            "use_impl_aliases": [],
+            "use_traits": [],
+            "use_impl_defs": [],
+            "use_extern_types": [],
+            "use_extern_functions": [],
+            "use_submodules": []
+          }
         }
       },
       "metadata": {

--- a/extensions/scarb-doc/tests/data/json_private_items_excluded.json
+++ b/extensions/scarb-doc/tests/data/json_private_items_excluded.json
@@ -83,7 +83,20 @@
                   "traits": [],
                   "impls": [],
                   "extern_types": [],
-                  "extern_functions": []
+                  "extern_functions": [],
+                  "pub_uses": {
+                    "use_constants": [],
+                    "use_free_functions": [],
+                    "use_structs": [],
+                    "use_enums": [],
+                    "use_module_type_aliases": [],
+                    "use_impl_aliases": [],
+                    "use_traits": [],
+                    "use_impl_defs": [],
+                    "use_extern_types": [],
+                    "use_extern_functions": [],
+                    "use_submodules": []
+                  }
                 }
               ],
               "constants": [],
@@ -142,7 +155,20 @@
               "traits": [],
               "impls": [],
               "extern_types": [],
-              "extern_functions": []
+              "extern_functions": [],
+              "pub_uses": {
+                "use_constants": [],
+                "use_free_functions": [],
+                "use_structs": [],
+                "use_enums": [],
+                "use_module_type_aliases": [],
+                "use_impl_aliases": [],
+                "use_traits": [],
+                "use_impl_defs": [],
+                "use_extern_types": [],
+                "use_extern_functions": [],
+                "use_submodules": []
+              }
             }
           ],
           "constants": [],
@@ -201,7 +227,20 @@
           "traits": [],
           "impls": [],
           "extern_types": [],
-          "extern_functions": []
+          "extern_functions": [],
+          "pub_uses": {
+            "use_constants": [],
+            "use_free_functions": [],
+            "use_structs": [],
+            "use_enums": [],
+            "use_module_type_aliases": [],
+            "use_impl_aliases": [],
+            "use_traits": [],
+            "use_impl_defs": [],
+            "use_extern_types": [],
+            "use_extern_functions": [],
+            "use_submodules": []
+          }
         }
       },
       "metadata": {

--- a/extensions/scarb-doc/tests/data/json_private_items_included.json
+++ b/extensions/scarb-doc/tests/data/json_private_items_included.json
@@ -219,7 +219,20 @@
                   "traits": [],
                   "impls": [],
                   "extern_types": [],
-                  "extern_functions": []
+                  "extern_functions": [],
+                  "pub_uses": {
+                    "use_constants": [],
+                    "use_free_functions": [],
+                    "use_structs": [],
+                    "use_enums": [],
+                    "use_module_type_aliases": [],
+                    "use_impl_aliases": [],
+                    "use_traits": [],
+                    "use_impl_defs": [],
+                    "use_extern_types": [],
+                    "use_extern_functions": [],
+                    "use_submodules": []
+                  }
                 },
                 {
                   "item_data": {
@@ -421,7 +434,20 @@
                   "traits": [],
                   "impls": [],
                   "extern_types": [],
-                  "extern_functions": []
+                  "extern_functions": [],
+                  "pub_uses": {
+                    "use_constants": [],
+                    "use_free_functions": [],
+                    "use_structs": [],
+                    "use_enums": [],
+                    "use_module_type_aliases": [],
+                    "use_impl_aliases": [],
+                    "use_traits": [],
+                    "use_impl_defs": [],
+                    "use_extern_types": [],
+                    "use_extern_functions": [],
+                    "use_submodules": []
+                  }
                 },
                 {
                   "item_data": {
@@ -623,7 +649,20 @@
                   "traits": [],
                   "impls": [],
                   "extern_types": [],
-                  "extern_functions": []
+                  "extern_functions": [],
+                  "pub_uses": {
+                    "use_constants": [],
+                    "use_free_functions": [],
+                    "use_structs": [],
+                    "use_enums": [],
+                    "use_module_type_aliases": [],
+                    "use_impl_aliases": [],
+                    "use_traits": [],
+                    "use_impl_defs": [],
+                    "use_extern_types": [],
+                    "use_extern_functions": [],
+                    "use_submodules": []
+                  }
                 }
               ],
               "constants": [],
@@ -818,7 +857,20 @@
               "traits": [],
               "impls": [],
               "extern_types": [],
-              "extern_functions": []
+              "extern_functions": [],
+              "pub_uses": {
+                "use_constants": [],
+                "use_free_functions": [],
+                "use_structs": [],
+                "use_enums": [],
+                "use_module_type_aliases": [],
+                "use_impl_aliases": [],
+                "use_traits": [],
+                "use_impl_defs": [],
+                "use_extern_types": [],
+                "use_extern_functions": [],
+                "use_submodules": []
+              }
             },
             {
               "item_data": {
@@ -1028,7 +1080,20 @@
                   "traits": [],
                   "impls": [],
                   "extern_types": [],
-                  "extern_functions": []
+                  "extern_functions": [],
+                  "pub_uses": {
+                    "use_constants": [],
+                    "use_free_functions": [],
+                    "use_structs": [],
+                    "use_enums": [],
+                    "use_module_type_aliases": [],
+                    "use_impl_aliases": [],
+                    "use_traits": [],
+                    "use_impl_defs": [],
+                    "use_extern_types": [],
+                    "use_extern_functions": [],
+                    "use_submodules": []
+                  }
                 },
                 {
                   "item_data": {
@@ -1230,7 +1295,20 @@
                   "traits": [],
                   "impls": [],
                   "extern_types": [],
-                  "extern_functions": []
+                  "extern_functions": [],
+                  "pub_uses": {
+                    "use_constants": [],
+                    "use_free_functions": [],
+                    "use_structs": [],
+                    "use_enums": [],
+                    "use_module_type_aliases": [],
+                    "use_impl_aliases": [],
+                    "use_traits": [],
+                    "use_impl_defs": [],
+                    "use_extern_types": [],
+                    "use_extern_functions": [],
+                    "use_submodules": []
+                  }
                 },
                 {
                   "item_data": {
@@ -1432,7 +1510,20 @@
                   "traits": [],
                   "impls": [],
                   "extern_types": [],
-                  "extern_functions": []
+                  "extern_functions": [],
+                  "pub_uses": {
+                    "use_constants": [],
+                    "use_free_functions": [],
+                    "use_structs": [],
+                    "use_enums": [],
+                    "use_module_type_aliases": [],
+                    "use_impl_aliases": [],
+                    "use_traits": [],
+                    "use_impl_defs": [],
+                    "use_extern_types": [],
+                    "use_extern_functions": [],
+                    "use_submodules": []
+                  }
                 }
               ],
               "constants": [],
@@ -1627,7 +1718,20 @@
               "traits": [],
               "impls": [],
               "extern_types": [],
-              "extern_functions": []
+              "extern_functions": [],
+              "pub_uses": {
+                "use_constants": [],
+                "use_free_functions": [],
+                "use_structs": [],
+                "use_enums": [],
+                "use_module_type_aliases": [],
+                "use_impl_aliases": [],
+                "use_traits": [],
+                "use_impl_defs": [],
+                "use_extern_types": [],
+                "use_extern_functions": [],
+                "use_submodules": []
+              }
             },
             {
               "item_data": {
@@ -1837,7 +1941,20 @@
                   "traits": [],
                   "impls": [],
                   "extern_types": [],
-                  "extern_functions": []
+                  "extern_functions": [],
+                  "pub_uses": {
+                    "use_constants": [],
+                    "use_free_functions": [],
+                    "use_structs": [],
+                    "use_enums": [],
+                    "use_module_type_aliases": [],
+                    "use_impl_aliases": [],
+                    "use_traits": [],
+                    "use_impl_defs": [],
+                    "use_extern_types": [],
+                    "use_extern_functions": [],
+                    "use_submodules": []
+                  }
                 },
                 {
                   "item_data": {
@@ -2039,7 +2156,20 @@
                   "traits": [],
                   "impls": [],
                   "extern_types": [],
-                  "extern_functions": []
+                  "extern_functions": [],
+                  "pub_uses": {
+                    "use_constants": [],
+                    "use_free_functions": [],
+                    "use_structs": [],
+                    "use_enums": [],
+                    "use_module_type_aliases": [],
+                    "use_impl_aliases": [],
+                    "use_traits": [],
+                    "use_impl_defs": [],
+                    "use_extern_types": [],
+                    "use_extern_functions": [],
+                    "use_submodules": []
+                  }
                 },
                 {
                   "item_data": {
@@ -2241,7 +2371,20 @@
                   "traits": [],
                   "impls": [],
                   "extern_types": [],
-                  "extern_functions": []
+                  "extern_functions": [],
+                  "pub_uses": {
+                    "use_constants": [],
+                    "use_free_functions": [],
+                    "use_structs": [],
+                    "use_enums": [],
+                    "use_module_type_aliases": [],
+                    "use_impl_aliases": [],
+                    "use_traits": [],
+                    "use_impl_defs": [],
+                    "use_extern_types": [],
+                    "use_extern_functions": [],
+                    "use_submodules": []
+                  }
                 }
               ],
               "constants": [],
@@ -2436,7 +2579,20 @@
               "traits": [],
               "impls": [],
               "extern_types": [],
-              "extern_functions": []
+              "extern_functions": [],
+              "pub_uses": {
+                "use_constants": [],
+                "use_free_functions": [],
+                "use_structs": [],
+                "use_enums": [],
+                "use_module_type_aliases": [],
+                "use_impl_aliases": [],
+                "use_traits": [],
+                "use_impl_defs": [],
+                "use_extern_types": [],
+                "use_extern_functions": [],
+                "use_submodules": []
+              }
             }
           ],
           "constants": [],
@@ -2639,7 +2795,20 @@
           "traits": [],
           "impls": [],
           "extern_types": [],
-          "extern_functions": []
+          "extern_functions": [],
+          "pub_uses": {
+            "use_constants": [],
+            "use_free_functions": [],
+            "use_structs": [],
+            "use_enums": [],
+            "use_module_type_aliases": [],
+            "use_impl_aliases": [],
+            "use_traits": [],
+            "use_impl_defs": [],
+            "use_extern_types": [],
+            "use_extern_functions": [],
+            "use_submodules": []
+          }
         }
       },
       "metadata": {

--- a/extensions/scarb-doc/tests/data/json_reexports.json
+++ b/extensions/scarb-doc/tests/data/json_reexports.json
@@ -10,163 +10,7 @@
             "signature": null,
             "full_path": "hello_world"
           },
-          "submodules": [
-            {
-              "item_data": {
-                "name": "sub_package",
-                "doc": null,
-                "signature": null,
-                "full_path": "sub_package"
-              },
-              "submodules": [
-                {
-                  "item_data": {
-                    "name": "inside_sub_module",
-                    "doc": null,
-                    "signature": null,
-                    "full_path": "sub_package::inside_sub_module"
-                  },
-                  "submodules": [],
-                  "constants": [],
-                  "free_functions": [],
-                  "structs": [],
-                  "enums": [],
-                  "type_aliases": [],
-                  "impl_aliases": [],
-                  "traits": [],
-                  "impls": [],
-                  "extern_types": [],
-                  "extern_functions": []
-                }
-              ],
-              "constants": [
-                {
-                  "item_data": {
-                    "name": "ABC",
-                    "doc": null,
-                    "signature": "pub const ABC: u32 = 44;",
-                    "full_path": "sub_package::ABC"
-                  }
-                }
-              ],
-              "free_functions": [
-                {
-                  "item_data": {
-                    "name": "display",
-                    "doc": null,
-                    "signature": "pub fn display()",
-                    "full_path": "sub_package::display"
-                  }
-                }
-              ],
-              "structs": [
-                {
-                  "members": [],
-                  "item_data": {
-                    "name": "TestStruct",
-                    "doc": null,
-                    "signature": "pub struct TestStruct {\n    abc: u32,\n}",
-                    "full_path": "sub_package::TestStruct"
-                  }
-                }
-              ],
-              "enums": [
-                {
-                  "variants": [
-                    {
-                      "item_data": {
-                        "name": "Var1",
-                        "doc": null,
-                        "signature": "Var1",
-                        "full_path": "sub_package::TestEnum::Var1"
-                      }
-                    }
-                  ],
-                  "item_data": {
-                    "name": "TestEnum",
-                    "doc": null,
-                    "signature": "pub enum TestEnum {\n    Var1,\n}",
-                    "full_path": "sub_package::TestEnum"
-                  }
-                }
-              ],
-              "type_aliases": [
-                {
-                  "item_data": {
-                    "name": "Type",
-                    "doc": null,
-                    "signature": "pub type Type = u32;",
-                    "full_path": "sub_package::Type"
-                  }
-                }
-              ],
-              "impl_aliases": [],
-              "traits": [
-                {
-                  "trait_constants": [],
-                  "trait_types": [],
-                  "trait_functions": [
-                    {
-                      "item_data": {
-                        "name": "test",
-                        "doc": null,
-                        "signature": "fn test()",
-                        "full_path": "sub_package::TestTrait::test"
-                      }
-                    }
-                  ],
-                  "item_data": {
-                    "name": "TestTrait",
-                    "doc": null,
-                    "signature": "pub trait TestTrait",
-                    "full_path": "sub_package::TestTrait"
-                  }
-                }
-              ],
-              "impls": [
-                {
-                  "impl_types": [],
-                  "impl_constants": [],
-                  "impl_functions": [
-                    {
-                      "item_data": {
-                        "name": "test",
-                        "doc": null,
-                        "signature": "fn test()",
-                        "full_path": "sub_package::TestImpl::test"
-                      }
-                    }
-                  ],
-                  "item_data": {
-                    "name": "TestImpl",
-                    "doc": null,
-                    "signature": "pub impl TestImpl of TestTrait;",
-                    "full_path": "sub_package::TestImpl"
-                  }
-                }
-              ],
-              "extern_types": [
-                {
-                  "item_data": {
-                    "name": "ExternalType",
-                    "doc": null,
-                    "signature": "pub extern type ExternalType;",
-                    "full_path": "sub_package::ExternalType"
-                  }
-                }
-              ],
-              "extern_functions": [
-                {
-                  "item_data": {
-                    "name": "extern_function",
-                    "doc": null,
-                    "signature": "pub extern fn extern_function() -> u32 nopanic;",
-                    "full_path": "sub_package::extern_function"
-                  }
-                }
-              ]
-            }
-          ],
+          "submodules": [],
           "constants": [],
           "free_functions": [],
           "structs": [],
@@ -176,7 +20,202 @@
           "traits": [],
           "impls": [],
           "extern_types": [],
-          "extern_functions": []
+          "extern_functions": [],
+          "pub_uses": {
+            "use_constants": [],
+            "use_free_functions": [],
+            "use_structs": [],
+            "use_enums": [],
+            "use_module_type_aliases": [],
+            "use_impl_aliases": [],
+            "use_traits": [],
+            "use_impl_defs": [],
+            "use_extern_types": [],
+            "use_extern_functions": [],
+            "use_submodules": [
+              {
+                "item_data": {
+                  "name": "sub_package",
+                  "doc": null,
+                  "signature": null,
+                  "full_path": "sub_package"
+                },
+                "submodules": [
+                  {
+                    "item_data": {
+                      "name": "inside_sub_module",
+                      "doc": null,
+                      "signature": null,
+                      "full_path": "sub_package::inside_sub_module"
+                    },
+                    "submodules": [],
+                    "constants": [],
+                    "free_functions": [],
+                    "structs": [],
+                    "enums": [],
+                    "type_aliases": [],
+                    "impl_aliases": [],
+                    "traits": [],
+                    "impls": [],
+                    "extern_types": [],
+                    "extern_functions": [],
+                    "pub_uses": {
+                      "use_constants": [],
+                      "use_free_functions": [],
+                      "use_structs": [],
+                      "use_enums": [],
+                      "use_module_type_aliases": [],
+                      "use_impl_aliases": [],
+                      "use_traits": [],
+                      "use_impl_defs": [],
+                      "use_extern_types": [],
+                      "use_extern_functions": [],
+                      "use_submodules": []
+                    }
+                  }
+                ],
+                "constants": [
+                  {
+                    "item_data": {
+                      "name": "ABC",
+                      "doc": null,
+                      "signature": "pub const ABC: u32 = 44;",
+                      "full_path": "sub_package::ABC"
+                    }
+                  }
+                ],
+                "free_functions": [
+                  {
+                    "item_data": {
+                      "name": "display",
+                      "doc": null,
+                      "signature": "pub fn display()",
+                      "full_path": "sub_package::display"
+                    }
+                  }
+                ],
+                "structs": [
+                  {
+                    "members": [],
+                    "item_data": {
+                      "name": "TestStruct",
+                      "doc": null,
+                      "signature": "pub struct TestStruct {\n    abc: u32,\n}",
+                      "full_path": "sub_package::TestStruct"
+                    }
+                  }
+                ],
+                "enums": [
+                  {
+                    "variants": [
+                      {
+                        "item_data": {
+                          "name": "Var1",
+                          "doc": null,
+                          "signature": "Var1",
+                          "full_path": "sub_package::TestEnum::Var1"
+                        }
+                      }
+                    ],
+                    "item_data": {
+                      "name": "TestEnum",
+                      "doc": null,
+                      "signature": "pub enum TestEnum {\n    Var1,\n}",
+                      "full_path": "sub_package::TestEnum"
+                    }
+                  }
+                ],
+                "type_aliases": [
+                  {
+                    "item_data": {
+                      "name": "Type",
+                      "doc": null,
+                      "signature": "pub type Type = u32;",
+                      "full_path": "sub_package::Type"
+                    }
+                  }
+                ],
+                "impl_aliases": [],
+                "traits": [
+                  {
+                    "trait_constants": [],
+                    "trait_types": [],
+                    "trait_functions": [
+                      {
+                        "item_data": {
+                          "name": "test",
+                          "doc": null,
+                          "signature": "fn test()",
+                          "full_path": "sub_package::TestTrait::test"
+                        }
+                      }
+                    ],
+                    "item_data": {
+                      "name": "TestTrait",
+                      "doc": null,
+                      "signature": "pub trait TestTrait",
+                      "full_path": "sub_package::TestTrait"
+                    }
+                  }
+                ],
+                "impls": [
+                  {
+                    "impl_types": [],
+                    "impl_constants": [],
+                    "impl_functions": [
+                      {
+                        "item_data": {
+                          "name": "test",
+                          "doc": null,
+                          "signature": "fn test()",
+                          "full_path": "sub_package::TestImpl::test"
+                        }
+                      }
+                    ],
+                    "item_data": {
+                      "name": "TestImpl",
+                      "doc": null,
+                      "signature": "pub impl TestImpl of TestTrait;",
+                      "full_path": "sub_package::TestImpl"
+                    }
+                  }
+                ],
+                "extern_types": [
+                  {
+                    "item_data": {
+                      "name": "ExternalType",
+                      "doc": null,
+                      "signature": "pub extern type ExternalType;",
+                      "full_path": "sub_package::ExternalType"
+                    }
+                  }
+                ],
+                "extern_functions": [
+                  {
+                    "item_data": {
+                      "name": "extern_function",
+                      "doc": null,
+                      "signature": "pub extern fn extern_function() -> u32 nopanic;",
+                      "full_path": "sub_package::extern_function"
+                    }
+                  }
+                ],
+                "pub_uses": {
+                  "use_constants": [],
+                  "use_free_functions": [],
+                  "use_structs": [],
+                  "use_enums": [],
+                  "use_module_type_aliases": [],
+                  "use_impl_aliases": [],
+                  "use_traits": [],
+                  "use_impl_defs": [],
+                  "use_extern_types": [],
+                  "use_extern_functions": [],
+                  "use_submodules": []
+                }
+              }
+            ]
+          }
         }
       },
       "metadata": {


### PR DESCRIPTION
closes https://github.com/software-mansion/scarb/issues/2161

The idea is to document all reexported items and create pages for all their parents if they don't exist using original path not the reexported one. 
So the expected behaviour is that for example (comes from corelib) for `pub use adapters::PeekableTrait;` gets documented in path` core-iter-adapters-peekable-PeekableTrait` and only there. 
Before the change each _pub use_ of the same item would be documented in `SUMMARY.md` causing the `mdbook build` to fail. 

To reproduce this bug you can pull scarb repo (from before this PR gets merged) generate documentation for corelib or any other package that contains more than one pub use for the same item and run `mdbook build`. 

New interface sample 👇 
![image](https://github.com/user-attachments/assets/e4278a39-8d3d-47ce-9a14-9afa6cfa47be)

