### PR TITLE
check linked item is not hidden before resolving location links

### DIFF
--- a/extensions/scarb-doc/src/types/other_types.rs
+++ b/extensions/scarb-doc/src/types/other_types.rs
@@ -50,6 +50,13 @@ impl ItemData {
             db.get_item_signature_with_links(documentable_item_id);
         let doc_location_links = doc_location_links
             .iter()
+            .filter(|link| {
+                if let Some(stable_location) = link.item_id.stable_location(db) {
+                    !is_doc_hidden_attr(db, &stable_location.syntax_node(db))
+                } else {
+                    false
+                }
+            })
             .map(|link| DocLocationLink::new(link.start, link.end, link.item_id, db))
             .collect::<Vec<_>>();
         let group = find_groups_from_attributes(db, &id);

--- a/extensions/scarb-doc/tests/code/code_6.cairo
+++ b/extensions/scarb-doc/tests/code/code_6.cairo
@@ -26,3 +26,8 @@ impl CongoUganda of Uganda<Congo> {
     fn rwanda(self: Congo) -> u32;
     fn uganda() {};
 }
+
+#[doc(hidden)]
+pub struct ThisShouldNotBeLinked() {}
+
+pub fn test_hidden_in_location_links(param: ThisShouldNotBeLinked) {}

--- a/extensions/scarb-doc/tests/data/hello_world_linked_items/src/SUMMARY.md
+++ b/extensions/scarb-doc/tests/data/hello_world_linked_items/src/SUMMARY.md
@@ -1,6 +1,8 @@
 # Summary
 
 - [hello_world](./hello_world.md)
+  - [Free functions](./hello_world-free_functions.md)
+      - [test_hidden_in_location_links](./hello_world-test_hidden_in_location_links.md)
   - [Structs](./hello_world-structs.md)
       - [Congo](./hello_world-Congo.md)
   - [Enums](./hello_world-enums.md)

--- a/extensions/scarb-doc/tests/data/hello_world_linked_items/src/hello_world-free_functions.md
+++ b/extensions/scarb-doc/tests/data/hello_world_linked_items/src/hello_world-free_functions.md
@@ -1,0 +1,6 @@
+
+## [Free functions](./hello_world-free_functions.md)
+
+| | |
+|:---|:---|
+| [test_hidden_in_location_links](./hello_world-test_hidden_in_location_links.md) | [...](./hello_world-test_hidden_in_location_links.md) |

--- a/extensions/scarb-doc/tests/data/hello_world_linked_items/src/hello_world-test_hidden_in_location_links.md
+++ b/extensions/scarb-doc/tests/data/hello_world_linked_items/src/hello_world-test_hidden_in_location_links.md
@@ -1,0 +1,6 @@
+# test_hidden_in_location_links
+
+Fully qualified path: [hello_world](./hello_world.md)::[test_hidden_in_location_links](./hello_world-test_hidden_in_location_links.md)
+
+<pre><code class="language-cairo">pub fn test_hidden_in_location_links(param: ThisShouldNotBeLinked)</code></pre>
+

--- a/extensions/scarb-doc/tests/data/hello_world_linked_items/src/hello_world.md
+++ b/extensions/scarb-doc/tests/data/hello_world_linked_items/src/hello_world.md
@@ -3,6 +3,12 @@
 Fully qualified path: [hello_world](./hello_world.md)
 
 
+## [Free functions](./hello_world-free_functions.md)
+
+| | |
+|:---|:---|
+| [test_hidden_in_location_links](./hello_world-test_hidden_in_location_links.md) | [...](./hello_world-test_hidden_in_location_links.md) |
+
 ## [Structs](./hello_world-structs.md)
 
 | | |


### PR DESCRIPTION
closes https://github.com/software-mansion/scarb/issues/2232

Checking `doc(hidden)` is enough because the location links are created from semantic data. Therefore the item existence is guaranteed. The case where they're not resolved (meaning that the subpage for the link target item isn't crated) can be either: 
- the target item has `doc(hidden)` attribute 
- or is reeksported from another crate. 

This PR adresses the attribute case. Reeksports case is addressed in https://github.com/software-mansion/scarb/pull/2307 
Ofc, assuming that the code can be successfully compiled. 