### PR TITLE
Execution args: allow to suppress execution output

### DIFF
--- a/extensions/scarb-execute/src/lib.rs
+++ b/extensions/scarb-execute/src/lib.rs
@@ -26,7 +26,7 @@ pub(crate) mod output;
 
 const MAX_ITERATION_COUNT: usize = 10000;
 
-pub fn main_inner(args: Args, ui: Ui) -> Result<usize, anyhow::Error> {
+pub fn main_inner(args: Args, ui: Ui) -> Result<Option<usize>, anyhow::Error> {
     let metadata = MetadataCommand::new()
         .envs(args.execution.features.clone().to_env_vars())
         .inherit_stderr()
@@ -40,7 +40,7 @@ pub fn execute(
     package: &PackageMetadata,
     args: &ExecutionArgs,
     ui: &Ui,
-) -> Result<usize, anyhow::Error> {
+) -> Result<Option<usize>, anyhow::Error> {
     let output = args
         .run
         .output
@@ -165,6 +165,10 @@ pub fn execute(
             .transpose()?,
     });
 
+    if output.is_none() {
+        return Ok(None);
+    }
+
     let output_dir = scarb_target_dir.join("execute").join(&package.name);
     create_output_dir(output_dir.as_std_path())?;
 
@@ -215,7 +219,7 @@ pub fn execute(
         fs::write(air_private_input_path, output_value)?;
     }
 
-    Ok(execution_id)
+    Ok(Some(execution_id))
 }
 
 fn find_build_target<'a>(

--- a/extensions/scarb-prove/src/main.rs
+++ b/extensions/scarb-prove/src/main.rs
@@ -53,6 +53,7 @@ fn main_inner(args: Args, ui: Ui) -> Result<()> {
         None => {
             assert!(args.execute);
             scarb_execute::execute(&metadata, &package, &args.execute_args, &ui)?
+                .ok_or(anyhow::anyhow!("no execution output found"))?
         }
     };
     ui.print(Status::new("Proving", &package.name));

--- a/utils/scarb-extensions-cli/src/execute.rs
+++ b/utils/scarb-extensions-cli/src/execute.rs
@@ -123,6 +123,8 @@ pub enum OutputFormat {
     CairoPie,
     /// Output in standard format
     Standard,
+    /// No output
+    None,
 }
 
 #[doc(hidden)]
@@ -149,6 +151,9 @@ impl OutputFormat {
     }
     pub fn is_cairo_pie(&self) -> bool {
         matches!(self, OutputFormat::CairoPie)
+    }
+    pub fn is_none(&self) -> bool {
+        matches!(self, OutputFormat::None)
     }
 }
 


### PR DESCRIPTION
`scarb execute` creates new output folder `target/execute/execution{i}` for every new invocation. When used for integration tests this causes rapid disk space bloat.

This PR introduces a new option `--output none` that suppresses creating new directoris and skips writing artifacts.