### PR TITLE
Reject dependency toml with invalid keywords

### DIFF
--- a/scarb/tests/build.rs
+++ b/scarb/tests/build.rs
@@ -374,7 +374,7 @@ fn compile_with_invalid_non_numeric_dep_version() {
                   |
                 7 |             moo = "y"
                   |                   ^^^
-                data did not match any variant of dependency specification
+                unexpected character 'y' while parsing major version number
         "#});
 }
 

--- a/scarb/tests/git_source.rs
+++ b/scarb/tests/git_source.rs
@@ -169,8 +169,6 @@ fn fetch_with_nested_paths() {
         .success();
 }
 
-// TODO(#130): Redo TomlDependency deserializer to stick parsing particular variant
-//   if specific keyword appears.
 #[test]
 fn fetch_with_short_ssh_git() {
     let t = TempDir::new().unwrap();
@@ -194,7 +192,40 @@ fn fetch_with_short_ssh_git() {
                   |
                 7 | dep = { git = "git@github.com:a/dep" }
                   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-                data did not match any variant of dependency specification
+                relative URL without a base: "git@github.com:a/dep"
+        "#});
+}
+
+#[test]
+fn fetch_with_invalid_keyword() {
+    let git_dep = gitx::new("dep", |t| {
+        ProjectBuilder::start()
+            .name("dep")
+            .lib_cairo("fn hello() -> felt252 { 42 }")
+            .build(&t)
+    });
+    let t = TempDir::new().unwrap();
+    ProjectBuilder::start()
+        .name("hello")
+        .version("1.0.0")
+        .dep("dep", git_dep.with("commit", "some-rev"))
+        .lib_cairo("fn world() -> felt252 { dep::hello() }")
+        .build(&t);
+
+    Scarb::quick_snapbox()
+        .arg("fetch")
+        .current_dir(&t)
+        .assert()
+        .failure()
+        .stdout_matches(indoc! {r#"
+            error: failed to parse manifest at: [..]
+
+            Caused by:
+                TOML parse error at line 7, column 7
+                  |
+                7 | dep = { git = "[..]", commit = "some-rev" }
+                  |       ^[..]^
+                unknown field `commit`
         "#});
 }
 


### PR DESCRIPTION
Previously, we've agreed to allow invalid keywords in dependency spec (see https://github.com/software-mansion/scarb/pull/2237#discussion_r2090618885). However, this seems to lead to a lot of hard to notice / debug errors, as users might mistype a spec. In such case, the project can still compile, but using a different revision than intended (e.g. if you type "commit" instead of "rev"). 
This PR disallows using invalid keywords in dependency spec and emits errors when parsing instead. 

fix #130 