### PR TITLE
Rewrite token stream spans to start at zero, for optimized get_text method

### DIFF
--- a/scarb/src/compiler/plugin/proc_macro/v2/host/attribute/inner_attribute.rs
+++ b/scarb/src/compiler/plugin/proc_macro/v2/host/attribute/inner_attribute.rs
@@ -141,7 +141,6 @@ impl ProcMacroHostPlugin {
         let mut used_attr_names: HashSet<SmolStr> = Default::default();
         let mut all_none = true;
         let ctx = AllocationContext::default();
-        let item_start_offset = item_ast.as_syntax_node().span(db).start;
 
         match item_ast.clone() {
             ast::ModuleItem::Trait(trait_ast) => {
@@ -167,13 +166,14 @@ impl ProcMacroHostPlugin {
                                 continue;
                             };
 
+                            let item_span = func.as_syntax_node().span(db);
                             let mut token_stream_builder = TokenStreamBuilder::new(db);
                             let attrs = func.attributes(db).elements(db).collect();
                             let found = self.parse_attrs(
                                 db,
                                 &mut token_stream_builder,
                                 attrs,
-                                item_start_offset,
+                                item_span,
                                 &ctx,
                             );
                             if let Some(name) = found.as_name() {
@@ -230,13 +230,14 @@ impl ProcMacroHostPlugin {
                                 continue;
                             };
 
+                            let item_span = func.as_syntax_node().span(db);
                             let mut token_stream_builder = TokenStreamBuilder::new(db);
                             let attrs = func.attributes(db).elements(db).collect();
                             let found = self.parse_attrs(
                                 db,
                                 &mut token_stream_builder,
                                 attrs,
-                                item_start_offset,
+                                item_span,
                                 &ctx,
                             );
                             if let Some(name) = found.as_name() {

--- a/scarb/src/compiler/plugin/proc_macro/v2/host/attribute/item_attribute.rs
+++ b/scarb/src/compiler/plugin/proc_macro/v2/host/attribute/item_attribute.rs
@@ -209,7 +209,7 @@ fn parse_item<T: ItemWithAttributes + ChildNodesWithoutAttributes>(
 ) -> AttrExpansionFound {
     let span = ast.span_with_trivia(db);
     let attrs = ast.item_attributes(db);
-    let expansion = host.parse_attrs(db, token_stream_builder, attrs, span.start, ctx);
+    let expansion = host.parse_attrs(db, token_stream_builder, attrs, span, ctx);
     token_stream_builder.extend(ast.child_nodes_without_attributes(db));
     expansion
 }

--- a/scarb/src/compiler/plugin/proc_macro/v2/host/attribute/parse_attributes.rs
+++ b/scarb/src/compiler/plugin/proc_macro/v2/host/attribute/parse_attributes.rs
@@ -5,7 +5,7 @@ use crate::compiler::plugin::proc_macro::v2::host::attribute::{
 use crate::compiler::plugin::proc_macro::v2::host::conversion::CallSiteLocation;
 use crate::compiler::plugin::proc_macro::v2::{ProcMacroHostPlugin, TokenStreamBuilder};
 use crate::compiler::plugin::proc_macro::{ExpansionKind, ExpansionQuery};
-use cairo_lang_filesystem::span::TextOffset;
+use cairo_lang_filesystem::span::TextSpan;
 use cairo_lang_macro::AllocationContext;
 use cairo_lang_syntax::attribute::structured::AttributeStructurize;
 use cairo_lang_syntax::node::db::SyntaxGroup;
@@ -17,7 +17,7 @@ impl ProcMacroHostPlugin {
         db: &dyn SyntaxGroup,
         builder: &mut TokenStreamBuilder<'_>,
         item_attrs: Vec<ast::Attribute>,
-        item_start_offset: TextOffset,
+        item_span: TextSpan,
         ctx: &AllocationContext,
     ) -> AttrExpansionFound {
         // This function parses attributes of the item,
@@ -48,11 +48,7 @@ impl ProcMacroHostPlugin {
                             id: found,
                             args,
                             call_site: CallSiteLocation::new(&attr, db),
-                            attribute_location: ExpandableAttrLocation::new(
-                                &attr,
-                                item_start_offset,
-                                db,
-                            ),
+                            attribute_location: ExpandableAttrLocation::new(&attr, item_span, db),
                         });
                         // Do not add the attribute for found expansion.
                         continue;

--- a/scarb/tests/proc_macro_v2_expand.rs
+++ b/scarb/tests/proc_macro_v2_expand.rs
@@ -974,7 +974,7 @@ fn code_mappings_preserve_attribute_error_on_inner_trait_locations_with_parser()
                     .into_iter()
                     .map(|TokenTree::Ident(token)| {
                         if token.content.to_string() == "12" {
-                            TokenTree::Ident(Token::new("34", TextSpan::call_site()))
+                            TokenTree::Ident(Token::new("34", TextSpan::new(0,2)))
                         } else {
                             TokenTree::Ident(token)
                         }
@@ -2176,30 +2176,30 @@ fn token_stream_parsed_with_correct_spans() {
         .stdout_matches(indoc! {r##"
             [..] Compiling some v1.0.0 ([..]Scarb.toml)
             [..] Compiling hello v1.0.0 ([..]Scarb.toml)
-            Ident(Token { content: "  ", span: TextSpan { start: 46, end: 48 } })
-            Ident(Token { content: "fn", span: TextSpan { start: 48, end: 50 } })
-            Ident(Token { content: " ", span: TextSpan { start: 50, end: 51 } })
-            Ident(Token { content: "foo", span: TextSpan { start: 51, end: 54 } })
-            Ident(Token { content: "(", span: TextSpan { start: 54, end: 55 } })
-            Ident(Token { content: ")", span: TextSpan { start: 55, end: 56 } })
-            Ident(Token { content: " ", span: TextSpan { start: 56, end: 57 } })
-            Ident(Token { content: "{", span: TextSpan { start: 57, end: 58 } })
+            Ident(Token { content: "  ", span: TextSpan { start: 0, end: 2 } })
+            Ident(Token { content: "fn", span: TextSpan { start: 2, end: 4 } })
+            Ident(Token { content: " ", span: TextSpan { start: 4, end: 5 } })
+            Ident(Token { content: "foo", span: TextSpan { start: 5, end: 8 } })
+            Ident(Token { content: "(", span: TextSpan { start: 8, end: 9 } })
+            Ident(Token { content: ")", span: TextSpan { start: 9, end: 10 } })
+            Ident(Token { content: " ", span: TextSpan { start: 10, end: 11 } })
+            Ident(Token { content: "{", span: TextSpan { start: 11, end: 12 } })
             Ident(Token { content: "
-            ", span: TextSpan { start: 58, end: 59 } })
-            Ident(Token { content: "    ", span: TextSpan { start: 59, end: 63 } })
-            Ident(Token { content: "let", span: TextSpan { start: 63, end: 66 } })
-            Ident(Token { content: " ", span: TextSpan { start: 66, end: 67 } })
-            Ident(Token { content: "_a", span: TextSpan { start: 67, end: 69 } })
-            Ident(Token { content: " ", span: TextSpan { start: 69, end: 70 } })
-            Ident(Token { content: "=", span: TextSpan { start: 70, end: 71 } })
-            Ident(Token { content: " ", span: TextSpan { start: 71, end: 72 } })
-            Ident(Token { content: "1", span: TextSpan { start: 72, end: 73 } })
-            Ident(Token { content: ";", span: TextSpan { start: 73, end: 74 } })
+            ", span: TextSpan { start: 12, end: 13 } })
+            Ident(Token { content: "    ", span: TextSpan { start: 13, end: 17 } })
+            Ident(Token { content: "let", span: TextSpan { start: 17, end: 20 } })
+            Ident(Token { content: " ", span: TextSpan { start: 20, end: 21 } })
+            Ident(Token { content: "_a", span: TextSpan { start: 21, end: 23 } })
+            Ident(Token { content: " ", span: TextSpan { start: 23, end: 24 } })
+            Ident(Token { content: "=", span: TextSpan { start: 24, end: 25 } })
+            Ident(Token { content: " ", span: TextSpan { start: 25, end: 26 } })
+            Ident(Token { content: "1", span: TextSpan { start: 26, end: 27 } })
+            Ident(Token { content: ";", span: TextSpan { start: 27, end: 28 } })
             Ident(Token { content: "
-            ", span: TextSpan { start: 74, end: 75 } })
-            Ident(Token { content: "}", span: TextSpan { start: 75, end: 76 } })
+            ", span: TextSpan { start: 28, end: 29 } })
+            Ident(Token { content: "}", span: TextSpan { start: 29, end: 30 } })
             Ident(Token { content: "
-            ", span: TextSpan { start: 76, end: 77 } })
+            ", span: TextSpan { start: 30, end: 31 } })
             [..]Finished `dev` profile target(s) in [..]
       "##});
 }

--- a/utils/scarb-test-support/src/cairo_plugin_project_builder.rs
+++ b/utils/scarb-test-support/src/cairo_plugin_project_builder.rs
@@ -128,11 +128,11 @@ impl CairoPluginProjectBuilder {
     }
 
     pub fn add_cairo_lang_parser_dep(self) -> Self {
-        self.add_dep(r#"cairo-lang-parser = { git = "https://github.com/starkware-libs/cairo.git", rev = "172195a5e8c889a2355c28f5c444e61da6ae8a2b" }"#)
+        self.add_dep(r#"cairo-lang-parser = "2.12.0-rc.3""#)
     }
 
     pub fn add_cairo_lang_syntax_dep(self) -> Self {
-        self.add_dep(r#"cairo-lang-syntax = { git = "https://github.com/starkware-libs/cairo.git", rev = "172195a5e8c889a2355c28f5c444e61da6ae8a2b" }"#)
+        self.add_dep(r#"cairo-lang-syntax = "2.12.0-rc.3""#)
     }
 
     pub fn default_v1() -> Self {


### PR DESCRIPTION
- **Use 2.12.0-rc.2 parser in proc macro tests**
- **Pass whole token stream span to the span adapter**
- ** Rewrite token stream spans to start at zero**


This has to be done, as get_text method in the compiler now works by slicing the file content with the spans, so we cannot start the parser with non-zero initial offset for new virtual files with token content only. 