### PR TITLE
Replace soon-to-be deprecated windows-2019 with latest in release build workflow

### DIFF
--- a/.github/workflows/_build-release.yml
+++ b/.github/workflows/_build-release.yml
@@ -144,7 +144,7 @@ jobs:
             os: macos-14
 
           - target: x86_64-pc-windows-msvc
-            os: windows-2019
+            os: windows-latest
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
See: https://github.com/actions/runner-images/issues/12045