### PR TITLE
feat: merge modules

### DIFF
--- a/extensions/scarb-doc/tests/data/json_reexports_merged_module.json
+++ b/extensions/scarb-doc/tests/data/json_reexports_merged_module.json
@@ -1,0 +1,261 @@
+{
+  "format_version": 1,
+  "packages_information": [
+    {
+      "crate_": {
+        "root_module": {
+          "item_data": {
+            "name": "hello_world",
+            "doc": null,
+            "signature": null,
+            "full_path": "hello_world"
+          },
+          "submodules": [
+            {
+              "item_data": {
+                "name": "Alejandro",
+                "doc": null,
+                "signature": null,
+                "full_path": "hello_world::Alejandro"
+              },
+              "submodules": [],
+              "constants": [],
+              "free_functions": [],
+              "structs": [],
+              "enums": [],
+              "type_aliases": [],
+              "impl_aliases": [],
+              "traits": [],
+              "impls": [],
+              "extern_types": [],
+              "extern_functions": [],
+              "pub_uses": {
+                "use_constants": [],
+                "use_free_functions": [],
+                "use_structs": [],
+                "use_enums": [],
+                "use_module_type_aliases": [],
+                "use_impl_aliases": [],
+                "use_traits": [],
+                "use_impl_defs": [],
+                "use_extern_types": [],
+                "use_extern_functions": [],
+                "use_submodules": [
+                  {
+                    "item_data": {
+                      "name": "Rodrigo",
+                      "doc": null,
+                      "signature": null,
+                      "full_path": "hello_world::Rodrigo"
+                    },
+                    "submodules": [
+                      {
+                        "item_data": {
+                          "name": "Valentina",
+                          "doc": null,
+                          "signature": null,
+                          "full_path": "hello_world::Rodrigo::Valentina"
+                        },
+                        "submodules": [],
+                        "constants": [],
+                        "free_functions": [],
+                        "structs": [],
+                        "enums": [],
+                        "type_aliases": [],
+                        "impl_aliases": [],
+                        "traits": [],
+                        "impls": [],
+                        "extern_types": [],
+                        "extern_functions": [],
+                        "pub_uses": {
+                          "use_constants": [],
+                          "use_free_functions": [],
+                          "use_structs": [],
+                          "use_enums": [],
+                          "use_module_type_aliases": [],
+                          "use_impl_aliases": [],
+                          "use_traits": [],
+                          "use_impl_defs": [],
+                          "use_extern_types": [],
+                          "use_extern_functions": [],
+                          "use_submodules": []
+                        }
+                      }
+                    ],
+                    "constants": [],
+                    "free_functions": [],
+                    "structs": [],
+                    "enums": [],
+                    "type_aliases": [],
+                    "impl_aliases": [],
+                    "traits": [],
+                    "impls": [],
+                    "extern_types": [],
+                    "extern_functions": [],
+                    "pub_uses": {
+                      "use_constants": [],
+                      "use_free_functions": [],
+                      "use_structs": [],
+                      "use_enums": [],
+                      "use_module_type_aliases": [],
+                      "use_impl_aliases": [],
+                      "use_traits": [],
+                      "use_impl_defs": [],
+                      "use_extern_types": [],
+                      "use_extern_functions": [],
+                      "use_submodules": []
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "item_data": {
+                "name": "Isabella",
+                "doc": null,
+                "signature": null,
+                "full_path": "hello_world::Isabella"
+              },
+              "submodules": [],
+              "constants": [],
+              "free_functions": [],
+              "structs": [],
+              "enums": [],
+              "type_aliases": [],
+              "impl_aliases": [],
+              "traits": [],
+              "impls": [],
+              "extern_types": [],
+              "extern_functions": [],
+              "pub_uses": {
+                "use_constants": [],
+                "use_free_functions": [],
+                "use_structs": [
+                  {
+                    "members": [],
+                    "item_data": {
+                      "name": "Mariana",
+                      "doc": null,
+                      "signature": "struct Mariana {}",
+                      "full_path": "hello_world::Rodrigo::Mariana"
+                    }
+                  }
+                ],
+                "use_enums": [],
+                "use_module_type_aliases": [],
+                "use_impl_aliases": [],
+                "use_traits": [],
+                "use_impl_defs": [],
+                "use_extern_types": [],
+                "use_extern_functions": [],
+                "use_submodules": []
+              }
+            },
+            {
+              "item_data": {
+                "name": "Rodrigo",
+                "doc": null,
+                "signature": null,
+                "full_path": "hello_world::Rodrigo"
+              },
+              "submodules": [
+                {
+                  "item_data": {
+                    "name": "Valentina",
+                    "doc": null,
+                    "signature": null,
+                    "full_path": "hello_world::Rodrigo::Valentina"
+                  },
+                  "submodules": [],
+                  "constants": [],
+                  "free_functions": [],
+                  "structs": [],
+                  "enums": [],
+                  "type_aliases": [],
+                  "impl_aliases": [],
+                  "traits": [],
+                  "impls": [],
+                  "extern_types": [],
+                  "extern_functions": [],
+                  "pub_uses": {
+                    "use_constants": [],
+                    "use_free_functions": [],
+                    "use_structs": [],
+                    "use_enums": [],
+                    "use_module_type_aliases": [],
+                    "use_impl_aliases": [],
+                    "use_traits": [],
+                    "use_impl_defs": [],
+                    "use_extern_types": [],
+                    "use_extern_functions": [],
+                    "use_submodules": []
+                  }
+                }
+              ],
+              "constants": [],
+              "free_functions": [],
+              "structs": [
+                {
+                  "members": [],
+                  "item_data": {
+                    "name": "Mariana",
+                    "doc": null,
+                    "signature": "struct Mariana {}",
+                    "full_path": "hello_world::Rodrigo::Mariana"
+                  }
+                }
+              ],
+              "enums": [],
+              "type_aliases": [],
+              "impl_aliases": [],
+              "traits": [],
+              "impls": [],
+              "extern_types": [],
+              "extern_functions": [],
+              "pub_uses": {
+                "use_constants": [],
+                "use_free_functions": [],
+                "use_structs": [],
+                "use_enums": [],
+                "use_module_type_aliases": [],
+                "use_impl_aliases": [],
+                "use_traits": [],
+                "use_impl_defs": [],
+                "use_extern_types": [],
+                "use_extern_functions": [],
+                "use_submodules": []
+              }
+            }
+          ],
+          "constants": [],
+          "free_functions": [],
+          "structs": [],
+          "enums": [],
+          "type_aliases": [],
+          "impl_aliases": [],
+          "traits": [],
+          "impls": [],
+          "extern_types": [],
+          "extern_functions": [],
+          "pub_uses": {
+            "use_constants": [],
+            "use_free_functions": [],
+            "use_structs": [],
+            "use_enums": [],
+            "use_module_type_aliases": [],
+            "use_impl_aliases": [],
+            "use_traits": [],
+            "use_impl_defs": [],
+            "use_extern_types": [],
+            "use_extern_functions": [],
+            "use_submodules": []
+          }
+        }
+      },
+      "metadata": {
+        "name": "hello_world",
+        "authors": null
+      }
+    }
+  ]
+}


### PR DESCRIPTION
following change for https://github.com/software-mansion/scarb/pull/2216
fixes modules overriding itself when reexported multiple times. 
see example in `test_reexports_merged_modules` 👉 `hello_world::Rodrigo::Valentina` wouldn't be documented. 