### PR TITLE
reimplement `exec_replace`

### DIFF
--- a/extensions/scarb-cairo-run/tests/arguments.rs
+++ b/extensions/scarb-cairo-run/tests/arguments.rs
@@ -1,6 +1,6 @@
 use assert_fs::TempDir;
 use indoc::indoc;
-use scarb_test_support::command::{OutputAssertExt, Scarb};
+use scarb_test_support::command::Scarb;
 use scarb_test_support::project_builder::ProjectBuilder;
 
 fn setup_fib_three_felt_args(t: &TempDir) {
@@ -87,7 +87,7 @@ fn invalid_number_of_args() {
         .current_dir(&t)
         .assert()
         .failure()
-        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
+        .stdout_matches(indoc! {r#"
             warn: `scarb cairo-run` will be deprecated soon
             help: use `scarb execute` instead
                Compiling hello v0.1.0 ([..]/Scarb.toml)
@@ -112,7 +112,7 @@ fn array_instead_of_felt() {
         .current_dir(&t)
         .assert()
         .failure()
-        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
+        .stdout_matches(indoc! {r#"
             warn: `scarb cairo-run` will be deprecated soon
             help: use `scarb execute` instead
                Compiling hello v0.1.0 ([..]Scarb.toml)
@@ -247,7 +247,7 @@ fn invalid_struct_deserialization() {
         .current_dir(&t)
         .assert()
         .failure()
-        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
+        .stdout_matches(indoc! {r#"
             warn: `scarb cairo-run` will be deprecated soon
             help: use `scarb execute` instead
                Compiling hello v0.1.0 ([..]Scarb.toml)
@@ -329,7 +329,7 @@ fn cannot_set_gas_limit_for_package_with_disabled_gas_calculation() {
         .current_dir(&t)
         .assert()
         .failure()
-        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
+        .stdout_matches(indoc! {r#"
             warn: `scarb cairo-run` will be deprecated soon
             help: use `scarb execute` instead
             error: gas calculation disabled for package `hello`, cannot define custom gas limit

--- a/extensions/scarb-cairo-run/tests/arguments.rs
+++ b/extensions/scarb-cairo-run/tests/arguments.rs
@@ -1,8 +1,7 @@
 use assert_fs::TempDir;
 use indoc::indoc;
-use scarb_test_support::command::Scarb;
+use scarb_test_support::command::{OutputAssertExt, Scarb};
 use scarb_test_support::project_builder::ProjectBuilder;
-use snapbox::cmd::OutputAssert;
 
 fn setup_fib_three_felt_args(t: &TempDir) {
     ProjectBuilder::start()
@@ -81,28 +80,24 @@ fn invalid_number_of_args() {
     let t = TempDir::new().unwrap();
     setup_fib_three_felt_args(&t);
 
-    let snapbox = Scarb::quick_snapbox()
+    Scarb::quick_snapbox()
         .arg("cairo-run")
         .arg("--")
         .arg(r#"[0, 1, 2, 3]"#)
         .current_dir(&t)
         .assert()
-        .failure();
-
-    output_assert(
-        snapbox,
-        indoc! {r#"
-        warn: `scarb cairo-run` will be deprecated soon
-        help: use `scarb execute` instead
-           Compiling hello v0.1.0 ([..]/Scarb.toml)
-            Finished `dev` profile target(s) in [..]
-             Running hello
-        error: failed to run the function
-
-        Caused by:
-            Function expects arguments of size 3 and received 4 instead.
-    "#},
-    );
+        .failure()
+        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
+            warn: `scarb cairo-run` will be deprecated soon
+            help: use `scarb execute` instead
+               Compiling hello v0.1.0 ([..]/Scarb.toml)
+                Finished `dev` profile target(s) in [..]
+                 Running hello
+            error: failed to run the function
+    
+            Caused by:
+                Function expects arguments of size 3 and received 4 instead.
+        "#});
 }
 
 #[test]
@@ -110,17 +105,14 @@ fn array_instead_of_felt() {
     let t = TempDir::new().unwrap();
     setup_fib_three_felt_args(&t);
 
-    let snapbox = Scarb::quick_snapbox()
+    Scarb::quick_snapbox()
         .arg("cairo-run")
         .arg("--")
         .arg(r#"[0, 1, [17]]"#)
         .current_dir(&t)
         .assert()
-        .failure();
-
-    output_assert(
-        snapbox,
-        indoc! {r#"
+        .failure()
+        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
             warn: `scarb cairo-run` will be deprecated soon
             help: use `scarb execute` instead
                Compiling hello v0.1.0 ([..]Scarb.toml)
@@ -130,8 +122,7 @@ fn array_instead_of_felt() {
 
             Caused by:
                 Function param 2 only partially contains argument 2.
-        "#},
-    );
+        "#});
 }
 
 #[test]
@@ -248,29 +239,25 @@ fn invalid_struct_deserialization() {
         "#})
         .build(&t);
 
-    let snapbox = Scarb::quick_snapbox()
+    // Received 2, because arrays in Cairo are represented as [begin_addr, end_addr]
+    Scarb::quick_snapbox()
         .arg("cairo-run")
         .arg("--")
         .arg(r#"[[0, 1, 2]]"#)
         .current_dir(&t)
         .assert()
-        .failure();
-
-    // Received 2, because arrays in Cairo are represented as [begin_addr, end_addr]
-    output_assert(
-        snapbox,
-        indoc! {r#"
-        warn: `scarb cairo-run` will be deprecated soon
-        help: use `scarb execute` instead
-           Compiling hello v0.1.0 ([..]Scarb.toml)
-            Finished `dev` profile target(s) in [..]
-             Running hello
-        error: failed to run the function
-
-        Caused by:
-            Function expects arguments of size 3 and received 2 instead.
-    "#},
-    );
+        .failure()
+        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
+            warn: `scarb cairo-run` will be deprecated soon
+            help: use `scarb execute` instead
+               Compiling hello v0.1.0 ([..]Scarb.toml)
+                Finished `dev` profile target(s) in [..]
+                 Running hello
+            error: failed to run the function
+    
+            Caused by:
+                Function expects arguments of size 3 and received 2 instead.
+        "#});
 }
 
 #[test]
@@ -335,22 +322,18 @@ fn cannot_set_gas_limit_for_package_with_disabled_gas_calculation() {
             enable-gas = false
         "#})
         .build(&t);
-    let output = Scarb::quick_snapbox()
+    Scarb::quick_snapbox()
         .arg("cairo-run")
         .arg("--available-gas")
         .arg("10")
         .current_dir(&t)
         .assert()
-        .failure();
-
-    output_assert(
-        output,
-        indoc! {r#"
-        warn: `scarb cairo-run` will be deprecated soon
-        help: use `scarb execute` instead
-        error: gas calculation disabled for package `hello`, cannot define custom gas limit
-    "#},
-    );
+        .failure()
+        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
+            warn: `scarb cairo-run` will be deprecated soon
+            help: use `scarb execute` instead
+            error: gas calculation disabled for package `hello`, cannot define custom gas limit
+        "#});
 }
 
 #[test]
@@ -374,13 +357,4 @@ fn can_control_verbosity() {
         .stdout_matches(indoc! {r#"
         something
         "#});
-}
-
-fn output_assert(output: OutputAssert, expected: &str) {
-    #[cfg(windows)]
-    output.stdout_matches(format!(
-        "{expected}error: process did not exit successfully: exit code: 1\n"
-    ));
-    #[cfg(not(windows))]
-    output.stdout_matches(expected);
 }

--- a/extensions/scarb-cairo-run/tests/build.rs
+++ b/extensions/scarb-cairo-run/tests/build.rs
@@ -1,8 +1,7 @@
 use assert_fs::TempDir;
 use indoc::indoc;
-use snapbox::cmd::OutputAssert;
 
-use scarb_test_support::command::Scarb;
+use scarb_test_support::command::{OutputAssertExt, Scarb};
 use scarb_test_support::project_builder::ProjectBuilder;
 
 #[test]
@@ -73,21 +72,19 @@ fn no_entrypoint_fails() {
         "#})
         .dep_cairo_run()
         .build(&t);
-    output_assert(
-        Scarb::quick_snapbox()
-            .arg("cairo-run")
-            .current_dir(&t)
-            .assert()
-            .failure(),
-        indoc! {r#"
-        warn: `scarb cairo-run` will be deprecated soon
-        help: use `scarb execute` instead
-        [..]Compiling hello v0.1.0 ([..]Scarb.toml)
-        [..]Finished `dev` profile target(s) in [..]
-        [..]Running hello
-        error: Function with suffix `::main` to run not found.
-        "#},
-    )
+    Scarb::quick_snapbox()
+        .arg("cairo-run")
+        .current_dir(&t)
+        .assert()
+        .failure()
+        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
+            warn: `scarb cairo-run` will be deprecated soon
+            help: use `scarb execute` instead
+            [..]Compiling hello v0.1.0 ([..]Scarb.toml)
+            [..]Finished `dev` profile target(s) in [..]
+            [..]Running hello
+            error: Function with suffix `::main` to run not found.
+        "#});
 }
 
 #[test]
@@ -107,21 +104,19 @@ fn no_debug_build_fails() {
         "#})
         .dep_cairo_run()
         .build(&t);
-    output_assert(
-        Scarb::quick_snapbox()
-            .arg("cairo-run")
-            .current_dir(&t)
-            .assert()
-            .failure(),
-        indoc! {r#"
-        warn: `scarb cairo-run` will be deprecated soon
-        help: use `scarb execute` instead
-        [..]Compiling hello v0.1.0 ([..]Scarb.toml)
-        [..]Finished `dev` profile target(s) in [..]
-        [..]Running hello
-        error: Function with suffix `::main` to run not found.
-        "#},
-    )
+    Scarb::quick_snapbox()
+        .arg("cairo-run")
+        .current_dir(&t)
+        .assert()
+        .failure()
+        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
+            warn: `scarb cairo-run` will be deprecated soon
+            help: use `scarb execute` instead
+            [..]Compiling hello v0.1.0 ([..]Scarb.toml)
+            [..]Finished `dev` profile target(s) in [..]
+            [..]Running hello
+            error: Function with suffix `::main` to run not found.
+        "#});
 }
 
 #[test]
@@ -176,23 +171,21 @@ fn ambiguous_executables_will_fail() {
         "#})
         .dep_cairo_run()
         .build(&t);
-    output_assert(
-        Scarb::quick_snapbox()
-            .arg("cairo-run")
-            .current_dir(&t)
-            .assert()
-            .failure(),
-        indoc! {r#"
-        warn: `scarb cairo-run` will be deprecated soon
-        help: use `scarb execute` instead
-        [..]Compiling hello v0.1.0 ([..]Scarb.toml)
-        [..]Finished `dev` profile target(s) in [..]
-        [..]Running hello
-        error: multiple executable functions found
-        please choose a function to run from the list:
-        `hello::hello`, `hello::world`
-        "#},
-    )
+    Scarb::quick_snapbox()
+        .arg("cairo-run")
+        .current_dir(&t)
+        .assert()
+        .failure()
+        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
+            warn: `scarb cairo-run` will be deprecated soon
+            help: use `scarb execute` instead
+            [..]Compiling hello v0.1.0 ([..]Scarb.toml)
+            [..]Finished `dev` profile target(s) in [..]
+            [..]Running hello
+            error: multiple executable functions found
+            please choose a function to run from the list:
+            `hello::hello`, `hello::world`
+        "#});
 }
 
 #[test]
@@ -217,23 +210,21 @@ fn ambiguous_executables_will_fail_no_debug_names() {
         "#})
         .dep_cairo_run()
         .build(&t);
-    output_assert(
-        Scarb::quick_snapbox()
-            .arg("cairo-run")
-            .current_dir(&t)
-            .assert()
-            .failure(),
+    Scarb::quick_snapbox()
+        .arg("cairo-run")
+        .current_dir(&t)
+        .assert()
+        .failure()
         // Note that we cannot list available executables, as we don't know their debug names.
-        indoc! {r#"
-        warn: `scarb cairo-run` will be deprecated soon
-        help: use `scarb execute` instead
-        [..]Compiling hello v0.1.0 ([..]Scarb.toml)
-        [..]Finished `dev` profile target(s) in [..]
-        [..]Running hello
-        error: multiple executable functions found
-        please only mark a single function as executable or enable debug ids and choose function by name
-        "#},
-    )
+        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
+            warn: `scarb cairo-run` will be deprecated soon
+            help: use `scarb execute` instead
+            [..]Compiling hello v0.1.0 ([..]Scarb.toml)
+            [..]Finished `dev` profile target(s) in [..]
+            [..]Running hello
+            error: multiple executable functions found
+            please only mark a single function as executable or enable debug ids and choose function by name
+        "#});
 }
 
 #[test]
@@ -300,23 +291,21 @@ fn cannot_choose_non_executable_if_any_present() {
         "#})
         .dep_cairo_run()
         .build(&t);
-    output_assert(
-        Scarb::quick_snapbox()
-            .arg("cairo-run")
-            .arg("--function")
-            .arg("a")
-            .current_dir(&t)
-            .assert()
-            .failure(),
-        indoc! {r#"
+    Scarb::quick_snapbox()
+        .arg("cairo-run")
+        .arg("--function")
+        .arg("a")
+        .current_dir(&t)
+        .assert()
+        .failure()
+        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
             warn: `scarb cairo-run` will be deprecated soon
             help: use `scarb execute` instead
             [..]Compiling hello v0.1.0 ([..]Scarb.toml)
             [..]Finished `dev` profile target(s) in [..]
             [..]Running hello
             error: Function with suffix `::a` to run not found.
-        "#},
-    )
+        "#});
 }
 
 #[test]
@@ -371,30 +360,19 @@ fn choose_not_existing_function() {
             }
         "#})
         .build(&t);
-    output_assert(
-        Scarb::quick_snapbox()
-            .arg("cairo-run")
-            .arg("--function")
-            .arg("b")
-            .current_dir(&t)
-            .assert()
-            .failure(),
-        indoc! {r#"
-        warn: `scarb cairo-run` will be deprecated soon
-        help: use `scarb execute` instead
-        [..]Compiling hello v0.1.0 ([..]Scarb.toml)
-        [..]Finished `dev` profile target(s) in [..]
-        [..]Running hello
-        [..]error: Function with suffix `::b` to run not found.
-    "#},
-    )
-}
-
-fn output_assert(output: OutputAssert, expected: &str) {
-    #[cfg(windows)]
-    output.stdout_matches(format!(
-        "{expected}error: process did not exit successfully: exit code: 1\n"
-    ));
-    #[cfg(not(windows))]
-    output.stdout_matches(expected);
+    Scarb::quick_snapbox()
+        .arg("cairo-run")
+        .arg("--function")
+        .arg("b")
+        .current_dir(&t)
+        .assert()
+        .failure()
+        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
+            warn: `scarb cairo-run` will be deprecated soon
+            help: use `scarb execute` instead
+            [..]Compiling hello v0.1.0 ([..]Scarb.toml)
+            [..]Finished `dev` profile target(s) in [..]
+            [..]Running hello
+            [..]error: Function with suffix `::b` to run not found.
+        "#});
 }

--- a/extensions/scarb-cairo-run/tests/build.rs
+++ b/extensions/scarb-cairo-run/tests/build.rs
@@ -1,7 +1,7 @@
 use assert_fs::TempDir;
 use indoc::indoc;
 
-use scarb_test_support::command::{OutputAssertExt, Scarb};
+use scarb_test_support::command::Scarb;
 use scarb_test_support::project_builder::ProjectBuilder;
 
 #[test]
@@ -77,7 +77,7 @@ fn no_entrypoint_fails() {
         .current_dir(&t)
         .assert()
         .failure()
-        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
+        .stdout_matches(indoc! {r#"
             warn: `scarb cairo-run` will be deprecated soon
             help: use `scarb execute` instead
             [..]Compiling hello v0.1.0 ([..]Scarb.toml)
@@ -109,7 +109,7 @@ fn no_debug_build_fails() {
         .current_dir(&t)
         .assert()
         .failure()
-        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
+        .stdout_matches(indoc! {r#"
             warn: `scarb cairo-run` will be deprecated soon
             help: use `scarb execute` instead
             [..]Compiling hello v0.1.0 ([..]Scarb.toml)
@@ -176,7 +176,7 @@ fn ambiguous_executables_will_fail() {
         .current_dir(&t)
         .assert()
         .failure()
-        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
+        .stdout_matches(indoc! {r#"
             warn: `scarb cairo-run` will be deprecated soon
             help: use `scarb execute` instead
             [..]Compiling hello v0.1.0 ([..]Scarb.toml)
@@ -216,7 +216,7 @@ fn ambiguous_executables_will_fail_no_debug_names() {
         .assert()
         .failure()
         // Note that we cannot list available executables, as we don't know their debug names.
-        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
+        .stdout_matches(indoc! {r#"
             warn: `scarb cairo-run` will be deprecated soon
             help: use `scarb execute` instead
             [..]Compiling hello v0.1.0 ([..]Scarb.toml)
@@ -298,7 +298,7 @@ fn cannot_choose_non_executable_if_any_present() {
         .current_dir(&t)
         .assert()
         .failure()
-        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
+        .stdout_matches(indoc! {r#"
             warn: `scarb cairo-run` will be deprecated soon
             help: use `scarb execute` instead
             [..]Compiling hello v0.1.0 ([..]Scarb.toml)
@@ -367,7 +367,7 @@ fn choose_not_existing_function() {
         .current_dir(&t)
         .assert()
         .failure()
-        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
+        .stdout_matches(indoc! {r#"
             warn: `scarb cairo-run` will be deprecated soon
             help: use `scarb execute` instead
             [..]Compiling hello v0.1.0 ([..]Scarb.toml)

--- a/extensions/scarb-cairo-run/tests/examples.rs
+++ b/extensions/scarb-cairo-run/tests/examples.rs
@@ -3,7 +3,6 @@ use indoc::indoc;
 use snapbox::cmd::{Command, cargo_bin};
 
 use scarb_test_support::cargo::manifest_dir;
-use scarb_test_support::command::OutputAssertExt;
 
 #[test]
 fn scarb_build_is_called() {
@@ -58,7 +57,7 @@ fn build_can_be_skipped() {
         .current_dir(example)
         .assert()
         .failure()
-        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
+        .stdout_matches(indoc! {r#"
             warn: `scarb cairo-run` will be deprecated soon
             help: use `scarb execute` instead
             error: package has not been compiled, file does not exist: `hello_world.sierra.json`
@@ -123,7 +122,7 @@ fn can_disable_gas() {
         .current_dir(example)
         .assert()
         .failure()
-        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
+        .stdout_matches(indoc! {r#"
             warn: `scarb cairo-run` will be deprecated soon
             help: use `scarb execute` instead
                Compiling hello_world v0.1.0 ([..]Scarb.toml)

--- a/extensions/scarb-cairo-test/tests/build.rs
+++ b/extensions/scarb-cairo-test/tests/build.rs
@@ -1,7 +1,7 @@
 use assert_fs::TempDir;
 use assert_fs::prelude::PathChild;
 use indoc::{formatdoc, indoc};
-use scarb_test_support::command::{OutputAssertExt, Scarb};
+use scarb_test_support::command::Scarb;
 use scarb_test_support::project_builder::ProjectBuilder;
 use scarb_test_support::workspace_builder::WorkspaceBuilder;
 
@@ -166,7 +166,7 @@ fn features_test_build_failed() {
         .current_dir(&t)
         .assert()
         .failure()
-        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
+        .stdout_matches(indoc! {r#"
             [..]Compiling test(hello_unittest) hello v1.0.0 ([..])
             error[E0006]: Function not found.
              --> [..]/src/lib.cairo[..]

--- a/extensions/scarb-cairo-test/tests/build.rs
+++ b/extensions/scarb-cairo-test/tests/build.rs
@@ -1,7 +1,7 @@
 use assert_fs::TempDir;
 use assert_fs::prelude::PathChild;
 use indoc::{formatdoc, indoc};
-use scarb_test_support::command::Scarb;
+use scarb_test_support::command::{OutputAssertExt, Scarb};
 use scarb_test_support::project_builder::ProjectBuilder;
 use scarb_test_support::workspace_builder::WorkspaceBuilder;
 
@@ -161,33 +161,20 @@ fn features_test_build_success() {
 fn features_test_build_failed() {
     let t = TempDir::new().unwrap();
     get_features_test_build(&t);
-    let snapbox = Scarb::quick_snapbox()
+    Scarb::quick_snapbox()
         .arg("cairo-test")
         .current_dir(&t)
         .assert()
-        .failure();
+        .failure()
+        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
+            [..]Compiling test(hello_unittest) hello v1.0.0 ([..])
+            error[E0006]: Function not found.
+             --> [..]/src/lib.cairo[..]
+            fn main() -> felt252 { f() }
+                                   ^
 
-    #[cfg(not(windows))]
-    snapbox.stdout_matches(indoc! {r#"
-        [..]Compiling test(hello_unittest) hello v1.0.0 ([..])
-        error[E0006]: Function not found.
-         --> [..]/src/lib.cairo[..]
-        fn main() -> felt252 { f() }
-                               ^
-        
-        error: could not compile `hello` due to previous error[..]
-    "#});
-    #[cfg(windows)]
-    snapbox.stdout_matches(indoc! {r#"
-        [..]Compiling test(hello_unittest) hello v1.0.0 ([..])
-        error[E0006]: Function not found.
-         --> [..]/src/lib.cairo[..]
-        fn main() -> felt252 { f() }
-                               ^
-        
-        error: could not compile `hello` due to previous error[..]
-        error: process did not exit successfully: exit code: 1
-    "#});
+            error: could not compile `hello` due to previous error[..]
+        "#});
 }
 
 #[test]

--- a/extensions/scarb-doc/tests/diagnostics.rs
+++ b/extensions/scarb-doc/tests/diagnostics.rs
@@ -1,7 +1,7 @@
 use assert_fs::TempDir;
 use indoc::indoc;
+use scarb_test_support::command::OutputAssertExt;
 use scarb_test_support::{command::Scarb, project_builder::ProjectBuilder};
-use snapbox::cmd::OutputAssert;
 
 #[test]
 fn test_diagnostics_success() {
@@ -110,15 +110,12 @@ fn test_diagnostics_error() {
         .dep_starknet()
         .build(&t);
 
-    let output = Scarb::quick_snapbox()
+    Scarb::quick_snapbox()
         .arg("doc")
         .current_dir(&t)
         .assert()
-        .failure();
-
-    failure_assert(
-        output,
-        indoc! {r#"
+        .failure()
+        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
             error: Expected either ';' or '{' after module name. Use ';' for an external module declaration or '{' for a module with a body.
              --> [..]lib.cairo:2:33
             pub(crate) mod DualCaseERC20Mock 
@@ -144,17 +141,7 @@ fn test_diagnostics_error() {
             |________________________________^
             
             error: Compilation failed.
-        "#},
-    );
-}
-
-fn failure_assert(output: OutputAssert, expected: &str) {
-    #[cfg(windows)]
-    output.stdout_matches(format!(
-        "{expected}error: process did not exit successfully: exit code: 1\n"
-    ));
-    #[cfg(not(windows))]
-    output.stdout_matches(expected);
+        "#});
 }
 
 #[test]

--- a/extensions/scarb-doc/tests/diagnostics.rs
+++ b/extensions/scarb-doc/tests/diagnostics.rs
@@ -1,6 +1,5 @@
 use assert_fs::TempDir;
 use indoc::indoc;
-use scarb_test_support::command::OutputAssertExt;
 use scarb_test_support::{command::Scarb, project_builder::ProjectBuilder};
 
 #[test]
@@ -115,7 +114,7 @@ fn test_diagnostics_error() {
         .current_dir(&t)
         .assert()
         .failure()
-        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
+        .stdout_matches(indoc! {r#"
             error: Expected either ';' or '{' after module name. Use ';' for an external module declaration or '{' for a module with a body.
              --> [..]lib.cairo:2:33
             pub(crate) mod DualCaseERC20Mock 

--- a/extensions/scarb-doc/tests/features.rs
+++ b/extensions/scarb-doc/tests/features.rs
@@ -5,7 +5,7 @@ use assert_fs::prelude::PathChild;
 use indoc::{formatdoc, indoc};
 use scarb_test_support::workspace_builder::WorkspaceBuilder;
 
-use scarb_test_support::command::Scarb;
+use scarb_test_support::command::{OutputAssertExt, Scarb};
 use scarb_test_support::project_builder::ProjectBuilder;
 
 const EXPECTED_ROOT_PACKAGE_NO_FEATURES_PATH: &str = "tests/data/hello_world_no_features";
@@ -95,7 +95,7 @@ fn test_workspace_without_features_in_manifest() {
         .lib_cairo(COMMON_CODE_WITHOUT_FEATURE)
         .build(&child_dir);
 
-    let snapbox = Scarb::quick_snapbox()
+    Scarb::quick_snapbox()
         .env("RUST_BACKTRACE", "0")
         .arg("doc")
         .args([
@@ -107,30 +107,15 @@ fn test_workspace_without_features_in_manifest() {
         ])
         .current_dir(&root_dir)
         .assert()
-        .failure();
+        .failure()
+        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
+            error: metadata command failed: `scarb metadata` exited with error
 
-    #[cfg(windows)]
-    snapbox.stdout_matches(indoc! {r#"
-        error: metadata command failed: `scarb metadata` exited with error
+            stdout:
+            error: none of the selected packages contains `test_feature` feature
+            note: to use features, you need to define [features] section in Scarb.toml
 
-        stdout:
-        error: none of the selected packages contains `test_feature` feature
-        note: to use features, you need to define [features] section in Scarb.toml
-
-        stderr:
-        
-        error: process did not exit successfully: exit code: 1
-        "#});
-
-    #[cfg(not(windows))]
-    snapbox.stdout_matches(indoc! {r#"
-        error: metadata command failed: `scarb metadata` exited with error
-
-        stdout:
-        error: none of the selected packages contains `test_feature` feature
-        note: to use features, you need to define [features] section in Scarb.toml
-
-        stderr:
+            stderr:
 
         "#});
 }
@@ -303,7 +288,7 @@ fn test_workspace_without_features_in_manifest_and_present_in_sub_package_code()
         .lib_cairo(COMMON_CODE_WITH_FEATURE)
         .build(&child_dir);
 
-    let snapbox = Scarb::quick_snapbox()
+    Scarb::quick_snapbox()
         .env("RUST_BACKTRACE", "0")
         .arg("doc")
         .args([
@@ -315,31 +300,17 @@ fn test_workspace_without_features_in_manifest_and_present_in_sub_package_code()
         ])
         .current_dir(&root_dir)
         .assert()
-        .failure();
-    #[cfg(windows)]
-    snapbox.stdout_matches(indoc! {r#"
+        .failure()
+        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
             error: metadata command failed: `scarb metadata` exited with error
-    
-            stdout:
-            error: none of the selected packages contains `test_feature` feature
-            note: to use features, you need to define [features] section in Scarb.toml
-    
-            stderr:
-            
-            error: process did not exit successfully: exit code: 1
-            "#});
 
-    #[cfg(not(windows))]
-    snapbox.stdout_matches(indoc! {r#"
-            error: metadata command failed: `scarb metadata` exited with error
-    
             stdout:
             error: none of the selected packages contains `test_feature` feature
             note: to use features, you need to define [features] section in Scarb.toml
-    
+
             stderr:
-    
-            "#});
+
+        "#});
 }
 
 #[test]
@@ -361,7 +332,7 @@ fn test_workspace_without_features_in_manifest_and_present_in_root_package_code(
         .lib_cairo(COMMON_CODE_WITH_FEATURE)
         .build(&child_dir);
 
-    let snapbox = Scarb::quick_snapbox()
+    Scarb::quick_snapbox()
         .env("RUST_BACKTRACE", "0")
         .arg("doc")
         .args([
@@ -373,30 +344,15 @@ fn test_workspace_without_features_in_manifest_and_present_in_root_package_code(
         ])
         .current_dir(&root_dir)
         .assert()
-        .failure();
-
-    #[cfg(windows)]
-    snapbox.stdout_matches(indoc! {r#"
-        error: metadata command failed: `scarb metadata` exited with error
-
-        stdout:
-        error: none of the selected packages contains `test_feature` feature
-        note: to use features, you need to define [features] section in Scarb.toml
-
-        stderr:
-        
-        error: process did not exit successfully: exit code: 1
-        "#});
-
-    #[cfg(not(windows))]
-    snapbox.stdout_matches(indoc! {r#"
-        error: metadata command failed: `scarb metadata` exited with error
-
-        stdout:
-        error: none of the selected packages contains `test_feature` feature
-        note: to use features, you need to define [features] section in Scarb.toml
-
-        stderr:
+        .failure()
+        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
+            error: metadata command failed: `scarb metadata` exited with error
+    
+            stdout:
+            error: none of the selected packages contains `test_feature` feature
+            note: to use features, you need to define [features] section in Scarb.toml
+    
+            stderr:
 
         "#});
 }

--- a/extensions/scarb-doc/tests/features.rs
+++ b/extensions/scarb-doc/tests/features.rs
@@ -5,7 +5,7 @@ use assert_fs::prelude::PathChild;
 use indoc::{formatdoc, indoc};
 use scarb_test_support::workspace_builder::WorkspaceBuilder;
 
-use scarb_test_support::command::{OutputAssertExt, Scarb};
+use scarb_test_support::command::Scarb;
 use scarb_test_support::project_builder::ProjectBuilder;
 
 const EXPECTED_ROOT_PACKAGE_NO_FEATURES_PATH: &str = "tests/data/hello_world_no_features";
@@ -108,7 +108,7 @@ fn test_workspace_without_features_in_manifest() {
         .current_dir(&root_dir)
         .assert()
         .failure()
-        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
+        .stdout_matches(indoc! {r#"
             error: metadata command failed: `scarb metadata` exited with error
 
             stdout:
@@ -301,7 +301,7 @@ fn test_workspace_without_features_in_manifest_and_present_in_sub_package_code()
         .current_dir(&root_dir)
         .assert()
         .failure()
-        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
+        .stdout_matches(indoc! {r#"
             error: metadata command failed: `scarb metadata` exited with error
 
             stdout:
@@ -345,7 +345,7 @@ fn test_workspace_without_features_in_manifest_and_present_in_root_package_code(
         .current_dir(&root_dir)
         .assert()
         .failure()
-        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
+        .stdout_matches(indoc! {r#"
             error: metadata command failed: `scarb metadata` exited with error
     
             stdout:

--- a/extensions/scarb-execute/tests/build.rs
+++ b/extensions/scarb-execute/tests/build.rs
@@ -3,7 +3,7 @@ use assert_fs::assert::PathAssert;
 use assert_fs::fixture::PathChild;
 use indoc::indoc;
 use predicates::prelude::*;
-use scarb_test_support::command::{OutputAssertExt, Scarb};
+use scarb_test_support::command::Scarb;
 use scarb_test_support::fsx::ChildPathEx;
 use scarb_test_support::predicates::is_file_empty;
 use scarb_test_support::project_builder::ProjectBuilder;
@@ -113,7 +113,7 @@ fn cannot_produce_trace_file_for_bootloader_target() {
         .current_dir(&t)
         .assert()
         .failure()
-        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
+        .stdout_matches(indoc! {r#"
             error: Standard output format is not supported for bootloader execution target
         "#});
 }
@@ -128,7 +128,7 @@ fn cannot_produce_cairo_pie_for_standalone_target() {
         .current_dir(&t)
         .assert()
         .failure()
-        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
+        .stdout_matches(indoc! {r#"
             error: Cairo pie output format is not supported for standalone execution target
         "#});
 }
@@ -158,7 +158,7 @@ fn fails_when_attr_missing() {
         .current_dir(&t)
         .assert()
         .failure()
-        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
+        .stdout_matches(indoc! {r#"
             [..]Compiling hello v0.1.0 ([..]Scarb.toml)
             error: Requested `#[executable]` not found.
             error: could not compile `hello` due to previous error
@@ -171,7 +171,7 @@ fn fails_when_attr_missing() {
         .current_dir(&t)
         .assert()
         .failure()
-        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
+        .stdout_matches(indoc! {r#"
             [..]Executing hello
             error: package has not been compiled, file does not exist: `hello.executable.json`
             help: run `scarb build` to compile the package
@@ -201,7 +201,7 @@ fn can_print_panic_reason() {
         .current_dir(&t)
         .assert()
         .failure()
-        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
+        .stdout_matches(indoc! {r#"
             [..]Compiling hello v0.1.0 ([..]Scarb.toml)
             [..]Finished `dev` profile target(s) in [..]
             [..]Executing hello
@@ -240,7 +240,7 @@ fn no_target_defined() {
         .current_dir(&t)
         .assert()
         .failure()
-        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
+        .stdout_matches(indoc! {r#"
             error: no executable target found for package `hello_world`
             help: you can add `executable` target to the package manifest with following excerpt
             -> Scarb.toml
@@ -286,7 +286,7 @@ fn undefined_target_specified() {
         .current_dir(&t)
         .assert()
         .failure()
-        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
+        .stdout_matches(indoc! {r#"
             error: no executable target with name `secondary` found for package `hello_world`
         "#});
 
@@ -297,7 +297,7 @@ fn undefined_target_specified() {
         .current_dir(&t)
         .assert()
         .failure()
-        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
+        .stdout_matches(indoc! {r#"
             error: no executable target with executable function `secondary` found for package `hello_world`
         "#});
 }
@@ -382,7 +382,7 @@ fn executable_must_be_chosen() {
         .current_dir(&t)
         .assert()
         .failure()
-        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
+        .stdout_matches(indoc! {r#"
             error: more than one executable target found for package `hello_world`
             help: specify the target with `--executable-name` or `--executable-function`
     

--- a/extensions/scarb-execute/tests/build.rs
+++ b/extensions/scarb-execute/tests/build.rs
@@ -3,11 +3,10 @@ use assert_fs::assert::PathAssert;
 use assert_fs::fixture::PathChild;
 use indoc::indoc;
 use predicates::prelude::*;
-use scarb_test_support::command::Scarb;
+use scarb_test_support::command::{OutputAssertExt, Scarb};
 use scarb_test_support::fsx::ChildPathEx;
 use scarb_test_support::predicates::is_file_empty;
 use scarb_test_support::project_builder::ProjectBuilder;
-use snapbox::cmd::OutputAssert;
 
 fn executable_project_builder() -> ProjectBuilder {
     ProjectBuilder::start()
@@ -107,37 +106,31 @@ fn can_execute_bootloader_target() {
 #[test]
 fn cannot_produce_trace_file_for_bootloader_target() {
     let t = build_executable_project();
-    let output = Scarb::quick_snapbox()
+    Scarb::quick_snapbox()
         .arg("execute")
         .arg("--target=bootloader")
         .arg("--output=standard")
         .current_dir(&t)
         .assert()
-        .failure();
-    output_assert(
-        output,
-        indoc! {r#"
-        error: Standard output format is not supported for bootloader execution target
-        "#},
-    );
+        .failure()
+        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
+            error: Standard output format is not supported for bootloader execution target
+        "#});
 }
 
 #[test]
 fn cannot_produce_cairo_pie_for_standalone_target() {
     let t = build_executable_project();
-    let output = Scarb::quick_snapbox()
+    Scarb::quick_snapbox()
         .arg("execute")
         .arg("--target=standalone")
         .arg("--output=cairo-pie")
         .current_dir(&t)
         .assert()
-        .failure();
-    output_assert(
-        output,
-        indoc! {r#"
-        error: Cairo pie output format is not supported for standalone execution target
-        "#},
-    );
+        .failure()
+        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
+            error: Cairo pie output format is not supported for standalone execution target
+        "#});
 }
 
 #[test]
@@ -160,34 +153,30 @@ fn fails_when_attr_missing() {
         "#})
         .build(&t);
 
-    output_assert(
-        Scarb::quick_snapbox()
-            .arg("execute")
-            .current_dir(&t)
-            .assert()
-            .failure(),
-        indoc! {r#"
-        [..]Compiling hello v0.1.0 ([..]Scarb.toml)
-        error: Requested `#[executable]` not found.
-        error: could not compile `hello` due to previous error
-        error: `scarb metadata` exited with error
-        "#},
-    );
+    Scarb::quick_snapbox()
+        .arg("execute")
+        .current_dir(&t)
+        .assert()
+        .failure()
+        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
+            [..]Compiling hello v0.1.0 ([..]Scarb.toml)
+            error: Requested `#[executable]` not found.
+            error: could not compile `hello` due to previous error
+            error: `scarb metadata` exited with error
+        "#});
 
-    output_assert(
-        Scarb::quick_snapbox()
-            .arg("execute")
-            .arg("--no-build")
-            .current_dir(&t)
-            .assert()
-            .failure(),
-        indoc! {r#"
-        [..]Executing hello
-        error: package has not been compiled, file does not exist: `hello.executable.json`
-        help: run `scarb build` to compile the package
+    Scarb::quick_snapbox()
+        .arg("execute")
+        .arg("--no-build")
+        .current_dir(&t)
+        .assert()
+        .failure()
+        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
+            [..]Executing hello
+            error: package has not been compiled, file does not exist: `hello.executable.json`
+            help: run `scarb build` to compile the package
 
-        "#},
-    );
+        "#});
 }
 
 #[test]
@@ -204,23 +193,20 @@ fn can_print_panic_reason() {
             }
         "#})
         .build(&t);
-    let output = Scarb::quick_snapbox()
+
+    Scarb::quick_snapbox()
         .arg("execute")
         .arg("--print-program-output")
         .arg("--print-resource-usage")
         .current_dir(&t)
         .assert()
-        .failure();
-
-    output_assert(
-        output,
-        indoc! {r#"
-        [..]Compiling hello v0.1.0 ([..]Scarb.toml)
-        [..]Finished `dev` profile target(s) in [..]
-        [..]Executing hello
-        error: Panicked with "abcd".
-        "#},
-    );
+        .failure()
+        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
+            [..]Compiling hello v0.1.0 ([..]Scarb.toml)
+            [..]Finished `dev` profile target(s) in [..]
+            [..]Executing hello
+            error: Panicked with "abcd".
+        "#});
 }
 
 #[test]
@@ -248,25 +234,22 @@ fn no_target_defined() {
         "#})
         .build(&t);
 
-    let output = Scarb::quick_snapbox()
+    Scarb::quick_snapbox()
         .arg("execute")
         .arg("--no-build")
         .current_dir(&t)
         .assert()
-        .failure();
-    output_assert(
-        output,
-        indoc! {r#"
-        error: no executable target found for package `hello_world`
-        help: you can add `executable` target to the package manifest with following excerpt
-        -> Scarb.toml
-            [executable]
+        .failure()
+        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
+            error: no executable target found for package `hello_world`
+            help: you can add `executable` target to the package manifest with following excerpt
+            -> Scarb.toml
+                [executable]
 
-            [dependencies]
-            cairo_execute = "[..].[..].[..]"
+                [dependencies]
+                cairo_execute = "[..].[..].[..]"
 
-    "#},
-    );
+        "#});
 }
 
 #[test]
@@ -296,29 +279,27 @@ fn undefined_target_specified() {
         "#})
         .build(&t);
 
-    let output = Scarb::quick_snapbox()
+    Scarb::quick_snapbox()
         .arg("execute")
         .arg("--executable-name=secondary")
         .arg("--no-build")
         .current_dir(&t)
         .assert()
-        .failure();
-    output_assert(
-        output,
-        "error: no executable target with name `secondary` found for package `hello_world`\n",
-    );
+        .failure()
+        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
+            error: no executable target with name `secondary` found for package `hello_world`,
+        "#});
 
-    let output = Scarb::quick_snapbox()
+    Scarb::quick_snapbox()
         .arg("execute")
         .arg("--executable-function=secondary")
         .arg("--no-build")
         .current_dir(&t)
         .assert()
-        .failure();
-    output_assert(
-        output,
-        "error: no executable target with executable function `secondary` found for package `hello_world`\n",
-    );
+        .failure()
+        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
+            error: no executable target with executable function `secondary` found for package `hello_world`
+        "#});
 }
 
 fn two_targets() -> ProjectBuilder {
@@ -395,21 +376,17 @@ fn executable_must_be_chosen() {
     let t = TempDir::new().unwrap();
     two_targets().build(&t);
 
-    let output = Scarb::quick_snapbox()
+    Scarb::quick_snapbox()
         .arg("execute")
         .arg("--no-build")
         .current_dir(&t)
         .assert()
-        .failure();
-
-    output_assert(
-        output,
-        indoc! {r#"
+        .failure()
+        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
             error: more than one executable target found for package `hello_world`
             help: specify the target with `--executable-name` or `--executable-function`
-            
-        "#},
-    );
+    
+        "#});
 }
 
 #[test]
@@ -468,13 +445,4 @@ fn can_use_features() {
         [..]Executing hello
         Saving output to: target/execute/hello/execution1
         "#});
-}
-
-fn output_assert(output: OutputAssert, expected: &str) {
-    #[cfg(windows)]
-    output.stdout_matches(format!(
-        "{expected}error: process did not exit successfully: exit code: 1\n"
-    ));
-    #[cfg(not(windows))]
-    output.stdout_matches(expected);
 }

--- a/extensions/scarb-execute/tests/build.rs
+++ b/extensions/scarb-execute/tests/build.rs
@@ -287,7 +287,7 @@ fn undefined_target_specified() {
         .assert()
         .failure()
         .stdout_matches_with_windows_exit_code_error(indoc! {r#"
-            error: no executable target with name `secondary` found for package `hello_world`,
+            error: no executable target with name `secondary` found for package `hello_world`
         "#});
 
     Scarb::quick_snapbox()

--- a/extensions/scarb-prove/tests/build.rs
+++ b/extensions/scarb-prove/tests/build.rs
@@ -2,7 +2,7 @@ use assert_fs::TempDir;
 use assert_fs::assert::PathAssert;
 use assert_fs::fixture::PathChild;
 use indoc::indoc;
-use scarb_test_support::command::{OutputAssertExt, Scarb};
+use scarb_test_support::command::Scarb;
 use scarb_test_support::project_builder::ProjectBuilder;
 
 fn build_executable_project() -> TempDir {
@@ -125,7 +125,7 @@ fn prove_fails_when_execution_output_not_found() {
         .current_dir(&t)
         .assert()
         .failure()
-        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
+        .stdout_matches(indoc! {r#"
             [..]Proving hello
             warn: soundness of proof is not yet guaranteed by Stwo, use at your own risk
             error: execution directory not found: [..]/target/execute/hello/execution1
@@ -159,7 +159,7 @@ fn prove_fails_when_cairo_pie_output() {
         .current_dir(&t)
         .assert()
         .failure()
-        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
+        .stdout_matches(indoc! {r#"
             [..]Proving hello
             warn: soundness of proof is not yet guaranteed by Stwo, use at your own risk
             error: proving cairo pie output is not supported: [..]/target/execute/hello/execution1/cairo_pie.zip
@@ -206,7 +206,7 @@ fn prove_fails_on_windows() {
         .current_dir(&t)
         .assert()
         .failure()
-        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
+        .stdout_matches(indoc! {r#"
             error: `scarb prove` is not supported on Windows
             help: use WSL or a Linux/macOS machine instead
 

--- a/extensions/scarb-verify/tests/build.rs
+++ b/extensions/scarb-verify/tests/build.rs
@@ -1,6 +1,6 @@
 use assert_fs::TempDir;
 use indoc::indoc;
-use scarb_test_support::command::{OutputAssertExt, Scarb};
+use scarb_test_support::command::Scarb;
 use scarb_test_support::project_builder::ProjectBuilder;
 
 fn build_executable_project() -> TempDir {
@@ -98,7 +98,7 @@ fn verify_fails_when_execution_output_not_found() {
         .current_dir(&t)
         .assert()
         .failure()
-        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
+        .stdout_matches(indoc! {r#"
             [..]Verifying hello
             error: execution directory does not exist at path: [..]/target/execute/hello/execution1
             help: make sure to run `scarb prove --execute` first
@@ -117,7 +117,7 @@ fn verify_fails_when_proof_file_not_found() {
         .current_dir(&t)
         .assert()
         .failure()
-        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
+        .stdout_matches(indoc! {r#"
             [..]Verifying proof
             error: proof file does not exist at path: nonexistent.json
         "#});

--- a/extensions/scarb-verify/tests/build.rs
+++ b/extensions/scarb-verify/tests/build.rs
@@ -1,8 +1,7 @@
 use assert_fs::TempDir;
 use indoc::indoc;
-use scarb_test_support::command::Scarb;
+use scarb_test_support::command::{OutputAssertExt, Scarb};
 use scarb_test_support::project_builder::ProjectBuilder;
-use snapbox::cmd::OutputAssert;
 
 fn build_executable_project() -> TempDir {
     let t = TempDir::new().unwrap();
@@ -93,46 +92,33 @@ fn verify_from_path() {
 fn verify_fails_when_execution_output_not_found() {
     let t = build_executable_project();
 
-    output_assert(
-        Scarb::quick_snapbox()
-            .arg("verify")
-            .arg("--execution-id=1")
-            .current_dir(&t)
-            .assert()
-            .failure(),
-        indoc! {r#"
-        [..]Verifying hello
-        error: execution directory does not exist at path: [..]/target/execute/hello/execution1
-        help: make sure to run `scarb prove --execute` first
-        and that the execution ID is correct
+    Scarb::quick_snapbox()
+        .arg("verify")
+        .arg("--execution-id=1")
+        .current_dir(&t)
+        .assert()
+        .failure()
+        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
+            [..]Verifying hello
+            error: execution directory does not exist at path: [..]/target/execute/hello/execution1
+            help: make sure to run `scarb prove --execute` first
+            and that the execution ID is correct
 
-        "#},
-    )
+        "#});
 }
 
 #[test]
 fn verify_fails_when_proof_file_not_found() {
     let t = build_executable_project();
 
-    output_assert(
-        Scarb::quick_snapbox()
-            .arg("verify")
-            .arg("--proof-file=nonexistent.json")
-            .current_dir(&t)
-            .assert()
-            .failure(),
-        indoc! {r#"
-        [..]Verifying proof
-        error: proof file does not exist at path: nonexistent.json
-        "#},
-    )
-}
-
-fn output_assert(output: OutputAssert, expected: &str) {
-    #[cfg(windows)]
-    output.stdout_matches(format!(
-        "{expected}error: process did not exit successfully: exit code: 1\n"
-    ));
-    #[cfg(not(windows))]
-    output.stdout_matches(expected);
+    Scarb::quick_snapbox()
+        .arg("verify")
+        .arg("--proof-file=nonexistent.json")
+        .current_dir(&t)
+        .assert()
+        .failure()
+        .stdout_matches_with_windows_exit_code_error(indoc! {r#"
+            [..]Verifying proof
+            error: proof file does not exist at path: nonexistent.json
+        "#});
 }

--- a/scarb/src/ops/subcommands.rs
+++ b/scarb/src/ops/subcommands.rs
@@ -73,7 +73,7 @@ pub fn execute_external_subcommand(
         cmd.envs(env);
     }
 
-    exec_replace(&mut cmd)
+    exec_replace(cmd)
 }
 
 #[tracing::instrument(level = "debug", skip(ws))]

--- a/scarb/src/process.rs
+++ b/scarb/src/process.rs
@@ -28,11 +28,11 @@ pub use crate::internal::fsx::is_executable;
 /// In doing so (and by effectively ignoring it) we should emulate proxying Ctrl-C handling to
 /// the application at hand, which will either terminate or handle it itself.
 /// According to Microsoft's documentation at
-/// <https://docs.microsoft.com/en-us/windows/console/ctrl-c-and-ctrl-break-signals>.
-/// The Ctrl-C signal is sent to all processes attached to a terminal, which should include our
-/// child process. If the child terminates, then we will reap them in Cargo pretty quickly, and if
-/// the child handles the signal, then we won't terminate (and we shouldn't!) until the process
-/// itself later exits.
+/// <https://docs.microsoft.com/en-us/windows/console/ctrl-c-and-ctrl-break-signals>
+/// the Ctrl-C signal is sent to all processes attached to a terminal, which should include our
+/// child process. If the child terminates, then we will terminate Scarb quickly and silently,
+/// and if the child handles the signal, then we won't terminate (and we shouldn't!) until
+/// the process itself later exits.
 ///
 /// # Drop semantics
 /// [`WillExecReplace`] implements the _Drop Bomb_ pattern, which means it will panic if dropped

--- a/scarb/src/process.rs
+++ b/scarb/src/process.rs
@@ -1,10 +1,10 @@
+use anyhow::{Context, Result, anyhow, bail};
+use std::error::Error;
 use std::ffi::OsStr;
 use std::io::{BufRead, BufReader, Read};
 use std::process::{Command, Stdio};
 use std::sync::Arc;
-use std::{fmt, thread};
-
-use anyhow::{Context, Result, anyhow, bail};
+use std::{fmt, mem, thread};
 use tracing::{Span, debug, debug_span, warn};
 
 use scarb_ui::components::{Spinner, Status};
@@ -14,23 +14,64 @@ pub use crate::internal::fsx::is_executable;
 
 /// Replaces the current process with the target process.
 ///
-/// On Unix, this executes the process using the Unix syscall `execvp`, which will block this
-/// process, and will only return if there is an error.
+/// # Flow
+/// This function just throws a special [`WillExecReplace`] error used to perform the syscall at
+/// the very end of the `main` function. This allows running all destructors waiting higher up
+/// the call stack.
 ///
-/// On Windows this isn't technically possible. Instead we emulate it to the best of our ability.
+/// # Implementation details
+/// On Unix, this executes the process using the Unix syscall `execvp`, which will block this
+/// process and will only return if there is an error.
+///
+/// On Windows this isn't technically possible. Instead, we emulate it to the best of our ability.
 /// One aspect we fix here is that we specify a handler for the Ctrl-C handler.
 /// In doing so (and by effectively ignoring it) we should emulate proxying Ctrl-C handling to
 /// the application at hand, which will either terminate or handle it itself.
 /// According to Microsoft's documentation at
 /// <https://docs.microsoft.com/en-us/windows/console/ctrl-c-and-ctrl-break-signals>.
-/// the Ctrl-C signal is sent to all processes attached to a terminal, which should include our
-/// child process. If the child terminates then we'll reap them in Cargo pretty quickly, and if
-/// the child handles the signal then we won't terminate (and we shouldn't!) until the process
+/// The Ctrl-C signal is sent to all processes attached to a terminal, which should include our
+/// child process. If the child terminates, then we will reap them in Cargo pretty quickly, and if
+/// the child handles the signal, then we won't terminate (and we shouldn't!) until the process
 /// itself later exits.
-#[tracing::instrument(level = "debug", skip_all)]
-pub fn exec_replace(cmd: &mut Command) -> Result<()> {
-    debug!("{}", shlex_join(cmd));
-    imp::exec_replace(cmd)
+///
+/// # Drop semantics
+/// [`WillExecReplace`] implements the _Drop Bomb_ pattern, which means it will panic if dropped
+/// without [`WillExecReplace::take_over`] being called.
+pub fn exec_replace(command: Command) -> Result<()> {
+    let err = WillExecReplace(Some(Box::new(command)));
+    debug!("{err}");
+    Err(err.into())
+}
+
+/// Error object thrown from [`exec_replace`].
+///
+/// See [`exec_replace`] for details.
+#[derive(Debug)]
+pub struct WillExecReplace(Option<Box<Command>>);
+
+impl WillExecReplace {
+    /// Performs or emulates process replacement and defuses the drop bomb.
+    pub fn take_over(mut self) -> ! {
+        let command = self.0.take().unwrap();
+        mem::forget(self); // Defuse the drop bomb.
+        imp::exec_replace(*command);
+    }
+}
+
+impl fmt::Display for WillExecReplace {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("EXEC")?;
+        f.write_str(&shlex_join(self.0.as_ref().unwrap()))?;
+        Ok(())
+    }
+}
+
+impl Error for WillExecReplace {}
+
+impl Drop for WillExecReplace {
+    fn drop(&mut self) {
+        panic!("not defused: {self}");
+    }
 }
 
 #[cfg(unix)]
@@ -38,19 +79,17 @@ mod imp {
     use std::os::unix::process::CommandExt;
     use std::process::Command;
 
-    use anyhow::{Result, bail};
-
-    pub fn exec_replace(cmd: &mut Command) -> Result<()> {
+    pub fn exec_replace(mut cmd: Command) -> ! {
         let err = cmd.exec();
-        bail!("process did not exit successfully: {err}")
+        panic!("{err}");
     }
 }
 
 #[cfg(windows)]
 mod imp {
+    use std::process;
     use std::process::Command;
 
-    use anyhow::{Context, Result, bail};
     use windows_sys::Win32::Foundation::{BOOL, FALSE, TRUE};
     use windows_sys::Win32::System::Console::SetConsoleCtrlHandler;
 
@@ -59,31 +98,23 @@ mod imp {
         TRUE
     }
 
-    pub fn exec_replace(cmd: &mut Command) -> Result<()> {
+    pub fn exec_replace(mut cmd: Command) -> ! {
         unsafe {
             if SetConsoleCtrlHandler(Some(ctrlc_handler), TRUE) == FALSE {
                 panic!("Could not set Ctrl-C handler.");
             }
         }
 
-        // Just execute the process as normal.
+        // Execute the process as normal.
 
         let exit_status = cmd
             .spawn()
-            .with_context(|| format!("failed to spawn: {}", cmd.get_program().to_string_lossy()))?
+            .expect("failed to spawn a subprocess")
             .wait()
-            .with_context(|| {
-                format!(
-                    "failed to wait for process to finish: {}",
-                    cmd.get_program().to_string_lossy()
-                )
-            })?;
+            .expect("failed to wait for the subprocess process to finish");
 
-        if exit_status.success() {
-            Ok(())
-        } else {
-            bail!("process did not exit successfully: {exit_status}");
-        }
+        let exit_code = exit_status.code().unwrap_or(1);
+        process::exit(exit_code);
     }
 }
 

--- a/utils/scarb-test-support/src/command.rs
+++ b/utils/scarb-test-support/src/command.rs
@@ -140,21 +140,3 @@ impl CommandExt for SnapboxCommand {
         panic!("Failed to deserialize stdout to JSON");
     }
 }
-
-pub trait OutputAssertExt {
-    /// A variant of [`OutputAssert::stdout_matches`] that accounts for Windows-only extra output
-    /// on process failures.
-    fn stdout_matches_with_windows_exit_code_error(self, expected: impl Into<String>) -> Self;
-}
-
-impl OutputAssertExt for OutputAssert {
-    fn stdout_matches_with_windows_exit_code_error(self, expected: impl Into<String>) -> Self {
-        let expected = expected.into();
-
-        #[cfg(windows)]
-        let expected =
-            format!("{expected}error: process did not exit successfully: exit code: 1\n");
-
-        self.stdout_matches(expected)
-    }
-}

--- a/utils/scarb-test-support/src/command.rs
+++ b/utils/scarb-test-support/src/command.rs
@@ -1,7 +1,7 @@
 use assert_fs::TempDir;
 use assert_fs::prelude::*;
 use serde::de::DeserializeOwned;
-use snapbox::cmd::{Command as SnapboxCommand, OutputAssert};
+use snapbox::cmd::Command as SnapboxCommand;
 use std::ffi::OsString;
 use std::io::BufRead;
 use std::path::{Path, PathBuf};


### PR DESCRIPTION
This PR reimplements our `exec_replace` approach to fix two issues:
1. We have inconsistently added a `error: process did not exit successfully: exit code: 1` line only on Windows, and this was accounted for in tests in a very dirty way.
2. We never cared about destructing objects created up in the call stack. This PR actually fixes an unnoticed bug - calling `exec_replace` would result in broken (unterminated) trace files.