### PR TITLE
scarb-execute: extend resource info with memory segments & improve formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6648,6 +6648,7 @@ dependencies = [
  "cairo-vm 2.2.0",
  "camino",
  "clap",
+ "console",
  "create-output-dir",
  "derive_builder",
  "indoc",
@@ -6660,6 +6661,7 @@ dependencies = [
  "serde",
  "serde_json",
  "snapbox",
+ "thousands",
  "tracing-subscriber",
 ]
 
@@ -7999,6 +8001,12 @@ checksum = "a3ad459d94dd517257cc96add8a43190ee620011bb6e6cdc82dafd97dfafafea"
 dependencies = [
  "thiserror-impl-no-std",
 ]
+
+[[package]]
+name = "thousands"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
 name = "thread_local"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,6 +141,7 @@ target-triple = "0.1"
 tempfile = "3"
 test-case = "3"
 thiserror = "2"
+thousands = "0.2"
 time = "0.3"
 tokio = { version = "1", features = ["macros", "io-util", "process", "rt", "rt-multi-thread", "sync"] }
 tokio-stream = "0.1"

--- a/extensions/scarb-execute/Cargo.toml
+++ b/extensions/scarb-execute/Cargo.toml
@@ -19,6 +19,7 @@ cairo-lang-utils.workspace = true
 cairo-vm.workspace = true
 camino.workspace = true
 clap.workspace = true
+console.workspace = true
 create-output-dir = { path = "../../utils/create-output-dir" }
 indoc.workspace = true
 predicates.workspace = true
@@ -29,6 +30,7 @@ scarb-ui = { path = "../../utils/scarb-ui" }
 serde.workspace = true
 serde_json.workspace = true
 tracing-subscriber.workspace = true
+thousands.workspace = true
 
 [dev-dependencies]
 assert_fs.workspace = true

--- a/extensions/scarb-execute/src/lib.rs
+++ b/extensions/scarb-execute/src/lib.rs
@@ -162,8 +162,8 @@ pub fn execute(
         layout: LayoutName::all_cairo,
         proof_mode,
         secure_run: None,
-        relocate_mem: output.is_standard(),
-        trace_enabled: output.is_standard(),
+        relocate_mem: output.is_standard() || args.run.print_resource_usage,
+        trace_enabled: output.is_standard() || args.run.print_resource_usage,
         disable_trace_padding: proof_mode,
         ..Default::default()
     };

--- a/extensions/scarb-execute/src/output.rs
+++ b/extensions/scarb-execute/src/output.rs
@@ -1,9 +1,12 @@
 use anyhow::Context;
 use anyhow::Result;
 use cairo_lang_runner::CairoHintProcessor;
+use cairo_vm::vm::errors::trace_errors::TraceError;
 use cairo_vm::vm::runners::cairo_runner::CairoRunner;
+use console::Style;
 use scarb_ui::Message;
 use serde::{Serialize, Serializer};
+use thousands::Separable;
 
 #[derive(Serialize)]
 pub struct ExecutionSummary {
@@ -66,6 +69,8 @@ pub struct ExecutionResources {
     n_memory_holes: usize,
     builtin_instance_counter: Vec<(String, usize)>,
     syscalls: Vec<(String, usize)>,
+    memory_segment_sizes: Vec<(String, usize)>,
+    max_memory_address: usize,
 }
 
 impl ExecutionResources {
@@ -81,17 +86,42 @@ impl ExecutionResources {
         let builtin_instance_counter = sort_by_value(&resources.builtin_instance_counter)
             .into_iter()
             .map(|(k, v)| (k.to_string(), *v))
+            .filter(|(_, v)| *v > 0)
             .collect::<Vec<_>>();
         let syscalls = sort_by_value(&all_used_resources.syscalls)
             .into_iter()
             .map(|(k, v)| (k.to_string(), *v))
             .collect::<Vec<_>>();
 
+        let mut memory_segment_addresses = runner.get_memory_segment_addresses()?;
+
+        let (trace_first, trace_last) = runner
+            .relocated_trace
+            .as_ref()
+            .map(|trace| (trace.first().unwrap(), trace.last().unwrap()))
+            .ok_or(TraceError::TraceNotRelocated)?;
+        memory_segment_addresses.insert("execution", (trace_first.ap, trace_last.ap));
+
+        let max_memory_address = memory_segment_addresses
+            .values()
+            .map(|(_, stop_ptr)| *stop_ptr)
+            .max()
+            .unwrap_or(0);
+
+        let mut memory_segment_sizes: Vec<(String, usize)> = memory_segment_addresses
+            .into_iter()
+            .map(|(segment, (start_ptr, stop_ptr))| (segment.to_string(), stop_ptr - start_ptr))
+            .filter(|(_, size)| *size > 0)
+            .collect();
+        memory_segment_sizes.sort_by(|(_, a), (_, b)| b.cmp(a));
+
         Ok(Self {
             n_steps: resources.n_steps,
             n_memory_holes: resources.n_memory_holes,
             builtin_instance_counter,
             syscalls,
+            memory_segment_sizes,
+            max_memory_address,
         })
     }
 }
@@ -102,13 +132,23 @@ impl Message for ExecutionResources {
         Self: Sized,
     {
         println!("Resources:");
-        println!("\tsteps: {}", self.n_steps);
-        println!("\tmemory holes: {}", self.n_memory_holes);
+        println!("\t{}", format_property("steps", self.n_steps));
         println!(
-            "\tbuiltins: ({})",
+            "\t{}",
+            format_property("max memory address", self.max_memory_address)
+        );
+        println!("\t{}", format_property("memory holes", self.n_memory_holes));
+        println!(
+            "\tbuiltins:\n{}",
             format_items(&self.builtin_instance_counter)
         );
-        println!("\tsyscalls: ({})", format_items(&self.syscalls));
+        println!(
+            "\tmemory segments:\n{}",
+            format_items(&self.memory_segment_sizes)
+        );
+        if !self.syscalls.is_empty() {
+            println!("\tsyscalls:\n{}", format_items(&self.syscalls));
+        }
     }
 
     fn structured<S: Serializer>(self, ser: S) -> anyhow::Result<S::Ok, S::Error>
@@ -131,12 +171,26 @@ where
 
 fn format_items<K, V>(items: &[(K, V)]) -> String
 where
-    K: std::fmt::Debug,
-    V: std::fmt::Display,
+    K: std::fmt::Display,
+    V: std::fmt::Display + Separable,
 {
     items
         .iter()
-        .map(|(key, value)| format!("{key:?}: {value}"))
+        .map(|(key, value)| format!("\t\t{}", format_property(key, value)))
         .collect::<Vec<String>>()
-        .join(", ")
+        .join("\n")
+}
+
+fn format_property<K, V>(key: K, value: V) -> String
+where
+    K: std::fmt::Display,
+    V: std::fmt::Display + Separable,
+{
+    format!(
+        "{key}: {}",
+        Style::new()
+            .yellow()
+            .bold()
+            .apply_to(value.separate_with_commas())
+    )
 }


### PR DESCRIPTION
This PR adds several extra fields that are useful for benchmarking:
- Memory segments size
- Max memory segment address

Also formatting is changed to improve readability:
- One property per line (easier to calculate diff)
- Colored values, thousand separators

<img width="672" height="402" alt="image" src="https://github.com/user-attachments/assets/aac0738e-59a7-41cb-b01a-42f7236fc5b8" />
