### PR TITLE
Fix docs: elvish completions

### DIFF
--- a/website/download.md
+++ b/website/download.md
@@ -198,7 +198,7 @@ try {
 # END SCARB COMPLETIONS
 ```
 
-Run `source ~/.config/elvish/rc.elv`, or open a new terminal session to apply the changes.
+Run `eval (slurp <  ~/.config/elvish/rc.elv)`, or open a new terminal session to apply the changes.
 
 </details>
 


### PR DESCRIPTION
The instructions for loading `elvish` completions are wrong (props to @wawel37 for discovery).

Since this is one of less popular shells that we don't support in starkup nor in install script, and since I wasn't able to find a way to make lazily-loaded completions similar to other shell, a more simple approach with completions loaded directly on shell start, akin to powershell one, is used. 
