### PR TITLE
Release 2.12.0-rc.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -830,8 +830,9 @@ checksum = "a3c8f83209414aacf0eeae3cf730b18d6981697fba62f200fcfb92b9f082acba"
 
 [[package]]
 name = "cairo-lang-casm"
-version = "2.11.4"
-source = "git+https://github.com/starkware-libs/cairo?rev=7675b74815370e6c16760e8b059ae5d773cade88#7675b74815370e6c16760e8b059ae5d773cade88"
+version = "2.12.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35c44a18fe499fbb045bc29502b3ff84ef6d890d83557d83740439232ad44b09"
 dependencies = [
  "cairo-lang-utils",
  "indoc",
@@ -843,8 +844,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-compiler"
-version = "2.11.4"
-source = "git+https://github.com/starkware-libs/cairo?rev=7675b74815370e6c16760e8b059ae5d773cade88#7675b74815370e6c16760e8b059ae5d773cade88"
+version = "2.12.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a82814326cca54aa03c91e678c5a1ce83bc5dcc23996db1830308201f42defe0"
 dependencies = [
  "anyhow",
  "cairo-lang-defs",
@@ -869,16 +871,18 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-debug"
-version = "2.11.4"
-source = "git+https://github.com/starkware-libs/cairo?rev=7675b74815370e6c16760e8b059ae5d773cade88#7675b74815370e6c16760e8b059ae5d773cade88"
+version = "2.12.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71733c729779572499866fccf3963766ff2cf58da8068cbdfc0d53f827be723e"
 dependencies = [
  "cairo-lang-utils",
 ]
 
 [[package]]
 name = "cairo-lang-defs"
-version = "2.11.4"
-source = "git+https://github.com/starkware-libs/cairo?rev=7675b74815370e6c16760e8b059ae5d773cade88#7675b74815370e6c16760e8b059ae5d773cade88"
+version = "2.12.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a6cd5d255033aab9a30a334a3fe916cc5a25599367fb49288e13b64936530c"
 dependencies = [
  "bincode",
  "cairo-lang-debug",
@@ -897,8 +901,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-diagnostics"
-version = "2.11.4"
-source = "git+https://github.com/starkware-libs/cairo?rev=7675b74815370e6c16760e8b059ae5d773cade88#7675b74815370e6c16760e8b059ae5d773cade88"
+version = "2.12.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46be05840c0485486b59820be4e5a83beb298ccf932089828dbdba0e181b32"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-filesystem",
@@ -908,8 +913,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-doc"
-version = "2.11.4"
-source = "git+https://github.com/starkware-libs/cairo?rev=7675b74815370e6c16760e8b059ae5d773cade88#7675b74815370e6c16760e8b059ae5d773cade88"
+version = "2.12.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3230caea21e400a4808f3c5220a9f479295f834c049e9d503d58ceb79b50bb85"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -928,8 +934,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-eq-solver"
-version = "2.11.4"
-source = "git+https://github.com/starkware-libs/cairo?rev=7675b74815370e6c16760e8b059ae5d773cade88#7675b74815370e6c16760e8b059ae5d773cade88"
+version = "2.12.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b14100faad5935802a61fc26b1c237a56d5fb941971f09d13e52655d96f1249e"
 dependencies = [
  "cairo-lang-utils",
  "good_lp",
@@ -937,8 +944,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-executable"
-version = "2.11.4"
-source = "git+https://github.com/starkware-libs/cairo?rev=7675b74815370e6c16760e8b059ae5d773cade88#7675b74815370e6c16760e8b059ae5d773cade88"
+version = "2.12.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78dbd102f2e88c3aacb24fafeff0cb8a5b7444f9440a380b2a40ee30be4370bc"
 dependencies = [
  "anyhow",
  "cairo-lang-casm",
@@ -962,8 +970,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-filesystem"
-version = "2.11.4"
-source = "git+https://github.com/starkware-libs/cairo?rev=7675b74815370e6c16760e8b059ae5d773cade88#7675b74815370e6c16760e8b059ae5d773cade88"
+version = "2.12.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75df3751324f1a3a9fd00bf37911223cff002aa9d0262b874d5e9469c9d56cfc"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-utils",
@@ -977,8 +986,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-formatter"
-version = "2.11.4"
-source = "git+https://github.com/starkware-libs/cairo?rev=7675b74815370e6c16760e8b059ae5d773cade88#7675b74815370e6c16760e8b059ae5d773cade88"
+version = "2.12.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8b073fc5f09c4550a2d82426d56bf5f4d4682505bdf95d1c41569f6c1b50399"
 dependencies = [
  "anyhow",
  "cairo-lang-diagnostics",
@@ -995,8 +1005,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-lowering"
-version = "2.11.4"
-source = "git+https://github.com/starkware-libs/cairo?rev=7675b74815370e6c16760e8b059ae5d773cade88#7675b74815370e6c16760e8b059ae5d773cade88"
+version = "2.12.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9215db6f94eeed6869bff84afb5c1d07c07817b064db8e6f16e67776b9671dc5"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -1010,7 +1021,6 @@ dependencies = [
  "cairo-lang-syntax",
  "cairo-lang-utils",
  "id-arena",
- "indent",
  "itertools 0.14.0",
  "log",
  "num-bigint",
@@ -1034,20 +1044,6 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-macro"
-version = "0.2.0-rc.0"
-source = "git+https://github.com/software-mansion/scarb.git?rev=a7b5dce2aea8ee404c51057c0180de721950f961#a7b5dce2aea8ee404c51057c0180de721950f961"
-dependencies = [
- "bumpalo",
- "cairo-lang-macro-attributes 0.2.0-rc.0",
- "cairo-lang-macro-stable 2.0.0-rc.0 (git+https://github.com/software-mansion/scarb.git?rev=a7b5dce2aea8ee404c51057c0180de721950f961)",
- "cairo-lang-primitive-token",
- "cairo-lang-quote 0.1.0-rc.0 (git+https://github.com/software-mansion/scarb.git?rev=a7b5dce2aea8ee404c51057c0180de721950f961)",
- "linkme",
- "serde",
-]
-
-[[package]]
-name = "cairo-lang-macro"
 version = "0.2.0-rc.1"
 dependencies = [
  "bumpalo",
@@ -1059,6 +1055,21 @@ dependencies = [
  "serde",
  "serde_json",
  "trybuild",
+]
+
+[[package]]
+name = "cairo-lang-macro"
+version = "0.2.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c2717fc698bed6895b7bd0117e296ff750b3038a12709e5eca50b86daef1ea"
+dependencies = [
+ "bumpalo",
+ "cairo-lang-macro-attributes 0.2.0-rc.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cairo-lang-macro-stable 2.0.0-rc.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cairo-lang-primitive-token",
+ "cairo-lang-quote 0.1.0-rc.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "linkme",
+ "serde",
 ]
 
 [[package]]
@@ -1074,8 +1085,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-macro-attributes"
-version = "0.2.0-rc.0"
-source = "git+https://github.com/software-mansion/scarb.git?rev=a7b5dce2aea8ee404c51057c0180de721950f961#a7b5dce2aea8ee404c51057c0180de721950f961"
+version = "0.2.0-rc.1"
 dependencies = [
  "quote",
  "scarb-stable-hash 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1085,6 +1095,8 @@ dependencies = [
 [[package]]
 name = "cairo-lang-macro-attributes"
 version = "0.2.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2babcf3fd15dec9c413ed72ffc1561fbc852f3a4b5e6709370bc4a16616fdc1"
 dependencies = [
  "quote",
  "scarb-stable-hash 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1104,12 +1116,14 @@ version = "2.0.0-rc.0"
 [[package]]
 name = "cairo-lang-macro-stable"
 version = "2.0.0-rc.0"
-source = "git+https://github.com/software-mansion/scarb.git?rev=a7b5dce2aea8ee404c51057c0180de721950f961#a7b5dce2aea8ee404c51057c0180de721950f961"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c19c6d899e411d6ec7fcd576d2e6dfb2d5faf0414bf9bdb70e0e71887c85a0e"
 
 [[package]]
 name = "cairo-lang-parser"
-version = "2.11.4"
-source = "git+https://github.com/starkware-libs/cairo?rev=7675b74815370e6c16760e8b059ae5d773cade88#7675b74815370e6c16760e8b059ae5d773cade88"
+version = "2.12.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3427ab8aa5bfada173a4dd03a534a45125c422edf44852540a0c31e09c742040"
 dependencies = [
  "cairo-lang-diagnostics",
  "cairo-lang-filesystem",
@@ -1128,8 +1142,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-plugins"
-version = "2.11.4"
-source = "git+https://github.com/starkware-libs/cairo?rev=7675b74815370e6c16760e8b059ae5d773cade88#7675b74815370e6c16760e8b059ae5d773cade88"
+version = "2.12.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "144e0e018a38c4108e0de3903a53a4e2f68fa945e911eb7995313d70be0fbcf3"
 dependencies = [
  "cairo-lang-defs",
  "cairo-lang-diagnostics",
@@ -1152,8 +1167,9 @@ checksum = "123ac0ecadf31bacae77436d72b88fa9caef2b8e92c89ce63a125ae911a12fae"
 
 [[package]]
 name = "cairo-lang-proc-macros"
-version = "2.11.4"
-source = "git+https://github.com/starkware-libs/cairo?rev=7675b74815370e6c16760e8b059ae5d773cade88#7675b74815370e6c16760e8b059ae5d773cade88"
+version = "2.12.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55fe3d756af0af0b9f06b048c45424c96b5afa62745775d14a49afc7b68bf08c"
 dependencies = [
  "cairo-lang-debug",
  "quote",
@@ -1162,8 +1178,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-project"
-version = "2.11.4"
-source = "git+https://github.com/starkware-libs/cairo?rev=7675b74815370e6c16760e8b059ae5d773cade88#7675b74815370e6c16760e8b059ae5d773cade88"
+version = "2.12.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a9853500b9b360d75e7960c287bbf579c94f6e03f78386c7b070ff013c12d3a"
 dependencies = [
  "cairo-lang-filesystem",
  "cairo-lang-utils",
@@ -1183,7 +1200,8 @@ dependencies = [
 [[package]]
 name = "cairo-lang-quote"
 version = "0.1.0-rc.0"
-source = "git+https://github.com/software-mansion/scarb.git?rev=a7b5dce2aea8ee404c51057c0180de721950f961#a7b5dce2aea8ee404c51057c0180de721950f961"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb80b393966baed40a321ab417bd0284e56186295ca94f7891ce321c625374b3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1191,8 +1209,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-runnable-utils"
-version = "2.11.4"
-source = "git+https://github.com/starkware-libs/cairo?rev=7675b74815370e6c16760e8b059ae5d773cade88#7675b74815370e6c16760e8b059ae5d773cade88"
+version = "2.12.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42a3c90a650e10b0af6622f6d00975c4a5e5dfd38b4a447b46cf1c898de09027"
 dependencies = [
  "cairo-lang-casm",
  "cairo-lang-sierra",
@@ -1208,8 +1227,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-runner"
-version = "2.11.4"
-source = "git+https://github.com/starkware-libs/cairo?rev=7675b74815370e6c16760e8b059ae5d773cade88#7675b74815370e6c16760e8b059ae5d773cade88"
+version = "2.12.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bb4b16f13b05877d9a1c5fc10d4af41de686027ca8daf9c07d3dfe1d87db92c"
 dependencies = [
  "ark-ff 0.5.0",
  "ark-secp256k1",
@@ -1237,8 +1257,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-semantic"
-version = "2.11.4"
-source = "git+https://github.com/starkware-libs/cairo?rev=7675b74815370e6c16760e8b059ae5d773cade88#7675b74815370e6c16760e8b059ae5d773cade88"
+version = "2.12.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6feeb77b3c05e5f41565d3755f9cf8d2deb7eb0db29329853c490b00cff89d14"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -1263,8 +1284,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra"
-version = "2.11.4"
-source = "git+https://github.com/starkware-libs/cairo?rev=7675b74815370e6c16760e8b059ae5d773cade88#7675b74815370e6c16760e8b059ae5d773cade88"
+version = "2.12.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f00df67c28b100816925cf4e5907b56ce6253048dba0493f7b606a9aaa811308"
 dependencies = [
  "anyhow",
  "cairo-lang-utils",
@@ -1289,8 +1311,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-ap-change"
-version = "2.11.4"
-source = "git+https://github.com/starkware-libs/cairo?rev=7675b74815370e6c16760e8b059ae5d773cade88#7675b74815370e6c16760e8b059ae5d773cade88"
+version = "2.12.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050857a0cd7df91b5d0e0d65376a0bf5158b29bad19527819213e3b3a67f4a9a"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
@@ -1304,8 +1327,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-gas"
-version = "2.11.4"
-source = "git+https://github.com/starkware-libs/cairo?rev=7675b74815370e6c16760e8b059ae5d773cade88#7675b74815370e6c16760e8b059ae5d773cade88"
+version = "2.12.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efa10ef9ee6c9a33162afee265c52de53e621213023242c16472b41be45a864f"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
@@ -1319,8 +1343,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-generator"
-version = "2.11.4"
-source = "git+https://github.com/starkware-libs/cairo?rev=7675b74815370e6c16760e8b059ae5d773cade88#7675b74815370e6c16760e8b059ae5d773cade88"
+version = "2.12.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9a5e8a2e49cd457547b4aed422d161a44c1e4c4e1ce70b8263134f78728055"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -1342,8 +1367,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-to-casm"
-version = "2.11.4"
-source = "git+https://github.com/starkware-libs/cairo?rev=7675b74815370e6c16760e8b059ae5d773cade88#7675b74815370e6c16760e8b059ae5d773cade88"
+version = "2.12.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "235b1042c81eda7faf42437cdd8046d0de1d8fbb6f5782c7172b93b523a615a5"
 dependencies = [
  "assert_matches",
  "cairo-lang-casm",
@@ -1362,8 +1388,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-type-size"
-version = "2.11.4"
-source = "git+https://github.com/starkware-libs/cairo?rev=7675b74815370e6c16760e8b059ae5d773cade88#7675b74815370e6c16760e8b059ae5d773cade88"
+version = "2.12.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78780b5391b692deca8f77e923d400b2b14434c9a675cab9ad28254a80ad2c9c"
 dependencies = [
  "cairo-lang-sierra",
  "cairo-lang-utils",
@@ -1371,8 +1398,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-starknet"
-version = "2.11.4"
-source = "git+https://github.com/starkware-libs/cairo?rev=7675b74815370e6c16760e8b059ae5d773cade88#7675b74815370e6c16760e8b059ae5d773cade88"
+version = "2.12.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c296b97c64a6675ac9365d1392ee1340819e691b50de757ea30aade027e9c01b"
 dependencies = [
  "anyhow",
  "cairo-lang-compiler",
@@ -1402,8 +1430,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-starknet-classes"
-version = "2.11.4"
-source = "git+https://github.com/starkware-libs/cairo?rev=7675b74815370e6c16760e8b059ae5d773cade88#7675b74815370e6c16760e8b059ae5d773cade88"
+version = "2.12.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36ec797df357c1bca2cc8b1713a05b39874de3a78dcee92b3e4765df4a8f681d"
 dependencies = [
  "cairo-lang-casm",
  "cairo-lang-sierra",
@@ -1424,8 +1453,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-syntax"
-version = "2.11.4"
-source = "git+https://github.com/starkware-libs/cairo?rev=7675b74815370e6c16760e8b059ae5d773cade88#7675b74815370e6c16760e8b059ae5d773cade88"
+version = "2.12.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b594fb41e8a561295129ece62542c95174353fa45dde9efd33e9926986273bc8"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-filesystem",
@@ -1441,8 +1471,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-syntax-codegen"
-version = "2.11.4"
-source = "git+https://github.com/starkware-libs/cairo?rev=7675b74815370e6c16760e8b059ae5d773cade88#7675b74815370e6c16760e8b059ae5d773cade88"
+version = "2.12.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce4ed028479d262c53f4e97ba1670540923ff67d53d2a2899c750e65075b9b18"
 dependencies = [
  "genco",
  "xshell",
@@ -1450,8 +1481,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-test-plugin"
-version = "2.11.4"
-source = "git+https://github.com/starkware-libs/cairo?rev=7675b74815370e6c16760e8b059ae5d773cade88#7675b74815370e6c16760e8b059ae5d773cade88"
+version = "2.12.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3304de9ac3042fef66b32d770e031a32defaf54b08613c66e901afb66baeb471"
 dependencies = [
  "anyhow",
  "cairo-lang-compiler",
@@ -1477,8 +1509,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-test-runner"
-version = "2.11.4"
-source = "git+https://github.com/starkware-libs/cairo?rev=7675b74815370e6c16760e8b059ae5d773cade88#7675b74815370e6c16760e8b059ae5d773cade88"
+version = "2.12.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc0cb13caf1feb79c8fc6a1131b0c6d4eaeee82c4a9ec0d2c88f7f22bbd7a57"
 dependencies = [
  "anyhow",
  "cairo-lang-compiler",
@@ -1499,8 +1532,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-test-utils"
-version = "2.11.4"
-source = "git+https://github.com/starkware-libs/cairo?rev=7675b74815370e6c16760e8b059ae5d773cade88#7675b74815370e6c16760e8b059ae5d773cade88"
+version = "2.12.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada97e08fdd235e0b9f4ce3475973af4bebbdd9ed2abef156ce06d314c23e0b2"
 dependencies = [
  "cairo-lang-formatter",
  "cairo-lang-utils",
@@ -1511,8 +1545,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-utils"
-version = "2.11.4"
-source = "git+https://github.com/starkware-libs/cairo?rev=7675b74815370e6c16760e8b059ae5d773cade88#7675b74815370e6c16760e8b059ae5d773cade88"
+version = "2.12.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b283b37a6d92fbabfb880bbaea15a964c088bfd705c2f4f516b588e21682baf"
 dependencies = [
  "env_logger",
  "hashbrown 0.15.4",
@@ -1529,8 +1564,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-language-server"
-version = "2.11.4"
-source = "git+https://github.com/software-mansion/cairols?rev=7ecba29dd8a72690af0c5d2c533a48e291662f2c#7ecba29dd8a72690af0c5d2c533a48e291662f2c"
+version = "2.12.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b44022b49c5aadccf13e061fec74f9ae00a067d5c968c0fbd30be04ad7d7ea2b"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1543,7 +1579,7 @@ dependencies = [
  "cairo-lang-formatter",
  "cairo-lang-lowering",
  "cairo-lang-macro 0.1.1",
- "cairo-lang-macro 0.2.0-rc.0",
+ "cairo-lang-macro 0.2.0-rc.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cairo-lang-parser",
  "cairo-lang-project",
  "cairo-lang-semantic",
@@ -1567,7 +1603,7 @@ dependencies = [
  "memchr",
  "rust-analyzer-salsa",
  "scarb-metadata 1.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "scarb-proc-macro-server-types 0.3.0-rc.0",
+ "scarb-proc-macro-server-types 0.3.0-rc.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "scarb-stable-hash 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 1.0.26",
  "serde",
@@ -1583,8 +1619,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lint"
-version = "2.11.4"
-source = "git+https://github.com/software-mansion/cairo-lint?rev=3cb99ece36b89338a2efd300a88ac22ebdb5a70e#3cb99ece36b89338a2efd300a88ac22ebdb5a70e"
+version = "2.12.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4cd5a589e1d026718e9c164d61e631ad3f2425d6f200c36bfc824457a0dadf"
 dependencies = [
  "anyhow",
  "cairo-lang-compiler",
@@ -6431,7 +6468,7 @@ dependencies = [
 
 [[package]]
 name = "scarb"
-version = "2.11.4"
+version = "2.12.0-rc.2"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -6542,7 +6579,7 @@ dependencies = [
 
 [[package]]
 name = "scarb-build-metadata"
-version = "2.11.4"
+version = "2.12.0-rc.2"
 dependencies = [
  "cargo_metadata",
  "semver 1.0.26",
@@ -6550,7 +6587,7 @@ dependencies = [
 
 [[package]]
 name = "scarb-cairo-language-server"
-version = "2.11.4"
+version = "2.12.0-rc.2"
 dependencies = [
  "assert_fs",
  "cairo-language-server",
@@ -6562,7 +6599,7 @@ dependencies = [
 
 [[package]]
 name = "scarb-cairo-run"
-version = "2.11.4"
+version = "2.12.0-rc.2"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -6582,7 +6619,7 @@ dependencies = [
 
 [[package]]
 name = "scarb-cairo-test"
-version = "2.11.4"
+version = "2.12.0-rc.2"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -6603,7 +6640,7 @@ dependencies = [
 
 [[package]]
 name = "scarb-doc"
-version = "2.11.4"
+version = "2.12.0-rc.2"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -6637,7 +6674,7 @@ dependencies = [
 
 [[package]]
 name = "scarb-execute"
-version = "2.11.4"
+version = "2.12.0-rc.2"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -6668,7 +6705,7 @@ dependencies = [
 
 [[package]]
 name = "scarb-extensions-cli"
-version = "2.11.4"
+version = "2.12.0-rc.2"
 dependencies = [
  "anyhow",
  "cairo-lang-runner",
@@ -6685,7 +6722,7 @@ dependencies = [
 
 [[package]]
 name = "scarb-mdbook"
-version = "2.11.4"
+version = "2.12.0-rc.2"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -6727,17 +6764,6 @@ dependencies = [
 
 [[package]]
 name = "scarb-proc-macro-server-types"
-version = "0.3.0-rc.0"
-source = "git+https://github.com/software-mansion/scarb.git?rev=a7b5dce2aea8ee404c51057c0180de721950f961#a7b5dce2aea8ee404c51057c0180de721950f961"
-dependencies = [
- "cairo-lang-macro 0.1.1",
- "cairo-lang-macro 0.2.0-rc.0",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "scarb-proc-macro-server-types"
 version = "0.3.0-rc.1"
 dependencies = [
  "cairo-lang-macro 0.1.1",
@@ -6747,8 +6773,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "scarb-proc-macro-server-types"
+version = "0.3.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f15d86b4986eb201963894cfe9b90d436c3c942254ad6c32dd963500a69e424"
+dependencies = [
+ "cairo-lang-macro 0.1.1",
+ "cairo-lang-macro 0.2.0-rc.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scarb-prove"
-version = "2.11.4"
+version = "2.12.0-rc.2"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -6835,7 +6873,7 @@ dependencies = [
 
 [[package]]
 name = "scarb-verify"
-version = "2.11.4"
+version = "2.12.0-rc.2"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -7589,7 +7627,7 @@ dependencies = [
 [[package]]
 name = "stwo-cairo-adapter"
 version = "0.1.0"
-source = "git+https://github.com/starkware-libs/stwo-cairo?rev=08ddec7125cd77104b3e0e3a84298a9d988778dd#08ddec7125cd77104b3e0e3a84298a9d988778dd"
+source = "git+https://github.com/starkware-libs/stwo-cairo?rev=d869658ca0af584c1ae04706b22a8eeaf15713e2#d869658ca0af584c1ae04706b22a8eeaf15713e2"
 dependencies = [
  "bytemuck",
  "cairo-lang-casm",
@@ -7608,7 +7646,7 @@ dependencies = [
 [[package]]
 name = "stwo-cairo-common"
 version = "0.1.0"
-source = "git+https://github.com/starkware-libs/stwo-cairo?rev=08ddec7125cd77104b3e0e3a84298a9d988778dd#08ddec7125cd77104b3e0e3a84298a9d988778dd"
+source = "git+https://github.com/starkware-libs/stwo-cairo?rev=d869658ca0af584c1ae04706b22a8eeaf15713e2#d869658ca0af584c1ae04706b22a8eeaf15713e2"
 dependencies = [
  "bytemuck",
  "itertools 0.12.1",
@@ -7625,7 +7663,7 @@ dependencies = [
 [[package]]
 name = "stwo-cairo-serialize"
 version = "0.1.0"
-source = "git+https://github.com/starkware-libs/stwo-cairo?rev=08ddec7125cd77104b3e0e3a84298a9d988778dd#08ddec7125cd77104b3e0e3a84298a9d988778dd"
+source = "git+https://github.com/starkware-libs/stwo-cairo?rev=d869658ca0af584c1ae04706b22a8eeaf15713e2#d869658ca0af584c1ae04706b22a8eeaf15713e2"
 dependencies = [
  "starknet-ff",
  "stwo-cairo-serialize-derive",
@@ -7635,7 +7673,7 @@ dependencies = [
 [[package]]
 name = "stwo-cairo-serialize-derive"
 version = "0.1.0"
-source = "git+https://github.com/starkware-libs/stwo-cairo?rev=08ddec7125cd77104b3e0e3a84298a9d988778dd#08ddec7125cd77104b3e0e3a84298a9d988778dd"
+source = "git+https://github.com/starkware-libs/stwo-cairo?rev=d869658ca0af584c1ae04706b22a8eeaf15713e2#d869658ca0af584c1ae04706b22a8eeaf15713e2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7667,7 +7705,7 @@ dependencies = [
 [[package]]
 name = "stwo_cairo_prover"
 version = "0.1.0"
-source = "git+https://github.com/starkware-libs/stwo-cairo?rev=08ddec7125cd77104b3e0e3a84298a9d988778dd#08ddec7125cd77104b3e0e3a84298a9d988778dd"
+source = "git+https://github.com/starkware-libs/stwo-cairo?rev=d869658ca0af584c1ae04706b22a8eeaf15713e2#d869658ca0af584c1ae04706b22a8eeaf15713e2"
 dependencies = [
  "bytemuck",
  "cairo-lang-casm",
@@ -7696,7 +7734,7 @@ dependencies = [
 [[package]]
 name = "stwo_cairo_utils"
 version = "0.1.0"
-source = "git+https://github.com/starkware-libs/stwo-cairo?rev=08ddec7125cd77104b3e0e3a84298a9d988778dd#08ddec7125cd77104b3e0e3a84298a9d988778dd"
+source = "git+https://github.com/starkware-libs/stwo-cairo?rev=d869658ca0af584c1ae04706b22a8eeaf15713e2#d869658ca0af584c1ae04706b22a8eeaf15713e2"
 dependencies = [
  "cairo-vm 2.0.0-rc4",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -830,9 +830,9 @@ checksum = "a3c8f83209414aacf0eeae3cf730b18d6981697fba62f200fcfb92b9f082acba"
 
 [[package]]
 name = "cairo-lang-casm"
-version = "2.12.0-rc.2"
+version = "2.12.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35c44a18fe499fbb045bc29502b3ff84ef6d890d83557d83740439232ad44b09"
+checksum = "d388dbb1fe09ce9b83ea9eeb7fad3ae6f0ae552cde62abb4d4399ebbbd95d37d"
 dependencies = [
  "cairo-lang-utils",
  "indoc",
@@ -844,9 +844,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-compiler"
-version = "2.12.0-rc.2"
+version = "2.12.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82814326cca54aa03c91e678c5a1ce83bc5dcc23996db1830308201f42defe0"
+checksum = "8e204ca47eb458252983cbb1017773339f559aa1e9a549cc04786ec9268090d8"
 dependencies = [
  "anyhow",
  "cairo-lang-defs",
@@ -871,18 +871,18 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-debug"
-version = "2.12.0-rc.2"
+version = "2.12.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71733c729779572499866fccf3963766ff2cf58da8068cbdfc0d53f827be723e"
+checksum = "61f798383c2be75b89c001cadcc717d9386c4044ef9401b4a8d933c18e3f5bb8"
 dependencies = [
  "cairo-lang-utils",
 ]
 
 [[package]]
 name = "cairo-lang-defs"
-version = "2.12.0-rc.2"
+version = "2.12.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a6cd5d255033aab9a30a334a3fe916cc5a25599367fb49288e13b64936530c"
+checksum = "06d4219385dd46cc5c963fabf3f9bd83d0e6ac0757d10d0f4b6d044ac9dc1993"
 dependencies = [
  "bincode",
  "cairo-lang-debug",
@@ -901,9 +901,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-diagnostics"
-version = "2.12.0-rc.2"
+version = "2.12.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b46be05840c0485486b59820be4e5a83beb298ccf932089828dbdba0e181b32"
+checksum = "7d167999c849ae55d03b11a61c2d202415da14e510519fa9bdc4bfb5c0c2bdad"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-filesystem",
@@ -913,9 +913,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-doc"
-version = "2.12.0-rc.2"
+version = "2.12.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3230caea21e400a4808f3c5220a9f479295f834c049e9d503d58ceb79b50bb85"
+checksum = "aeb4783420f9afc6b50404466fdfe38fdbdad2195a2de20ad455c0ae2f7956e0"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -934,9 +934,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-eq-solver"
-version = "2.12.0-rc.2"
+version = "2.12.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b14100faad5935802a61fc26b1c237a56d5fb941971f09d13e52655d96f1249e"
+checksum = "ba1d215fabebd67be90e207a969a8dea7ea36b55363874c9c2f437288c058215"
 dependencies = [
  "cairo-lang-utils",
  "good_lp",
@@ -944,9 +944,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-executable"
-version = "2.12.0-rc.2"
+version = "2.12.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78dbd102f2e88c3aacb24fafeff0cb8a5b7444f9440a380b2a40ee30be4370bc"
+checksum = "579697020d8b97c71f126e48daa569a36f90e200398271e29ee1e6874b73fdc1"
 dependencies = [
  "anyhow",
  "cairo-lang-casm",
@@ -970,9 +970,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-filesystem"
-version = "2.12.0-rc.2"
+version = "2.12.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75df3751324f1a3a9fd00bf37911223cff002aa9d0262b874d5e9469c9d56cfc"
+checksum = "fb3acd07dad161fbee0e99fa9bcded0e794ec6661424814eb2a63b2c03182605"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-utils",
@@ -986,9 +986,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-formatter"
-version = "2.12.0-rc.2"
+version = "2.12.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8b073fc5f09c4550a2d82426d56bf5f4d4682505bdf95d1c41569f6c1b50399"
+checksum = "bac9d87fd457040825a6241186e97ab38385dbee0172d31c0b39ae80c7c7ddfb"
 dependencies = [
  "anyhow",
  "cairo-lang-diagnostics",
@@ -1005,9 +1005,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-lowering"
-version = "2.12.0-rc.2"
+version = "2.12.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9215db6f94eeed6869bff84afb5c1d07c07817b064db8e6f16e67776b9671dc5"
+checksum = "bdf439339014468da405dbd8c9a4fe812862c98b5ed8107ab0712105b1b4899b"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -1121,9 +1121,9 @@ checksum = "8c19c6d899e411d6ec7fcd576d2e6dfb2d5faf0414bf9bdb70e0e71887c85a0e"
 
 [[package]]
 name = "cairo-lang-parser"
-version = "2.12.0-rc.2"
+version = "2.12.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3427ab8aa5bfada173a4dd03a534a45125c422edf44852540a0c31e09c742040"
+checksum = "5b4938a93f9c142e7effb2b33c8debf3bb4b29594ac06b7617f1acab7af0fc05"
 dependencies = [
  "cairo-lang-diagnostics",
  "cairo-lang-filesystem",
@@ -1142,9 +1142,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-plugins"
-version = "2.12.0-rc.2"
+version = "2.12.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144e0e018a38c4108e0de3903a53a4e2f68fa945e911eb7995313d70be0fbcf3"
+checksum = "f81e60980013accaae46bb35baa1c28b5d9b4b4a4e256ecd4acc808f60eda969"
 dependencies = [
  "cairo-lang-defs",
  "cairo-lang-diagnostics",
@@ -1167,9 +1167,9 @@ checksum = "123ac0ecadf31bacae77436d72b88fa9caef2b8e92c89ce63a125ae911a12fae"
 
 [[package]]
 name = "cairo-lang-proc-macros"
-version = "2.12.0-rc.2"
+version = "2.12.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55fe3d756af0af0b9f06b048c45424c96b5afa62745775d14a49afc7b68bf08c"
+checksum = "23e52123946067e9c6274824cea9e6d17b81faa4c4dc691dc7c239b2e0a810d1"
 dependencies = [
  "cairo-lang-debug",
  "quote",
@@ -1178,9 +1178,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-project"
-version = "2.12.0-rc.2"
+version = "2.12.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9853500b9b360d75e7960c287bbf579c94f6e03f78386c7b070ff013c12d3a"
+checksum = "41b6b52966eeac7e962f88bc245c6feb39bb81dbf4eff1f3c9a4ae42caab972d"
 dependencies = [
  "cairo-lang-filesystem",
  "cairo-lang-utils",
@@ -1209,9 +1209,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-runnable-utils"
-version = "2.12.0-rc.2"
+version = "2.12.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a3c90a650e10b0af6622f6d00975c4a5e5dfd38b4a447b46cf1c898de09027"
+checksum = "7559c70c26789e75d08fe57f15944683cb46ae76d57074cce81598fd3c4a9051"
 dependencies = [
  "cairo-lang-casm",
  "cairo-lang-sierra",
@@ -1227,9 +1227,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-runner"
-version = "2.12.0-rc.2"
+version = "2.12.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bb4b16f13b05877d9a1c5fc10d4af41de686027ca8daf9c07d3dfe1d87db92c"
+checksum = "caa4d820d863dafd540e3403c44ae0a69ca483dfde4ef80497dfeae79ef30a7d"
 dependencies = [
  "ark-ff 0.5.0",
  "ark-secp256k1",
@@ -1257,9 +1257,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-semantic"
-version = "2.12.0-rc.2"
+version = "2.12.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6feeb77b3c05e5f41565d3755f9cf8d2deb7eb0db29329853c490b00cff89d14"
+checksum = "3c04bb1d9a95a4276bcc4120e5065751a78618d86e99a3db5e816e7a24f72e0c"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -1284,9 +1284,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra"
-version = "2.12.0-rc.2"
+version = "2.12.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00df67c28b100816925cf4e5907b56ce6253048dba0493f7b606a9aaa811308"
+checksum = "9a94c82067094c4ef96657d9246637bb6f3948e1a6e7cb6f8b3df6225919b6b1"
 dependencies = [
  "anyhow",
  "cairo-lang-utils",
@@ -1311,9 +1311,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-ap-change"
-version = "2.12.0-rc.2"
+version = "2.12.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "050857a0cd7df91b5d0e0d65376a0bf5158b29bad19527819213e3b3a67f4a9a"
+checksum = "3427caf2876ca0e2f6a54a495bcfe703bb15f620f22dca2ea642acc60c0d59bd"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
@@ -1327,9 +1327,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-gas"
-version = "2.12.0-rc.2"
+version = "2.12.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efa10ef9ee6c9a33162afee265c52de53e621213023242c16472b41be45a864f"
+checksum = "850325f788437f771ad771dc1c22fd0b2a0d8eb7066da3b79f70360d7fc445db"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
@@ -1343,9 +1343,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-generator"
-version = "2.12.0-rc.2"
+version = "2.12.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9a5e8a2e49cd457547b4aed422d161a44c1e4c4e1ce70b8263134f78728055"
+checksum = "a2c92fd570281c1f40e724406e0fb770184856b7b1ab174e40bcb41df1802aed"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -1367,9 +1367,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-to-casm"
-version = "2.12.0-rc.2"
+version = "2.12.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235b1042c81eda7faf42437cdd8046d0de1d8fbb6f5782c7172b93b523a615a5"
+checksum = "c588c548dcbe1b0cdd211e9f9eabe68860824272fb18fca82389c2e6719032b3"
 dependencies = [
  "assert_matches",
  "cairo-lang-casm",
@@ -1388,9 +1388,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-type-size"
-version = "2.12.0-rc.2"
+version = "2.12.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78780b5391b692deca8f77e923d400b2b14434c9a675cab9ad28254a80ad2c9c"
+checksum = "a63037802d5b6b9fb93588cf492bd823e2ef17a45f70b9500b26646b4f853747"
 dependencies = [
  "cairo-lang-sierra",
  "cairo-lang-utils",
@@ -1398,9 +1398,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-starknet"
-version = "2.12.0-rc.2"
+version = "2.12.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c296b97c64a6675ac9365d1392ee1340819e691b50de757ea30aade027e9c01b"
+checksum = "c94bb47069a05677d2c8d39f76d0a6eae204b72599c2ae5eee085caebbb7d465"
 dependencies = [
  "anyhow",
  "cairo-lang-compiler",
@@ -1430,9 +1430,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-starknet-classes"
-version = "2.12.0-rc.2"
+version = "2.12.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36ec797df357c1bca2cc8b1713a05b39874de3a78dcee92b3e4765df4a8f681d"
+checksum = "d5f430aa075b439967e9dd843a069d84c2489c86caf3073892abeb2061925b3a"
 dependencies = [
  "cairo-lang-casm",
  "cairo-lang-sierra",
@@ -1453,9 +1453,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-syntax"
-version = "2.12.0-rc.2"
+version = "2.12.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b594fb41e8a561295129ece62542c95174353fa45dde9efd33e9926986273bc8"
+checksum = "606c96331e4fa0890bcff51c32629d47f665cf5554ed42885e017d8f537ec7a9"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-filesystem",
@@ -1471,9 +1471,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-syntax-codegen"
-version = "2.12.0-rc.2"
+version = "2.12.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce4ed028479d262c53f4e97ba1670540923ff67d53d2a2899c750e65075b9b18"
+checksum = "0c2a2c12cb98f77b76a91b4bee1b7723b6afd840615480cc325b628001dbb56b"
 dependencies = [
  "genco",
  "xshell",
@@ -1481,9 +1481,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-test-plugin"
-version = "2.12.0-rc.2"
+version = "2.12.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3304de9ac3042fef66b32d770e031a32defaf54b08613c66e901afb66baeb471"
+checksum = "18a6c85838e820153d47ca74549809a146b905b503eaf966397064dac2c14c0c"
 dependencies = [
  "anyhow",
  "cairo-lang-compiler",
@@ -1509,9 +1509,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-test-runner"
-version = "2.12.0-rc.2"
+version = "2.12.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc0cb13caf1feb79c8fc6a1131b0c6d4eaeee82c4a9ec0d2c88f7f22bbd7a57"
+checksum = "bd2302e164b97d0055790e393459aeafe0ca8d9a8ea159f412bd6ab0bb633810"
 dependencies = [
  "anyhow",
  "cairo-lang-compiler",
@@ -1532,9 +1532,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-test-utils"
-version = "2.12.0-rc.2"
+version = "2.12.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ada97e08fdd235e0b9f4ce3475973af4bebbdd9ed2abef156ce06d314c23e0b2"
+checksum = "27ad396f867473edb772f0801a2400478f861e43e0ae43e78dd60bf93f4b8b2c"
 dependencies = [
  "cairo-lang-formatter",
  "cairo-lang-utils",
@@ -1545,9 +1545,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-utils"
-version = "2.12.0-rc.2"
+version = "2.12.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b283b37a6d92fbabfb880bbaea15a964c088bfd705c2f4f516b588e21682baf"
+checksum = "23d3e265bff4a05f3473d06ffd05ba207c630fac4913feefbe9563dc9736726c"
 dependencies = [
  "env_logger",
  "hashbrown 0.15.4",
@@ -1602,7 +1602,7 @@ dependencies = [
  "lsp-types",
  "memchr",
  "rust-analyzer-salsa",
- "scarb-metadata 1.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scarb-metadata 1.15.0",
  "scarb-proc-macro-server-types 0.3.0-rc.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "scarb-stable-hash 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 1.0.26",
@@ -1641,7 +1641,7 @@ dependencies = [
  "lsp-types",
  "num-bigint",
  "rust-analyzer-salsa",
- "scarb-metadata 1.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scarb-metadata 1.15.0",
  "tempfile",
  "tracing",
  "which 7.0.3",
@@ -6536,7 +6536,7 @@ dependencies = [
  "reqwest",
  "scarb-build-metadata",
  "scarb-extensions-cli",
- "scarb-metadata 1.15.0",
+ "scarb-metadata 1.15.1",
  "scarb-proc-macro-server-types 0.3.0-rc.1",
  "scarb-stable-hash 1.0.0",
  "scarb-test-support",
@@ -6609,7 +6609,7 @@ dependencies = [
  "clap",
  "indoc",
  "scarb-extensions-cli",
- "scarb-metadata 1.15.0",
+ "scarb-metadata 1.15.1",
  "scarb-test-support",
  "scarb-ui",
  "serde",
@@ -6630,7 +6630,7 @@ dependencies = [
  "clap",
  "indoc",
  "scarb-extensions-cli",
- "scarb-metadata 1.15.0",
+ "scarb-metadata 1.15.1",
  "scarb-test-support",
  "scarb-ui",
  "serde_json",
@@ -6662,7 +6662,7 @@ dependencies = [
  "itertools 0.14.0",
  "rust-analyzer-salsa",
  "scarb-extensions-cli",
- "scarb-metadata 1.15.0",
+ "scarb-metadata 1.15.1",
  "scarb-test-support",
  "scarb-ui",
  "serde",
@@ -6691,7 +6691,7 @@ dependencies = [
  "indoc",
  "predicates",
  "scarb-extensions-cli",
- "scarb-metadata 1.15.0",
+ "scarb-metadata 1.15.1",
  "scarb-test-support",
  "scarb-ui",
  "serde",
@@ -6737,6 +6737,19 @@ dependencies = [
 [[package]]
 name = "scarb-metadata"
 version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c9a74ee34fdb42e20bf992f211a502d07e8b3a3abf6b1d33ccf94e5f1038314"
+dependencies = [
+ "camino",
+ "semver 1.0.26",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "scarb-metadata"
+version = "1.15.1"
 dependencies = [
  "assert_fs",
  "cairo-lang-filesystem",
@@ -6746,19 +6759,6 @@ dependencies = [
  "serde",
  "serde_json",
  "snapbox",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "scarb-metadata"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c9a74ee34fdb42e20bf992f211a502d07e8b3a3abf6b1d33ccf94e5f1038314"
-dependencies = [
- "camino",
- "semver 1.0.26",
- "serde",
- "serde_json",
  "thiserror 2.0.12",
 ]
 
@@ -6796,7 +6796,7 @@ dependencies = [
  "indoc",
  "predicates",
  "scarb-extensions-cli",
- "scarb-metadata 1.15.0",
+ "scarb-metadata 1.15.1",
  "scarb-test-support",
  "scarb-ui",
  "serde_json",
@@ -6864,7 +6864,7 @@ dependencies = [
  "clap",
  "console",
  "indicatif",
- "scarb-metadata 1.15.0",
+ "scarb-metadata 1.15.1",
  "serde",
  "serde_json",
  "test-case",
@@ -6881,7 +6881,7 @@ dependencies = [
  "clap",
  "indoc",
  "scarb-extensions-cli",
- "scarb-metadata 1.15.0",
+ "scarb-metadata 1.15.1",
  "scarb-test-support",
  "scarb-ui",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1564,9 +1564,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-language-server"
-version = "2.12.0-rc.2"
+version = "2.12.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b44022b49c5aadccf13e061fec74f9ae00a067d5c968c0fbd30be04ad7d7ea2b"
+checksum = "a665461794d350e5e55f7176c0626b2310160924e1f4d611610ccd49f8c7f05e"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1619,9 +1619,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lint"
-version = "2.12.0-rc.2"
+version = "2.12.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4cd5a589e1d026718e9c164d61e631ad3f2425d6f200c36bfc824457a0dadf"
+checksum = "22f115826d493f16d13a5f5bd9899277e85855603cc493ba53c7f268eb379707"
 dependencies = [
  "anyhow",
  "cairo-lang-compiler",
@@ -1879,7 +1879,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4692,7 +4692,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -6468,7 +6468,7 @@ dependencies = [
 
 [[package]]
 name = "scarb"
-version = "2.12.0-rc.2"
+version = "2.12.0-rc.3"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -6579,7 +6579,7 @@ dependencies = [
 
 [[package]]
 name = "scarb-build-metadata"
-version = "2.12.0-rc.2"
+version = "2.12.0-rc.3"
 dependencies = [
  "cargo_metadata",
  "semver 1.0.26",
@@ -6587,7 +6587,7 @@ dependencies = [
 
 [[package]]
 name = "scarb-cairo-language-server"
-version = "2.12.0-rc.2"
+version = "2.12.0-rc.3"
 dependencies = [
  "assert_fs",
  "cairo-language-server",
@@ -6599,7 +6599,7 @@ dependencies = [
 
 [[package]]
 name = "scarb-cairo-run"
-version = "2.12.0-rc.2"
+version = "2.12.0-rc.3"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -6619,7 +6619,7 @@ dependencies = [
 
 [[package]]
 name = "scarb-cairo-test"
-version = "2.12.0-rc.2"
+version = "2.12.0-rc.3"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -6640,7 +6640,7 @@ dependencies = [
 
 [[package]]
 name = "scarb-doc"
-version = "2.12.0-rc.2"
+version = "2.12.0-rc.3"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -6674,7 +6674,7 @@ dependencies = [
 
 [[package]]
 name = "scarb-execute"
-version = "2.12.0-rc.2"
+version = "2.12.0-rc.3"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -6705,7 +6705,7 @@ dependencies = [
 
 [[package]]
 name = "scarb-extensions-cli"
-version = "2.12.0-rc.2"
+version = "2.12.0-rc.3"
 dependencies = [
  "anyhow",
  "cairo-lang-runner",
@@ -6722,7 +6722,7 @@ dependencies = [
 
 [[package]]
 name = "scarb-mdbook"
-version = "2.12.0-rc.2"
+version = "2.12.0-rc.3"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -6786,7 +6786,7 @@ dependencies = [
 
 [[package]]
 name = "scarb-prove"
-version = "2.12.0-rc.2"
+version = "2.12.0-rc.3"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -6873,7 +6873,7 @@ dependencies = [
 
 [[package]]
 name = "scarb-verify"
-version = "2.12.0-rc.2"
+version = "2.12.0-rc.3"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -7627,7 +7627,7 @@ dependencies = [
 [[package]]
 name = "stwo-cairo-adapter"
 version = "0.1.0"
-source = "git+https://github.com/starkware-libs/stwo-cairo?rev=d869658ca0af584c1ae04706b22a8eeaf15713e2#d869658ca0af584c1ae04706b22a8eeaf15713e2"
+source = "git+https://github.com/starkware-libs/stwo-cairo?rev=714b6b43f94c3d0d6d7ce1601a1606988c4d67ed#714b6b43f94c3d0d6d7ce1601a1606988c4d67ed"
 dependencies = [
  "bytemuck",
  "cairo-lang-casm",
@@ -7646,7 +7646,7 @@ dependencies = [
 [[package]]
 name = "stwo-cairo-common"
 version = "0.1.0"
-source = "git+https://github.com/starkware-libs/stwo-cairo?rev=d869658ca0af584c1ae04706b22a8eeaf15713e2#d869658ca0af584c1ae04706b22a8eeaf15713e2"
+source = "git+https://github.com/starkware-libs/stwo-cairo?rev=714b6b43f94c3d0d6d7ce1601a1606988c4d67ed#714b6b43f94c3d0d6d7ce1601a1606988c4d67ed"
 dependencies = [
  "bytemuck",
  "itertools 0.12.1",
@@ -7663,7 +7663,7 @@ dependencies = [
 [[package]]
 name = "stwo-cairo-serialize"
 version = "0.1.0"
-source = "git+https://github.com/starkware-libs/stwo-cairo?rev=d869658ca0af584c1ae04706b22a8eeaf15713e2#d869658ca0af584c1ae04706b22a8eeaf15713e2"
+source = "git+https://github.com/starkware-libs/stwo-cairo?rev=714b6b43f94c3d0d6d7ce1601a1606988c4d67ed#714b6b43f94c3d0d6d7ce1601a1606988c4d67ed"
 dependencies = [
  "starknet-ff",
  "stwo-cairo-serialize-derive",
@@ -7673,7 +7673,7 @@ dependencies = [
 [[package]]
 name = "stwo-cairo-serialize-derive"
 version = "0.1.0"
-source = "git+https://github.com/starkware-libs/stwo-cairo?rev=d869658ca0af584c1ae04706b22a8eeaf15713e2#d869658ca0af584c1ae04706b22a8eeaf15713e2"
+source = "git+https://github.com/starkware-libs/stwo-cairo?rev=714b6b43f94c3d0d6d7ce1601a1606988c4d67ed#714b6b43f94c3d0d6d7ce1601a1606988c4d67ed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7705,7 +7705,7 @@ dependencies = [
 [[package]]
 name = "stwo_cairo_prover"
 version = "0.1.0"
-source = "git+https://github.com/starkware-libs/stwo-cairo?rev=d869658ca0af584c1ae04706b22a8eeaf15713e2#d869658ca0af584c1ae04706b22a8eeaf15713e2"
+source = "git+https://github.com/starkware-libs/stwo-cairo?rev=714b6b43f94c3d0d6d7ce1601a1606988c4d67ed#714b6b43f94c3d0d6d7ce1601a1606988c4d67ed"
 dependencies = [
  "bytemuck",
  "cairo-lang-casm",
@@ -7734,7 +7734,7 @@ dependencies = [
 [[package]]
 name = "stwo_cairo_utils"
 version = "0.1.0"
-source = "git+https://github.com/starkware-libs/stwo-cairo?rev=d869658ca0af584c1ae04706b22a8eeaf15713e2#d869658ca0af584c1ae04706b22a8eeaf15713e2"
+source = "git+https://github.com/starkware-libs/stwo-cairo?rev=714b6b43f94c3d0d6d7ce1601a1606988c4d67ed#714b6b43f94c3d0d6d7ce1601a1606988c4d67ed"
 dependencies = [
  "cairo-vm 2.0.0-rc4",
  "clap",
@@ -8918,7 +8918,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1879,7 +1879,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2184,9 +2184,9 @@ dependencies = [
 
 [[package]]
 name = "deno_path_util"
-version = "0.4.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "516f813389095889776b81cc9108ff6f336fd9409b4b12fc0138aea23d2708e1"
+checksum = "995a5563d815755b07c0f4b7a25a99cd3ef1c2f261ed7d1e9a53eae050a3f77e"
 dependencies = [
  "deno_error",
  "percent-encoding",
@@ -2197,9 +2197,9 @@ dependencies = [
 
 [[package]]
 name = "deno_task_shell"
-version = "0.25.2"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32286533eb9abd6aaf517af62aea766c07aab8e4955450d11bced0a6f395869"
+checksum = "0f21502a83ad5d8fc650ec6a06d6a811c8514a3f23ed718fe6457c43e87df8e5"
 dependencies = [
  "anyhow",
  "deno_path_util",
@@ -4692,7 +4692,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.2",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -8918,7 +8918,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ members = [
 "resolver" = "2"
 
 [workspace.package]
-version = "2.11.4"
+version = "2.12.0-rc.2"
 edition = "2024"
 
 authors = ["Software Mansion <contact@swmansion.com>"]
@@ -44,31 +44,31 @@ async-trait = "0.1"
 axum = { version = "0.6", features = ["http2"] }
 bincode = "2.0.1"
 bumpalo = "=3.17.0"
-cairo-lang-casm = "*"
-cairo-lang-compiler = "*"
-cairo-lang-defs = "*"
-cairo-lang-diagnostics = "*"
-cairo-lang-doc = "*"
-cairo-lang-executable = "*"
-cairo-lang-filesystem = "*"
-cairo-lang-formatter = "*"
-cairo-lang-lowering = "*"
+cairo-lang-casm = "2.12.0-rc.2"
+cairo-lang-compiler = "2.12.0-rc.2"
+cairo-lang-defs = "2.12.0-rc.2"
+cairo-lang-diagnostics = "2.12.0-rc.2"
+cairo-lang-doc = "2.12.0-rc.2"
+cairo-lang-executable = "2.12.0-rc.2"
+cairo-lang-filesystem = "2.12.0-rc.2"
+cairo-lang-formatter = "2.12.0-rc.2"
+cairo-lang-lowering = "2.12.0-rc.2"
 cairo-lang-macro-v1 = { version = "0.1", package = "cairo-lang-macro", features = ["serde"] }
-cairo-lang-parser = "*"
+cairo-lang-parser = "2.12.0-rc.2"
 cairo-lang-primitive-token = "1"
-cairo-lang-runner = "*"
-cairo-lang-semantic = "*"
-cairo-lang-sierra = "*"
-cairo-lang-sierra-generator = "*"
-cairo-lang-sierra-to-casm = "*"
-cairo-lang-starknet = "*"
-cairo-lang-starknet-classes = "*"
-cairo-lang-syntax = "*"
-cairo-lang-test-plugin = "*"
-cairo-lang-test-runner = "*"
-cairo-lang-utils = { version = "*", features = ["env_logger"] }
-cairo-language-server = "*"
-cairo-lint = "*"
+cairo-lang-runner = "2.12.0-rc.2"
+cairo-lang-semantic = "2.12.0-rc.2"
+cairo-lang-sierra = "2.12.0-rc.2"
+cairo-lang-sierra-generator = "2.12.0-rc.2"
+cairo-lang-sierra-to-casm = "2.12.0-rc.2"
+cairo-lang-starknet = "2.12.0-rc.2"
+cairo-lang-starknet-classes = "2.12.0-rc.2"
+cairo-lang-syntax = "2.12.0-rc.2"
+cairo-lang-test-plugin = "2.12.0-rc.2"
+cairo-lang-test-runner = "2.12.0-rc.2"
+cairo-lang-utils = { version = "2.12.0-rc.2", features = ["env_logger"] }
+cairo-language-server = "2.12.0-rc.2"
+cairo-lint = "2.12.0-rc.2"
 cairo-vm = "2.2.0"
 camino = { version = "1", features = ["serde1"] }
 cargo_metadata = ">=0.18"
@@ -132,8 +132,8 @@ smol_str = { version = "0.3", features = ["serde"] }
 snapbox = { version = "0.4", features = ["cmd", "path"] }
 starknet-core = "0.14.0"
 starknet-types-core = "0.1"
-stwo-cairo-adapter = { version = "*", features = ["std"] }
-stwo_cairo_prover = "*"
+stwo-cairo-adapter = { git = "https://github.com/starkware-libs/stwo-cairo", rev = "d869658ca0af584c1ae04706b22a8eeaf15713e2", features = ["std"] }
+stwo_cairo_prover = { git = "https://github.com/starkware-libs/stwo-cairo", rev = "d869658ca0af584c1ae04706b22a8eeaf15713e2" }
 syn = "2"
 tar = "0.4"
 target-triple = "0.1"
@@ -161,44 +161,6 @@ xshell = "0.2"
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
 zip = { version = "0.6", default-features = false, features = ["deflate"] }
 zstd = "0.13"
-
-[patch.crates-io]
-cairo-lang-casm = { git = "https://github.com/starkware-libs/cairo", rev = "7675b74815370e6c16760e8b059ae5d773cade88" }
-cairo-lang-compiler = { git = "https://github.com/starkware-libs/cairo", rev = "7675b74815370e6c16760e8b059ae5d773cade88" }
-cairo-lang-debug = { git = "https://github.com/starkware-libs/cairo", rev = "7675b74815370e6c16760e8b059ae5d773cade88" }
-cairo-lang-defs = { git = "https://github.com/starkware-libs/cairo", rev = "7675b74815370e6c16760e8b059ae5d773cade88" }
-cairo-lang-diagnostics = { git = "https://github.com/starkware-libs/cairo", rev = "7675b74815370e6c16760e8b059ae5d773cade88" }
-cairo-lang-doc = { git = "https://github.com/starkware-libs/cairo", rev = "7675b74815370e6c16760e8b059ae5d773cade88" }
-cairo-lang-eq-solver = { git = "https://github.com/starkware-libs/cairo", rev = "7675b74815370e6c16760e8b059ae5d773cade88" }
-cairo-lang-executable = { git = "https://github.com/starkware-libs/cairo", rev = "7675b74815370e6c16760e8b059ae5d773cade88" }
-cairo-lang-filesystem = { git = "https://github.com/starkware-libs/cairo", rev = "7675b74815370e6c16760e8b059ae5d773cade88" }
-cairo-lang-formatter = { git = "https://github.com/starkware-libs/cairo", rev = "7675b74815370e6c16760e8b059ae5d773cade88" }
-cairo-lang-lowering = { git = "https://github.com/starkware-libs/cairo", rev = "7675b74815370e6c16760e8b059ae5d773cade88" }
-cairo-lang-parser = { git = "https://github.com/starkware-libs/cairo", rev = "7675b74815370e6c16760e8b059ae5d773cade88" }
-cairo-lang-plugins = { git = "https://github.com/starkware-libs/cairo", rev = "7675b74815370e6c16760e8b059ae5d773cade88" }
-cairo-lang-proc-macros = { git = "https://github.com/starkware-libs/cairo", rev = "7675b74815370e6c16760e8b059ae5d773cade88" }
-cairo-lang-project = { git = "https://github.com/starkware-libs/cairo", rev = "7675b74815370e6c16760e8b059ae5d773cade88" }
-cairo-lang-runnable-utils = { git = "https://github.com/starkware-libs/cairo", rev = "7675b74815370e6c16760e8b059ae5d773cade88" }
-cairo-lang-runner = { git = "https://github.com/starkware-libs/cairo", rev = "7675b74815370e6c16760e8b059ae5d773cade88" }
-cairo-lang-semantic = { git = "https://github.com/starkware-libs/cairo", rev = "7675b74815370e6c16760e8b059ae5d773cade88" }
-cairo-lang-sierra = { git = "https://github.com/starkware-libs/cairo", rev = "7675b74815370e6c16760e8b059ae5d773cade88" }
-cairo-lang-sierra-ap-change = { git = "https://github.com/starkware-libs/cairo", rev = "7675b74815370e6c16760e8b059ae5d773cade88" }
-cairo-lang-sierra-gas = { git = "https://github.com/starkware-libs/cairo", rev = "7675b74815370e6c16760e8b059ae5d773cade88" }
-cairo-lang-sierra-generator = { git = "https://github.com/starkware-libs/cairo", rev = "7675b74815370e6c16760e8b059ae5d773cade88" }
-cairo-lang-sierra-to-casm = { git = "https://github.com/starkware-libs/cairo", rev = "7675b74815370e6c16760e8b059ae5d773cade88" }
-cairo-lang-sierra-type-size = { git = "https://github.com/starkware-libs/cairo", rev = "7675b74815370e6c16760e8b059ae5d773cade88" }
-cairo-lang-starknet = { git = "https://github.com/starkware-libs/cairo", rev = "7675b74815370e6c16760e8b059ae5d773cade88" }
-cairo-lang-starknet-classes = { git = "https://github.com/starkware-libs/cairo", rev = "7675b74815370e6c16760e8b059ae5d773cade88" }
-cairo-lang-syntax = { git = "https://github.com/starkware-libs/cairo", rev = "7675b74815370e6c16760e8b059ae5d773cade88" }
-cairo-lang-syntax-codegen = { git = "https://github.com/starkware-libs/cairo", rev = "7675b74815370e6c16760e8b059ae5d773cade88" }
-cairo-lang-test-plugin = { git = "https://github.com/starkware-libs/cairo", rev = "7675b74815370e6c16760e8b059ae5d773cade88" }
-cairo-lang-test-runner = { git = "https://github.com/starkware-libs/cairo", rev = "7675b74815370e6c16760e8b059ae5d773cade88" }
-cairo-lang-test-utils = { git = "https://github.com/starkware-libs/cairo", rev = "7675b74815370e6c16760e8b059ae5d773cade88" }
-cairo-lang-utils = { git = "https://github.com/starkware-libs/cairo", rev = "7675b74815370e6c16760e8b059ae5d773cade88" }
-cairo-language-server = { git = "https://github.com/software-mansion/cairols", rev = "7ecba29dd8a72690af0c5d2c533a48e291662f2c" }
-cairo-lint = { git = "https://github.com/software-mansion/cairo-lint", rev = "3cb99ece36b89338a2efd300a88ac22ebdb5a70e" }
-stwo-cairo-adapter = { git = "https://github.com/starkware-libs/stwo-cairo", rev = "08ddec7125cd77104b3e0e3a84298a9d988778dd" }
-stwo_cairo_prover = { git = "https://github.com/starkware-libs/stwo-cairo", rev = "08ddec7125cd77104b3e0e3a84298a9d988778dd" }
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ members = [
 "resolver" = "2"
 
 [workspace.package]
-version = "2.12.0-rc.2"
+version = "2.12.0-rc.3"
 edition = "2024"
 
 authors = ["Software Mansion <contact@swmansion.com>"]
@@ -44,31 +44,31 @@ async-trait = "0.1"
 axum = { version = "0.6", features = ["http2"] }
 bincode = "2.0.1"
 bumpalo = "=3.17.0"
-cairo-lang-casm = "2.12.0-rc.2"
-cairo-lang-compiler = "2.12.0-rc.2"
-cairo-lang-defs = "2.12.0-rc.2"
-cairo-lang-diagnostics = "2.12.0-rc.2"
-cairo-lang-doc = "2.12.0-rc.2"
-cairo-lang-executable = "2.12.0-rc.2"
-cairo-lang-filesystem = "2.12.0-rc.2"
-cairo-lang-formatter = "2.12.0-rc.2"
-cairo-lang-lowering = "2.12.0-rc.2"
+cairo-lang-casm = "2.12.0-rc.3"
+cairo-lang-compiler = "2.12.0-rc.3"
+cairo-lang-defs = "2.12.0-rc.3"
+cairo-lang-diagnostics = "2.12.0-rc.3"
+cairo-lang-doc = "2.12.0-rc.3"
+cairo-lang-executable = "2.12.0-rc.3"
+cairo-lang-filesystem = "2.12.0-rc.3"
+cairo-lang-formatter = "2.12.0-rc.3"
+cairo-lang-lowering = "2.12.0-rc.3"
 cairo-lang-macro-v1 = { version = "0.1", package = "cairo-lang-macro", features = ["serde"] }
-cairo-lang-parser = "2.12.0-rc.2"
+cairo-lang-parser = "2.12.0-rc.3"
 cairo-lang-primitive-token = "1"
-cairo-lang-runner = "2.12.0-rc.2"
-cairo-lang-semantic = "2.12.0-rc.2"
-cairo-lang-sierra = "2.12.0-rc.2"
-cairo-lang-sierra-generator = "2.12.0-rc.2"
-cairo-lang-sierra-to-casm = "2.12.0-rc.2"
-cairo-lang-starknet = "2.12.0-rc.2"
-cairo-lang-starknet-classes = "2.12.0-rc.2"
-cairo-lang-syntax = "2.12.0-rc.2"
-cairo-lang-test-plugin = "2.12.0-rc.2"
-cairo-lang-test-runner = "2.12.0-rc.2"
-cairo-lang-utils = { version = "2.12.0-rc.2", features = ["env_logger"] }
-cairo-language-server = "2.12.0-rc.2"
-cairo-lint = "2.12.0-rc.2"
+cairo-lang-runner = "2.12.0-rc.3"
+cairo-lang-semantic = "2.12.0-rc.3"
+cairo-lang-sierra = "2.12.0-rc.3"
+cairo-lang-sierra-generator = "2.12.0-rc.3"
+cairo-lang-sierra-to-casm = "2.12.0-rc.3"
+cairo-lang-starknet = "2.12.0-rc.3"
+cairo-lang-starknet-classes = "2.12.0-rc.3"
+cairo-lang-syntax = "2.12.0-rc.3"
+cairo-lang-test-plugin = "2.12.0-rc.3"
+cairo-lang-test-runner = "2.12.0-rc.3"
+cairo-lang-utils = { version = "2.12.0-rc.3", features = ["env_logger"] }
+cairo-language-server = "2.12.0-rc.3"
+cairo-lint = "2.12.0-rc.3"
 cairo-vm = "2.2.0"
 camino = { version = "1", features = ["serde1"] }
 cargo_metadata = ">=0.18"
@@ -132,8 +132,8 @@ smol_str = { version = "0.3", features = ["serde"] }
 snapbox = { version = "0.4", features = ["cmd", "path"] }
 starknet-core = "0.14.0"
 starknet-types-core = "0.1"
-stwo-cairo-adapter = { git = "https://github.com/starkware-libs/stwo-cairo", rev = "d869658ca0af584c1ae04706b22a8eeaf15713e2", features = ["std"] }
-stwo_cairo_prover = { git = "https://github.com/starkware-libs/stwo-cairo", rev = "d869658ca0af584c1ae04706b22a8eeaf15713e2" }
+stwo-cairo-adapter = { git = "https://github.com/starkware-libs/stwo-cairo", rev = "714b6b43f94c3d0d6d7ce1601a1606988c4d67ed", features = ["std"] }
+stwo_cairo_prover = { git = "https://github.com/starkware-libs/stwo-cairo", rev = "714b6b43f94c3d0d6d7ce1601a1606988c4d67ed" }
 syn = "2"
 tar = "0.4"
 target-triple = "0.1"

--- a/extensions/scarb-cairo-run/tests/examples.rs
+++ b/extensions/scarb-cairo-run/tests/examples.rs
@@ -84,7 +84,7 @@ fn can_limit_gas() {
         .env("SCARB_TARGET_DIR", t.path())
         .arg("cairo-run")
         .arg("--available-gas")
-        .arg("100000")
+        .arg("100000000")
         .current_dir(example)
         .assert()
         .success()
@@ -95,7 +95,7 @@ fn can_limit_gas() {
                 Finished `dev` profile target(s) in [..]
                  Running hello_world
             Run completed successfully, returning [987]
-            Remaining gas: 69790
+            Remaining gas: 99804810
         "#});
 }
 

--- a/extensions/scarb-cairo-test/src/main.rs
+++ b/extensions/scarb-cairo-test/src/main.rs
@@ -7,7 +7,7 @@ use std::{env, fs};
 use anyhow::{Context, Result};
 use cairo_lang_sierra::program::VersionedProgram;
 use cairo_lang_test_plugin::{TestCompilation, TestCompilationMetadata};
-use cairo_lang_test_runner::{CompiledTestRunner, RunProfilerConfig, TestRunConfig};
+use cairo_lang_test_runner::{CompiledTestRunner, TestRunConfig};
 use camino::Utf8PathBuf;
 use clap::Parser;
 use indoc::formatdoc;
@@ -95,7 +95,7 @@ fn main() -> Result<()> {
                 filter: args.filter.clone(),
                 include_ignored: args.include_ignored,
                 ignored: args.ignored,
-                run_profiler: RunProfilerConfig::None,
+                profiler_config: None,
                 gas_enabled: is_gas_enabled(&metadata, &package.id, target),
                 print_resource_usage: args.print_resource_usage,
             };

--- a/extensions/scarb-cairo-test/tests/build.rs
+++ b/extensions/scarb-cairo-test/tests/build.rs
@@ -223,12 +223,12 @@ fn integration_tests() {
             [..]Finished `dev` profile target(s) in [..]
             [..]Testing hello
             running 2 tests
-            test hello_integrationtest::[..]::tests::it_works ... ok (gas usage est.: 30510)
-            test hello_integrationtest::[..]::tests::it_works ... ok (gas usage est.: 30510)
+            test hello_integrationtest::[..]::tests::it_works ... ok (gas usage est.: 199190)
+            test hello_integrationtest::[..]::tests::it_works ... ok (gas usage est.: 199190)
             test result: ok. 2 passed; 0 failed; 0 ignored; 0 filtered out;
             
             running 1 test
-            test hello::tests::it_works ... ok (gas usage est.: 30510)
+            test hello::tests::it_works ... ok (gas usage est.: 199190)
             test result: ok. 1 passed; 0 failed; 0 ignored; 0 filtered out;
         "#});
 }
@@ -350,7 +350,7 @@ fn can_choose_test_kind_to_run() {
             [..]Finished `dev` profile target(s) in [..]
             [..]Testing hello
             running 1 test
-            test hello::tests::it_works ... ok (gas usage est.: 30510)
+            test hello::tests::it_works ... ok (gas usage est.: [..])
             test result: ok. 1 passed; 0 failed; 0 ignored; 0 filtered out;
         "#});
     Scarb::quick_snapbox()
@@ -365,8 +365,8 @@ fn can_choose_test_kind_to_run() {
             [..]Finished `dev` profile target(s) in [..]
             [..]Testing hello
             running 2 tests
-            test hello_integrationtest::[..]::tests::it_works ... ok (gas usage est.: 30510)
-            test hello_integrationtest::[..]::tests::it_works ... ok (gas usage est.: 30510)
+            test hello_integrationtest::[..]::tests::it_works ... ok (gas usage est.: [..])
+            test hello_integrationtest::[..]::tests::it_works ... ok (gas usage est.: [..])
             test result: ok. 2 passed; 0 failed; 0 ignored; 0 filtered out;
         "#});
 }

--- a/extensions/scarb-execute/tests/build.rs
+++ b/extensions/scarb-execute/tests/build.rs
@@ -162,7 +162,7 @@ fn fails_when_attr_missing() {
             [..]Compiling hello v0.1.0 ([..]Scarb.toml)
             error: Requested `#[executable]` not found.
             error: could not compile `hello` due to previous error
-            error: `scarb metadata` exited with error
+            error: `scarb` command exited with error
         "#});
 
     Scarb::quick_snapbox()

--- a/scarb-metadata/CHANGELOG.md
+++ b/scarb-metadata/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- Fix the error message for Scarb exiting with error in `ScarbCommand`.
+
 ## 1.15.0 (2025-06-09)
 - Use `2024` edition.
 - Add `features` and `default_features` fields to `DependencyMetadata`.

--- a/scarb-metadata/CHANGELOG.md
+++ b/scarb-metadata/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## 1.15.1 (2025-07-28)
 - Fix the error message for Scarb exiting with error in `ScarbCommand`.
 
 ## 1.15.0 (2025-06-09)

--- a/scarb-metadata/Cargo.toml
+++ b/scarb-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scarb-metadata"
-version = "1.15.0"
+version = "1.15.1"
 edition.workspace = true
 
 authors.workspace = true

--- a/scarb-metadata/src/command/scarb_command.rs
+++ b/scarb-metadata/src/command/scarb_command.rs
@@ -13,7 +13,7 @@ pub enum ScarbCommandError {
     #[error("failed to read `scarb` output")]
     Io(#[from] io::Error),
     /// Error during execution of `scarb` command.
-    #[error("`scarb metadata` exited with error")]
+    #[error("`scarb` command exited with error")]
     ScarbError,
 }
 

--- a/scarb/src/compiler/compilers/executable.rs
+++ b/scarb/src/compiler/compilers/executable.rs
@@ -157,7 +157,7 @@ fn multiple_executables_error_message(executables: Vec<String>, scarb_toml: &Utf
     formatdoc! {r#"
         more than one executable found in the main crate:
             {}
-        help: add a separate `executable` target for each of your executable functions
+        help: specify a separate `executable` target for each of your executable functions
         -> {scarb_toml}
         {manifest}
         "#,

--- a/scarb/src/compiler/incremental/fingerprint.rs
+++ b/scarb/src/compiler/incremental/fingerprint.rs
@@ -224,6 +224,19 @@ impl PluginFingerprint {
             local.path.hash(&mut hasher);
             local.checksum.hash(&mut hasher);
         }
+        // HACK: turns out the `snforge-scarb-plugin` is non-deterministic.
+        // To support it, we check the env variable that it uses as an input.
+        // It's hardcoded here, as we need to support older versions of snforge.
+        // TODO(#2444): Fix me.
+        if !self.is_builtin
+            && self
+                .component_discriminator
+                .contains("snforge_scarb_plugin")
+        {
+            std::env::var("SNFORGE_TEST_FILTER")
+                .unwrap_or_default()
+                .hash(&mut hasher);
+        }
         hasher.finish_as_short_hash()
     }
 }

--- a/scarb/src/compiler/incremental/fingerprint.rs
+++ b/scarb/src/compiler/incremental/fingerprint.rs
@@ -15,7 +15,7 @@ use camino::Utf8PathBuf;
 use itertools::Itertools;
 use scarb_stable_hash::{StableHasher, u64_hash};
 use smol_str::SmolStr;
-use std::cell::RefCell;
+use std::cell::{OnceCell, RefCell};
 use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;
@@ -64,6 +64,12 @@ pub struct Fingerprint {
 
     /// Local files that should be checked for freshness.
     local: Vec<LocalFingerprint>,
+
+    /// Cached fingerprint digest.
+    ///
+    /// Calculating digests multiple times over the span of compilation is dangerous,
+    /// as the underlying inputs may change during the compilation.
+    digest: OnceCell<String>,
 }
 
 #[derive(Debug)]
@@ -291,6 +297,7 @@ impl Fingerprint {
                 &ws.config().ui(),
             ),
             deps: Default::default(),
+            digest: OnceCell::new(),
         })
     }
 
@@ -345,8 +352,8 @@ impl Fingerprint {
             if seen.insert(dep.component_discriminator.clone()) {
                 let dep_fingerprint = dep.fingerprint.upgrade()
                     .expect(
-                    "dependency fingerprint should never be dropped, as long as unit fingerprint is alive"
-                );
+                        "dependency fingerprint should never be dropped, as long as unit fingerprint is alive"
+                    );
                 match dep_fingerprint.deref() {
                     ComponentFingerprint::Library(dep_fingerprint) => {
                         Self::calculate_id(dep_fingerprint.deref(), seen, hasher).hash(hasher);
@@ -366,10 +373,14 @@ impl Fingerprint {
     /// allowing to determine if the cache can be reused or if a recompilation is needed.
     #[tracing::instrument(level = "trace", skip_all)]
     pub fn digest(&self) -> String {
-        // We use the set to avoid cycles when calculating digests recursively for deps.
-        let mut seen = HashSet::<SmolStr>::new();
-        seen.insert(self.component_discriminator.clone());
-        Self::calculate_digest(self, &mut seen)
+        self.digest
+            .get_or_init(|| {
+                // We use the set to avoid cycles when calculating digests recursively for deps.
+                let mut seen = HashSet::<SmolStr>::new();
+                seen.insert(self.component_discriminator.clone());
+                Self::calculate_digest(self, &mut seen)
+            })
+            .clone()
     }
 
     fn calculate_digest(fingerprint: &Fingerprint, seen: &mut HashSet<SmolStr>) -> String {

--- a/scarb/src/compiler/plugin/proc_macro/v2/host/attribute/inner_attribute.rs
+++ b/scarb/src/compiler/plugin/proc_macro/v2/host/attribute/inner_attribute.rs
@@ -141,7 +141,6 @@ impl ProcMacroHostPlugin {
         let mut used_attr_names: HashSet<SmolStr> = Default::default();
         let mut all_none = true;
         let ctx = AllocationContext::default();
-        let item_start_offset = item_ast.as_syntax_node().span(db).start;
 
         match item_ast.clone() {
             ast::ModuleItem::Trait(trait_ast) => {
@@ -167,13 +166,14 @@ impl ProcMacroHostPlugin {
                                 continue;
                             };
 
+                            let item_span = func.as_syntax_node().span(db);
                             let mut token_stream_builder = TokenStreamBuilder::new(db);
                             let attrs = func.attributes(db).elements(db).collect();
                             let found = self.parse_attrs(
                                 db,
                                 &mut token_stream_builder,
                                 attrs,
-                                item_start_offset,
+                                item_span,
                                 &ctx,
                             );
                             if let Some(name) = found.as_name() {
@@ -230,13 +230,14 @@ impl ProcMacroHostPlugin {
                                 continue;
                             };
 
+                            let item_span = func.as_syntax_node().span(db);
                             let mut token_stream_builder = TokenStreamBuilder::new(db);
                             let attrs = func.attributes(db).elements(db).collect();
                             let found = self.parse_attrs(
                                 db,
                                 &mut token_stream_builder,
                                 attrs,
-                                item_start_offset,
+                                item_span,
                                 &ctx,
                             );
                             if let Some(name) = found.as_name() {

--- a/scarb/src/compiler/plugin/proc_macro/v2/host/attribute/item_attribute.rs
+++ b/scarb/src/compiler/plugin/proc_macro/v2/host/attribute/item_attribute.rs
@@ -209,7 +209,7 @@ fn parse_item<T: ItemWithAttributes + ChildNodesWithoutAttributes>(
 ) -> AttrExpansionFound {
     let span = ast.span_with_trivia(db);
     let attrs = ast.item_attributes(db);
-    let expansion = host.parse_attrs(db, token_stream_builder, attrs, span.start, ctx);
+    let expansion = host.parse_attrs(db, token_stream_builder, attrs, span, ctx);
     token_stream_builder.extend(ast.child_nodes_without_attributes(db));
     expansion
 }

--- a/scarb/src/compiler/plugin/proc_macro/v2/host/attribute/parse_attributes.rs
+++ b/scarb/src/compiler/plugin/proc_macro/v2/host/attribute/parse_attributes.rs
@@ -5,7 +5,7 @@ use crate::compiler::plugin::proc_macro::v2::host::attribute::{
 use crate::compiler::plugin::proc_macro::v2::host::conversion::CallSiteLocation;
 use crate::compiler::plugin::proc_macro::v2::{ProcMacroHostPlugin, TokenStreamBuilder};
 use crate::compiler::plugin::proc_macro::{ExpansionKind, ExpansionQuery};
-use cairo_lang_filesystem::span::TextOffset;
+use cairo_lang_filesystem::span::TextSpan;
 use cairo_lang_macro::AllocationContext;
 use cairo_lang_syntax::attribute::structured::AttributeStructurize;
 use cairo_lang_syntax::node::db::SyntaxGroup;
@@ -17,7 +17,7 @@ impl ProcMacroHostPlugin {
         db: &dyn SyntaxGroup,
         builder: &mut TokenStreamBuilder<'_>,
         item_attrs: Vec<ast::Attribute>,
-        item_start_offset: TextOffset,
+        item_span: TextSpan,
         ctx: &AllocationContext,
     ) -> AttrExpansionFound {
         // This function parses attributes of the item,
@@ -48,11 +48,7 @@ impl ProcMacroHostPlugin {
                             id: found,
                             args,
                             call_site: CallSiteLocation::new(&attr, db),
-                            attribute_location: ExpandableAttrLocation::new(
-                                &attr,
-                                item_start_offset,
-                                db,
-                            ),
+                            attribute_location: ExpandableAttrLocation::new(&attr, item_span, db),
                         });
                         // Do not add the attribute for found expansion.
                         continue;

--- a/scarb/src/core/manifest/compiler_config.rs
+++ b/scarb/src/core/manifest/compiler_config.rs
@@ -83,6 +83,7 @@ mod serdex {
                 }
                 InliningStrategy::Predefined(name) => match name.as_str() {
                     "default" => Ok(Self::Default),
+                    "release" => Ok(Self::Default),
                     "avoid" => Ok(Self::Avoid),
                     _ => Err(serde::de::Error::custom(format!(
                         "unknown inlining strategy: `{name}`\nuse one of: `default`, `avoid` or a number"

--- a/scarb/src/core/manifest/compiler_config.rs
+++ b/scarb/src/core/manifest/compiler_config.rs
@@ -115,7 +115,11 @@ impl DefaultForProfile for ManifestCompilerConfig {
             unstable_add_statements_code_locations_debug_info: false,
             panic_backtrace: false,
             unsafe_panic: false,
-            inlining_strategy: InliningStrategy::default(),
+            inlining_strategy: if profile.is_dev() {
+                InliningStrategy::Avoid
+            } else {
+                Default::default()
+            },
             incremental: true,
         }
     }

--- a/scarb/tests/metadata.rs
+++ b/scarb/tests/metadata.rs
@@ -1962,7 +1962,7 @@ fn cairo_section_overrides_profile_defaults() {
         json!({
             "allow_warnings": true,
             "enable_gas": true,
-            "inlining_strategy": "default",
+            "inlining_strategy": "avoid",
             "sierra_replace_ids": true,
             "unstable_add_statements_code_locations_debug_info": false,
             "unstable_add_statements_functions_debug_info": false,

--- a/scarb/tests/proc_macro_v2_expand.rs
+++ b/scarb/tests/proc_macro_v2_expand.rs
@@ -974,7 +974,7 @@ fn code_mappings_preserve_attribute_error_on_inner_trait_locations_with_parser()
                     .into_iter()
                     .map(|TokenTree::Ident(token)| {
                         if token.content.to_string() == "12" {
-                            TokenTree::Ident(Token::new("34", TextSpan::call_site()))
+                            TokenTree::Ident(Token::new("34", TextSpan::new(0,2)))
                         } else {
                             TokenTree::Ident(token)
                         }
@@ -2176,30 +2176,30 @@ fn token_stream_parsed_with_correct_spans() {
         .stdout_matches(indoc! {r##"
             [..] Compiling some v1.0.0 ([..]Scarb.toml)
             [..] Compiling hello v1.0.0 ([..]Scarb.toml)
-            Ident(Token { content: "  ", span: TextSpan { start: 46, end: 48 } })
-            Ident(Token { content: "fn", span: TextSpan { start: 48, end: 50 } })
-            Ident(Token { content: " ", span: TextSpan { start: 50, end: 51 } })
-            Ident(Token { content: "foo", span: TextSpan { start: 51, end: 54 } })
-            Ident(Token { content: "(", span: TextSpan { start: 54, end: 55 } })
-            Ident(Token { content: ")", span: TextSpan { start: 55, end: 56 } })
-            Ident(Token { content: " ", span: TextSpan { start: 56, end: 57 } })
-            Ident(Token { content: "{", span: TextSpan { start: 57, end: 58 } })
+            Ident(Token { content: "  ", span: TextSpan { start: 0, end: 2 } })
+            Ident(Token { content: "fn", span: TextSpan { start: 2, end: 4 } })
+            Ident(Token { content: " ", span: TextSpan { start: 4, end: 5 } })
+            Ident(Token { content: "foo", span: TextSpan { start: 5, end: 8 } })
+            Ident(Token { content: "(", span: TextSpan { start: 8, end: 9 } })
+            Ident(Token { content: ")", span: TextSpan { start: 9, end: 10 } })
+            Ident(Token { content: " ", span: TextSpan { start: 10, end: 11 } })
+            Ident(Token { content: "{", span: TextSpan { start: 11, end: 12 } })
             Ident(Token { content: "
-            ", span: TextSpan { start: 58, end: 59 } })
-            Ident(Token { content: "    ", span: TextSpan { start: 59, end: 63 } })
-            Ident(Token { content: "let", span: TextSpan { start: 63, end: 66 } })
-            Ident(Token { content: " ", span: TextSpan { start: 66, end: 67 } })
-            Ident(Token { content: "_a", span: TextSpan { start: 67, end: 69 } })
-            Ident(Token { content: " ", span: TextSpan { start: 69, end: 70 } })
-            Ident(Token { content: "=", span: TextSpan { start: 70, end: 71 } })
-            Ident(Token { content: " ", span: TextSpan { start: 71, end: 72 } })
-            Ident(Token { content: "1", span: TextSpan { start: 72, end: 73 } })
-            Ident(Token { content: ";", span: TextSpan { start: 73, end: 74 } })
+            ", span: TextSpan { start: 12, end: 13 } })
+            Ident(Token { content: "    ", span: TextSpan { start: 13, end: 17 } })
+            Ident(Token { content: "let", span: TextSpan { start: 17, end: 20 } })
+            Ident(Token { content: " ", span: TextSpan { start: 20, end: 21 } })
+            Ident(Token { content: "_a", span: TextSpan { start: 21, end: 23 } })
+            Ident(Token { content: " ", span: TextSpan { start: 23, end: 24 } })
+            Ident(Token { content: "=", span: TextSpan { start: 24, end: 25 } })
+            Ident(Token { content: " ", span: TextSpan { start: 25, end: 26 } })
+            Ident(Token { content: "1", span: TextSpan { start: 26, end: 27 } })
+            Ident(Token { content: ";", span: TextSpan { start: 27, end: 28 } })
             Ident(Token { content: "
-            ", span: TextSpan { start: 74, end: 75 } })
-            Ident(Token { content: "}", span: TextSpan { start: 75, end: 76 } })
+            ", span: TextSpan { start: 28, end: 29 } })
+            Ident(Token { content: "}", span: TextSpan { start: 29, end: 30 } })
             Ident(Token { content: "
-            ", span: TextSpan { start: 76, end: 77 } })
+            ", span: TextSpan { start: 30, end: 31 } })
             [..]Finished `dev` profile target(s) in [..]
       "##});
 }

--- a/scarb/tests/profiles.rs
+++ b/scarb/tests/profiles.rs
@@ -349,7 +349,7 @@ fn compiler_config_defaults_in_dev() {
                 .unwrap()
                 .as_str()
                 .unwrap(),
-            "default"
+            "avoid"
         );
     }
 }

--- a/utils/scarb-test-support/src/cairo_plugin_project_builder.rs
+++ b/utils/scarb-test-support/src/cairo_plugin_project_builder.rs
@@ -128,11 +128,11 @@ impl CairoPluginProjectBuilder {
     }
 
     pub fn add_cairo_lang_parser_dep(self) -> Self {
-        self.add_dep(r#"cairo-lang-parser = { git = "https://github.com/starkware-libs/cairo.git", rev = "172195a5e8c889a2355c28f5c444e61da6ae8a2b" }"#)
+        self.add_dep(r#"cairo-lang-parser = "2.12.0-rc.3""#)
     }
 
     pub fn add_cairo_lang_syntax_dep(self) -> Self {
-        self.add_dep(r#"cairo-lang-syntax = { git = "https://github.com/starkware-libs/cairo.git", rev = "172195a5e8c889a2355c28f5c444e61da6ae8a2b" }"#)
+        self.add_dep(r#"cairo-lang-syntax = "2.12.0-rc.3""#)
     }
 
     pub fn default_v1() -> Self {

--- a/website/.vitepress/config.mjs
+++ b/website/.vitepress/config.mjs
@@ -53,6 +53,13 @@ const sidebar = {
           "/docs/extensions/documentation-generation",
         ),
         p("Linter", "/docs/extensions/linter"),
+        {
+          text: "Oracles",
+          items: [
+            p("Overview", "/docs/extensions/oracles/overview"),
+            p("stdio protocol", "/docs/extensions/oracles/stdio"),
+          ],
+        },
       ],
     },
     {

--- a/website/.vitepress/theme/style.css
+++ b/website/.vitepress/theme/style.css
@@ -76,8 +76,8 @@
 }
 
 :root {
-  --swm-font-family-geometric-humanist: Avenir, Montserrat, Corbel, "URW Gothic",
-    source-sans-pro, sans-serif;
+  --swm-font-family-geometric-humanist:
+    Avenir, Montserrat, Corbel, "URW Gothic", source-sans-pro, sans-serif;
 }
 
 :root {

--- a/website/docs/extensions/oracles/overview.md
+++ b/website/docs/extensions/oracles/overview.md
@@ -1,0 +1,53 @@
+# Oracles <Badge type="warning" text="experimental" />
+
+> [!WARNING]
+> This is an experimental feature. The API and behaviour may change in future versions of Scarb.
+> Oracles are currently available in **`scarb execute`** with the `--experimental-oracles` flag
+> Support is also planned in future versions of **`cairo-test`** and **`snforge`**.
+
+An oracle is an external process (like a script, binary, or web service) that exposes custom logic or data to a Cairo
+program at runtime. You use it to perform tasks the Cairo VM can't, such as accessing real-world data or executing
+complex, non-provable computations.
+
+## Using oracles
+
+The `oracle` library provides a type-safe interface for interacting with external oracles in Cairo applications.
+Invoking oracles via this package is the recommended way, as it provides a well-tested, secure, and maintainable
+interface for oracle interactions.
+
+<BigLink href="https://scarbs.xyz/packages/oracle">
+  Go to oracle on scarbs.xyz
+</BigLink>
+
+The documentation for this package provides a bird's-eye overview, guidelines, and instructions on how to invoke oracles
+from Cairo code.
+
+<BigLink href="https://docs.swmansion.com/cairo-oracle">
+  Go to oracle documentation
+</BigLink>
+
+In the [oracle repository](https://github.com/software-mansion/cairo-oracle) there is also an end-to-end example
+showcasing the feature. It implements a simple Cairo executable script, that invokes an oracle written in Rust that
+runs as a child process.
+
+<BigLink href="https://github.com/software-mansion/cairo-oracle/tree/main/example">
+  Go to oracle example
+</BigLink>
+
+## Writing oracles
+
+In Cairo, the oracle abstraction doesn't specify how to implement or execute oracles. Those are details that are
+specific to the executor being used. Oracles are invoked using generic connection strings with the following format:
+
+```
+protocol:connection params
+```
+
+The [Scarb executor](../../extensions/execute.md) implements oracles as subprocesses that communicate using
+a [`stdio`](./stdio.md) protocol.
+
+In the oracle repository, you can find ready-to-use SDKs that ease writing oracles compatible with Scarb executor.
+
+<BigLink href="https://github.com/software-mansion/cairo-oracle/tree/main/sdk">
+  Go to oracle SDKs
+</BigLink>

--- a/website/docs/extensions/oracles/stdio.md
+++ b/website/docs/extensions/oracles/stdio.md
@@ -1,0 +1,120 @@
+# `stdio` protocol <Badge type="warning" text="experimental" />
+
+The `stdio` oracle protocol works by spawning subprocesses that talk a strict subset
+of [JSON-RPC 2.0](https://www.jsonrpc.org/specification) over standard input/output.
+
+## Connection string format
+
+Oracles are invoked using connection strings with the following format:
+
+```
+stdio:<command>
+```
+
+Where `<command>` is the shell command to execute the oracle process. Arguments are delimited as in shell invocations,
+and basic escape sequences are supported, but more complex features like environment variable expansions, pipes, and
+redirections aren't.
+
+#### Example
+
+```cairo
+oracle::invoke(
+    "stdio:cargo -q run --manifest-path my_oracle/Cargo.toml",
+    'selector',
+    (param1, param2)
+)
+```
+
+## General flow
+
+The following sequence diagram provides a bird's eye view of this protocol's flow.
+
+```mermaid
+sequenceDiagram
+    participant E as Executor
+    create participant O as Oracle
+    E -->> O: Spawns oracle process
+    O ->> E: Ready request
+    E ->> O: ACK
+    loop Function invocations
+        E ->> O: Invoke request
+        O ->> E: Response (result or error)
+    end
+    E ->> O: Shutdown notification
+    destroy O
+    O -->> E: Process terminates
+```
+
+## Transport protocol
+
+1. Oracle sends messages to its standard output.
+2. Executor sends messages to oracle's standard input.
+3. The first byte sent by the oracle must always be `{` (`0x7b`).
+4. Messages in both directions **must always** fit in a single line.
+5. Oracle can write its logs to standard error. Executor will include these lines in its own logs.
+
+## Error handling
+
+Oracle failure never halts program execution. Instead, failing invocations always return an `oracle::Error` object in
+Cairo code. The internal structure of this type is opaque, but it can be displayed and (de)serialised.
+
+## Process spawning
+
+On the first invocation to a particular connection string, the executor spawns an oracle process using the specified
+command.
+
+Each unique connection string maintains a persistent process which is terminated when the executor ends. Failed
+connections aren't cached and will retry on subsequent calls.
+
+## Initialisation
+
+The oracle process announces that it is ready to accept commands and waits for the executor for acknowledgement.
+
+```jsonc
+// oracle to executor
+{"jsonrpc":"2.0","id":0,"method":"ready"}
+
+// executor to oracle
+{"jsonrpc":"2.0","id":0,"result":{}}
+```
+
+1. The `ready` method doesn't require any parameters to provide by the oracle nor any back in the result. It is possible
+   that some optional parameters will be introduced in the future.
+2. If the executor errors on this request, oracle must terminate.
+3. The `id` is not fixed; it can be any value that is valid, according to JSON-RPC spec.
+4. Executor will never send any data to the oracle until it receives `ready` request.
+
+## Function invocation
+
+Cairo program calls oracle functions via the `invoke` cheatcode. The executor translates this to `invoke` requests that
+it sends to the oracle. Oracle responds with JSON-RPC responses containing results or errors. This step runs in a
+synchronous loop throughout Cairo program execution.
+
+```jsonc
+// executor to oracle
+{"jsonrpc":"2.0","id":0,"method":"invoke","params":{"selector":"f","calldata":["0x2710"]}}
+
+// oracle to executor
+{"jsonrpc":"2.0","id":0,"result":["0x5f5e100"]}
+
+// executor to oracle
+{"jsonrpc":"2.0","id":1,"method":"invoke","params":{"selector":"f","calldata":["0x2711"]}}
+
+// oracle to executor
+{"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"error message"}}
+```
+
+1. The `selector` field specifies which oracle function to call.
+2. Input/result data is always an array of hex-encoded Felt252 values that represent input/output as serialised by Cairo
+   [Serde](https://www.starknet.io/cairo-book/appendix-03-derivable-traits.html?highlight=serde#serializing-with-serde).
+3. This protocol doesn't specify custom error codes beneath ones specified by JSON-RPC.
+4. Parallel/asynchronous function invocations are not possible.
+
+## Termination
+
+When the oracle process is no longer needed, the executor asks it to terminate gracefully.
+
+```jsonc
+// executor to oracle
+{ "jsonrpc": "2.0", "method": "shutdown" }
+```

--- a/website/docs/guides/creating-executable-package.md
+++ b/website/docs/guides/creating-executable-package.md
@@ -3,14 +3,16 @@ import { data as rel } from "../../github.data";
 import {data as constants} from "../../constants.data";
 </script>
 
-## Defining an Executable Package
+# Defining an Executable Package
 
 Start a new Scarb project with `scarb new <project_name>`.
 In your `Scarb.toml` file:
 
-1. Set the package to compile to a Cairo executable by adding `[executable]` (note that `lib` or `starknet-contract` targets cannot be executed in this way).
+1. Set the package to compile to a Cairo executable by adding `[executable]` (note that `lib` or `starknet-contract`
+   targets cannot be executed in this way).
 2. Add the `cairo_execute="{{ rel.stable.starknetPackageVersionReq }}"` plugin to your dependencies.
-3. Disable gas usage by adding `enable-gas = false` under the `[cairo]` section (gas is only supported for `lib` or `starknet-contract` targets).
+3. Disable gas usage by adding `enable-gas = false` under the `[cairo]` section (gas is only supported for `lib` or
+   `starknet-contract` targets).
 
 Below we have an example of the manifest file of a simple executable
 
@@ -29,7 +31,8 @@ enable-gas = false
 cairo_execute = "{{ rel.stable.starknetPackageVersionReq }}"
 ```
 
-Now we can move on to the code itself. An executable project must have **exactly one function** annotated with the `#[executable]` attribute. Consider the following simple `lib.cairo` file of an executable project:
+Now we can move on to the code itself. An executable project must have **exactly one function** annotated with the
+`#[executable]` attribute. Consider the following simple `lib.cairo` file of an executable project:
 
 ```cairo
 #[executable]
@@ -46,10 +49,12 @@ scarb execute -p test_execute --print-program-output --arguments 5
 
 Where `test_execute` is the name of the package with the executable target (as defined in our Scarb.toml manifest).
 
-The above command runs our executable function within the `test-execute` package and prints the program's output segment.
+The above command runs our executable function within the `test-execute` package and prints the program's output
+segment.
 
 The execution information will be saved under the `target/execute/<target name>` directory.
-For each execution, a new output directory will be created, with consecutive number as names (e.g. `execution1`, `execution2`, ...).
+For each execution, a new output directory will be created, with consecutive number as names (e.g. `execution1`,
+`execution2`, ...).
 To clean the target directory, you can use the `scarb clean` command.
 
 For more information see detailed [`scarb execute`](../extensions/execute.md) documentation.

--- a/website/docs/reference/manifest.md
+++ b/website/docs/reference/manifest.md
@@ -333,9 +333,11 @@ This flag cannot be set to `false` while compiling the `starknet-contract` targe
 
 ### `inlining-strategy`
 
-This field is responsible for setting the inlining strategy to be used by compiler when building the package.
-The possible values are `default`, `avoid` or a numerical value.
+This field is responsible for setting the inlining strategy to be used by the compiler when building the package.
+The possible values are `release`, `avoid` or a numerical value.
 If `avoid` strategy is set, the compiler will only inline function annotated with `#[inline(always)]` attribute.
+By default, Scarb will use `avoid` strategy in `dev` profile and `default` strategy in `release` profile.
+
 Example usage:
 
 ```toml
@@ -354,8 +356,8 @@ inlining-strategy = 18
 
 > [!WARNING]
 > Using the `avoid` strategy may result in a slower execution of the compiled code.
-> Please use with caution, only if your tooling requires that.
-> You can use profile settings overwriting, for more granular control of which builds use the avoid strategy.
+> Please use with caution. If you need to deploy your contracts on Starknet, it is recommended to use the `release` strategy.
+> You can use profile settings overwriting, for more granular control of which builds use the `avoid` and `release` strategy.
 
 ### `panic-backtrace`
 

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -11,39 +11,42 @@
         "@octokit/core": "6.1.4",
         "cairo-tm-grammar": "github:software-mansion-labs/cairo-tm-grammar",
         "mermaid": "11.4.1",
-        "prettier": "3.3.2",
+        "prettier": "3.6.2",
         "semver": "7.6.2",
-        "vitepress": "1.2.3",
+        "vitepress": "1.6.3",
         "vitepress-plugin-mermaid": "2.0.17",
-        "vue": "3.4.30"
+        "vue": "3.5.17"
       }
     },
     "node_modules/@algolia/autocomplete-core": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.9.3.tgz",
-      "integrity": "sha512-009HdfugtGCdC4JdXUbVJClA0q0zh24yyePn+KUGk3rP7j8FEe/m5Yo/z65gn6nP/cM39PxpzqKrL7A6fP6PPw==",
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.17.7.tgz",
+      "integrity": "sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q==",
+      "license": "MIT",
       "dependencies": {
-        "@algolia/autocomplete-plugin-algolia-insights": "1.9.3",
-        "@algolia/autocomplete-shared": "1.9.3"
+        "@algolia/autocomplete-plugin-algolia-insights": "1.17.7",
+        "@algolia/autocomplete-shared": "1.17.7"
       }
     },
     "node_modules/@algolia/autocomplete-plugin-algolia-insights": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.9.3.tgz",
-      "integrity": "sha512-a/yTUkcO/Vyy+JffmAnTWbr4/90cLzw+CC3bRbhnULr/EM0fGNvM13oQQ14f2moLMcVDyAx/leczLlAOovhSZg==",
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.17.7.tgz",
+      "integrity": "sha512-Jca5Ude6yUOuyzjnz57og7Et3aXjbwCSDf/8onLHSQgw1qW3ALl9mrMWaXb5FmPVkV3EtkD2F/+NkT6VHyPu9A==",
+      "license": "MIT",
       "dependencies": {
-        "@algolia/autocomplete-shared": "1.9.3"
+        "@algolia/autocomplete-shared": "1.17.7"
       },
       "peerDependencies": {
         "search-insights": ">= 1 < 3"
       }
     },
     "node_modules/@algolia/autocomplete-preset-algolia": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.9.3.tgz",
-      "integrity": "sha512-d4qlt6YmrLMYy95n5TB52wtNDr6EgAIPH81dvvvW8UmuWRgxEtY0NJiPwl/h95JtG2vmRM804M0DSwMCNZlzRA==",
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.17.7.tgz",
+      "integrity": "sha512-ggOQ950+nwbWROq2MOCIL71RE0DdQZsceqrg32UqnhDz8FlO9rL8ONHNsI2R1MH0tkgVIDKI/D0sMiUchsFdWA==",
+      "license": "MIT",
       "dependencies": {
-        "@algolia/autocomplete-shared": "1.9.3"
+        "@algolia/autocomplete-shared": "1.17.7"
       },
       "peerDependencies": {
         "@algolia/client-search": ">= 4.9.1 < 6",
@@ -51,127 +54,193 @@
       }
     },
     "node_modules/@algolia/autocomplete-shared": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.9.3.tgz",
-      "integrity": "sha512-Wnm9E4Ye6Rl6sTTqjoymD+l8DjSTHsHboVRYrKgEt8Q7UHm9nYbqhN/i0fhUYA3OAEH7WA8x3jfpnmJm3rKvaQ==",
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.17.7.tgz",
+      "integrity": "sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg==",
+      "license": "MIT",
       "peerDependencies": {
         "@algolia/client-search": ">= 4.9.1 < 6",
         "algoliasearch": ">= 4.9.1 < 6"
       }
     },
-    "node_modules/@algolia/cache-browser-local-storage": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.22.1.tgz",
-      "integrity": "sha512-Sw6IAmOCvvP6QNgY9j+Hv09mvkvEIDKjYW8ow0UDDAxSXy664RBNQk3i/0nt7gvceOJ6jGmOTimaZoY1THmU7g==",
+    "node_modules/@algolia/client-abtesting": {
+      "version": "5.34.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.34.0.tgz",
+      "integrity": "sha512-d6ardhDtQsnMpyr/rPrS3YuIE9NYpY4rftkC7Ap9tyuhZ/+V3E/LH+9uEewPguKzVqduApdwJzYq2k+vAXVEbQ==",
+      "license": "MIT",
       "dependencies": {
-        "@algolia/cache-common": "4.22.1"
-      }
-    },
-    "node_modules/@algolia/cache-common": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.22.1.tgz",
-      "integrity": "sha512-TJMBKqZNKYB9TptRRjSUtevJeQVXRmg6rk9qgFKWvOy8jhCPdyNZV1nB3SKGufzvTVbomAukFR8guu/8NRKBTA=="
-    },
-    "node_modules/@algolia/cache-in-memory": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.22.1.tgz",
-      "integrity": "sha512-ve+6Ac2LhwpufuWavM/aHjLoNz/Z/sYSgNIXsinGofWOysPilQZPUetqLj8vbvi+DHZZaYSEP9H5SRVXnpsNNw==",
-      "dependencies": {
-        "@algolia/cache-common": "4.22.1"
-      }
-    },
-    "node_modules/@algolia/client-account": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.22.1.tgz",
-      "integrity": "sha512-k8m+oegM2zlns/TwZyi4YgCtyToackkOpE+xCaKCYfBfDtdGOaVZCM5YvGPtK+HGaJMIN/DoTL8asbM3NzHonw==",
-      "dependencies": {
-        "@algolia/client-common": "4.22.1",
-        "@algolia/client-search": "4.22.1",
-        "@algolia/transporter": "4.22.1"
+        "@algolia/client-common": "5.34.0",
+        "@algolia/requester-browser-xhr": "5.34.0",
+        "@algolia/requester-fetch": "5.34.0",
+        "@algolia/requester-node-http": "5.34.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-analytics": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.22.1.tgz",
-      "integrity": "sha512-1ssi9pyxyQNN4a7Ji9R50nSdISIumMFDwKNuwZipB6TkauJ8J7ha/uO60sPJFqQyqvvI+px7RSNRQT3Zrvzieg==",
+      "version": "5.34.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.34.0.tgz",
+      "integrity": "sha512-WXIByjHNA106JO1Dj6b4viSX/yMN3oIB4qXr2MmyEmNq0MgfuPfPw8ayLRIZPa9Dp27hvM3G8MWJ4RG978HYFw==",
+      "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "4.22.1",
-        "@algolia/client-search": "4.22.1",
-        "@algolia/requester-common": "4.22.1",
-        "@algolia/transporter": "4.22.1"
+        "@algolia/client-common": "5.34.0",
+        "@algolia/requester-browser-xhr": "5.34.0",
+        "@algolia/requester-fetch": "5.34.0",
+        "@algolia/requester-node-http": "5.34.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.22.1.tgz",
-      "integrity": "sha512-IvaL5v9mZtm4k4QHbBGDmU3wa/mKokmqNBqPj0K7lcR8ZDKzUorhcGp/u8PkPC/e0zoHSTvRh7TRkGX3Lm7iOQ==",
+      "version": "5.34.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.34.0.tgz",
+      "integrity": "sha512-JeN1XJLZIkkv6yK0KT93CIXXk+cDPUGNg5xeH4fN9ZykYFDWYRyqgaDo+qvg4RXC3WWkdQ+hogQuuCk4Y3Eotw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-insights": {
+      "version": "5.34.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.34.0.tgz",
+      "integrity": "sha512-gdFlcQa+TWXJUsihHDlreFWniKPFIQ15i5oynCY4m9K3DCex5g5cVj9VG4Hsquxf2t6Y0yv8w6MvVTGDO8oRLw==",
+      "license": "MIT",
       "dependencies": {
-        "@algolia/requester-common": "4.22.1",
-        "@algolia/transporter": "4.22.1"
+        "@algolia/client-common": "5.34.0",
+        "@algolia/requester-browser-xhr": "5.34.0",
+        "@algolia/requester-fetch": "5.34.0",
+        "@algolia/requester-node-http": "5.34.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.22.1.tgz",
-      "integrity": "sha512-sl+/klQJ93+4yaqZ7ezOttMQ/nczly/3GmgZXJ1xmoewP5jmdP/X/nV5U7EHHH3hCUEHeN7X1nsIhGPVt9E1cQ==",
+      "version": "5.34.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.34.0.tgz",
+      "integrity": "sha512-g91NHhIZDkh1IUeNtsUd8V/ZxuBc2ByOfDqhCkoQY3Z/mZszhpn3Czn6AR5pE81fx793vMaiOZvQVB5QttArkQ==",
+      "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "4.22.1",
-        "@algolia/requester-common": "4.22.1",
-        "@algolia/transporter": "4.22.1"
+        "@algolia/client-common": "5.34.0",
+        "@algolia/requester-browser-xhr": "5.34.0",
+        "@algolia/requester-fetch": "5.34.0",
+        "@algolia/requester-node-http": "5.34.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-query-suggestions": {
+      "version": "5.34.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.34.0.tgz",
+      "integrity": "sha512-cvRApDfFrlJ3Vcn37U4Nd/7S6T8cx7FW3mVLJPqkkzixv8DQ/yV+x4VLirxOtGDdq3KohcIbIGWbg1QuyOZRvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.34.0",
+        "@algolia/requester-browser-xhr": "5.34.0",
+        "@algolia/requester-fetch": "5.34.0",
+        "@algolia/requester-node-http": "5.34.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.22.1.tgz",
-      "integrity": "sha512-yb05NA4tNaOgx3+rOxAmFztgMTtGBi97X7PC3jyNeGiwkAjOZc2QrdZBYyIdcDLoI09N0gjtpClcackoTN0gPA==",
+      "version": "5.34.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.34.0.tgz",
+      "integrity": "sha512-m9tK4IqJmn+flEPRtuxuHgiHmrKV0su5fuVwVpq8/es4DMjWMgX1a7Lg1PktvO8AbKaTp9kTtBAPnwXpuCwmEg==",
+      "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "4.22.1",
-        "@algolia/requester-common": "4.22.1",
-        "@algolia/transporter": "4.22.1"
+        "@algolia/client-common": "5.34.0",
+        "@algolia/requester-browser-xhr": "5.34.0",
+        "@algolia/requester-fetch": "5.34.0",
+        "@algolia/requester-node-http": "5.34.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
-    "node_modules/@algolia/logger-common": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.22.1.tgz",
-      "integrity": "sha512-OnTFymd2odHSO39r4DSWRFETkBufnY2iGUZNrMXpIhF5cmFE8pGoINNPzwg02QLBlGSaLqdKy0bM8S0GyqPLBg=="
-    },
-    "node_modules/@algolia/logger-console": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.22.1.tgz",
-      "integrity": "sha512-O99rcqpVPKN1RlpgD6H3khUWylU24OXlzkavUAMy6QZd1776QAcauE3oP8CmD43nbaTjBexZj2nGsBH9Tc0FVA==",
+    "node_modules/@algolia/ingestion": {
+      "version": "1.34.0",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.34.0.tgz",
+      "integrity": "sha512-2rxy4XoeRtIpzxEh5u5UgDC5HY4XbNdjzNgFx1eDrfFkSHpEVjirtLhISMy2N5uSFqYu1uUby5/NC1Soq8J7iw==",
+      "license": "MIT",
       "dependencies": {
-        "@algolia/logger-common": "4.22.1"
+        "@algolia/client-common": "5.34.0",
+        "@algolia/requester-browser-xhr": "5.34.0",
+        "@algolia/requester-fetch": "5.34.0",
+        "@algolia/requester-node-http": "5.34.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/monitoring": {
+      "version": "1.34.0",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.34.0.tgz",
+      "integrity": "sha512-OJiDhlJX8ZdWAndc50Z6aUEW/YmnhFK2ul3rahMw5/c9Damh7+oY9SufoK2LimJejy+65Qka06YPG29v2G/vww==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.34.0",
+        "@algolia/requester-browser-xhr": "5.34.0",
+        "@algolia/requester-fetch": "5.34.0",
+        "@algolia/requester-node-http": "5.34.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/recommend": {
+      "version": "5.34.0",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.34.0.tgz",
+      "integrity": "sha512-fzNQZAdVxu/Gnbavy8KW5gurApwdYcPW6+pjO7Pw8V5drCR3eSqnOxSvp79rhscDX8ezwqMqqK4F3Hsq+KpRzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.34.0",
+        "@algolia/requester-browser-xhr": "5.34.0",
+        "@algolia/requester-fetch": "5.34.0",
+        "@algolia/requester-node-http": "5.34.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.22.1.tgz",
-      "integrity": "sha512-dtQGYIg6MteqT1Uay3J/0NDqD+UciHy3QgRbk7bNddOJu+p3hzjTRYESqEnoX/DpEkaNYdRHUKNylsqMpgwaEw==",
+      "version": "5.34.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.34.0.tgz",
+      "integrity": "sha512-gEI0xjzA/xvMpEdYmgQnf6AQKllhgKRtnEWmwDrnct+YPIruEHlx1dd7nRJTy/33MiYcCxkB4khXpNrHuqgp3Q==",
+      "license": "MIT",
       "dependencies": {
-        "@algolia/requester-common": "4.22.1"
+        "@algolia/client-common": "5.34.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
-    "node_modules/@algolia/requester-common": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.22.1.tgz",
-      "integrity": "sha512-dgvhSAtg2MJnR+BxrIFqlLtkLlVVhas9HgYKMk2Uxiy5m6/8HZBL40JVAMb2LovoPFs9I/EWIoFVjOrFwzn5Qg=="
+    "node_modules/@algolia/requester-fetch": {
+      "version": "5.34.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.34.0.tgz",
+      "integrity": "sha512-5SwGOttpbACT4jXzfSJ3mnTcF46SVNSnZ1JjxC3qBa3qKi4U0CJGzuVVy3L798u8dG5H0SZ2MAB5v7180Gnqew==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.34.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.22.1.tgz",
-      "integrity": "sha512-JfmZ3MVFQkAU+zug8H3s8rZ6h0ahHZL/SpMaSasTCGYR5EEJsCc8SI5UZ6raPN2tjxa5bxS13BRpGSBUens7EA==",
+      "version": "5.34.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.34.0.tgz",
+      "integrity": "sha512-409XlyIyEXrxyGjWxd0q5RASizHSRVUU0AXPCEdqnbcGEzbCgL1n7oYI8YxzE/RqZLha+PNwWCcTVn7EE5tyyQ==",
+      "license": "MIT",
       "dependencies": {
-        "@algolia/requester-common": "4.22.1"
-      }
-    },
-    "node_modules/@algolia/transporter": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.22.1.tgz",
-      "integrity": "sha512-kzWgc2c9IdxMa3YqA6TN0NW5VrKYYW/BELIn7vnLyn+U/RFdZ4lxxt9/8yq3DKV5snvoDzzO4ClyejZRdV3lMQ==",
-      "dependencies": {
-        "@algolia/cache-common": "4.22.1",
-        "@algolia/logger-common": "4.22.1",
-        "@algolia/requester-common": "4.22.1"
+        "@algolia/client-common": "5.34.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@antfu/install-pkg": {
@@ -196,16 +265,50 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
-    "node_modules/@babel/parser": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.7.tgz",
-      "integrity": "sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw==",
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
       "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.0.tgz",
+      "integrity": "sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.0"
+      },
       "bin": {
         "parser": "bin/babel-parser.js"
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.28.1",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.1.tgz",
+      "integrity": "sha512-x0LvFTekgSX+83TI28Y9wYPUfzrnl2aT5+5QLnO6v7mSJYtEEevuDRN0F0uSHRk1G1IWZC43o00Y0xDDrpBGPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@braintree/sanitize-url": {
@@ -254,28 +357,31 @@
       "license": "Apache-2.0"
     },
     "node_modules/@docsearch/css": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.6.0.tgz",
-      "integrity": "sha512-+sbxb71sWre+PwDK7X2T8+bhS6clcVMLwBPznX45Qu6opJcgRjAp7gYSDzVFp187J+feSj5dNBN1mJoi6ckkUQ=="
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.8.2.tgz",
+      "integrity": "sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ==",
+      "license": "MIT"
     },
     "node_modules/@docsearch/js": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.6.0.tgz",
-      "integrity": "sha512-QujhqINEElrkIfKwyyyTfbsfMAYCkylInLYMRqHy7PHc8xTBQCow73tlo/Kc7oIwBrCLf0P3YhjlOeV4v8hevQ==",
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.8.2.tgz",
+      "integrity": "sha512-Q5wY66qHn0SwA7Taa0aDbHiJvaFJLOJyHmooQ7y8hlwwQLQ/5WwCcoX0g7ii04Qi2DJlHsd0XXzJ8Ypw9+9YmQ==",
+      "license": "MIT",
       "dependencies": {
-        "@docsearch/react": "3.6.0",
+        "@docsearch/react": "3.8.2",
         "preact": "^10.0.0"
       }
     },
     "node_modules/@docsearch/react": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.6.0.tgz",
-      "integrity": "sha512-HUFut4ztcVNmqy9gp/wxNbC7pTOHhgVVkHVGCACTuLhUKUhKAF9KYHJtMiLUJxEqiFLQiuri1fWF8zqwM/cu1w==",
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.8.2.tgz",
+      "integrity": "sha512-xCRrJQlTt8N9GU0DG4ptwHRkfnSnD/YpdeaXe02iKfqs97TkZJv60yE+1eq/tjPcVnTW8dP5qLP7itifFVV5eg==",
+      "license": "MIT",
       "dependencies": {
-        "@algolia/autocomplete-core": "1.9.3",
-        "@algolia/autocomplete-preset-algolia": "1.9.3",
-        "@docsearch/css": "3.6.0",
-        "algoliasearch": "^4.19.1"
+        "@algolia/autocomplete-core": "1.17.7",
+        "@algolia/autocomplete-preset-algolia": "1.17.7",
+        "@docsearch/css": "3.8.2",
+        "algoliasearch": "^5.14.2"
       },
       "peerDependencies": {
         "@types/react": ">= 16.8.0 < 19.0.0",
@@ -305,6 +411,7 @@
       "cpu": [
         "ppc64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "aix"
@@ -320,6 +427,7 @@
       "cpu": [
         "arm"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -335,6 +443,7 @@
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -350,6 +459,7 @@
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -365,6 +475,7 @@
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -380,6 +491,7 @@
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -395,6 +507,7 @@
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -410,6 +523,7 @@
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -425,6 +539,7 @@
       "cpu": [
         "arm"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -440,6 +555,7 @@
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -455,6 +571,7 @@
       "cpu": [
         "ia32"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -470,6 +587,7 @@
       "cpu": [
         "loong64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -485,6 +603,7 @@
       "cpu": [
         "mips64el"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -500,6 +619,7 @@
       "cpu": [
         "ppc64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -515,6 +635,7 @@
       "cpu": [
         "riscv64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -530,6 +651,7 @@
       "cpu": [
         "s390x"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -545,6 +667,7 @@
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -560,6 +683,7 @@
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
@@ -575,6 +699,7 @@
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
@@ -590,6 +715,7 @@
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "sunos"
@@ -605,6 +731,7 @@
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -620,6 +747,7 @@
       "cpu": [
         "ia32"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -635,12 +763,22 @@
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@iconify-json/simple-icons": {
+      "version": "1.2.44",
+      "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.44.tgz",
+      "integrity": "sha512-CdWgSPygwDlDbKtDWjvi3NtUefnkoepXv90n3dQxJerqzD9kI+nEJOiWUBM+eOyMYQKtxBpLWFBrgeotF0IZKw==",
+      "license": "CC0-1.0",
+      "dependencies": {
+        "@iconify/types": "*"
       }
     },
     "node_modules/@iconify/types": {
@@ -666,9 +804,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
+      "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
       "license": "MIT"
     },
     "node_modules/@mermaid-js/mermaid-mindmap": {
@@ -793,209 +931,343 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.22.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.22.4.tgz",
-      "integrity": "sha512-Fxamp4aEZnfPOcGA8KSNEohV8hX7zVHOemC8jVBoBUHu5zpJK/Eu3uJwt6BMgy9fkvzxDaurgj96F/NiLukF2w==",
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.45.1.tgz",
+      "integrity": "sha512-NEySIFvMY0ZQO+utJkgoMiCAjMrGvnbDLHvcmlA33UXJpYBCvlBEbMMtV837uCkS+plG2umfhn0T5mMAxGrlRA==",
       "cpu": [
         "arm"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.22.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.22.4.tgz",
-      "integrity": "sha512-VXoK5UMrgECLYaMuGuVTOx5kcuap1Jm8g/M83RnCHBKOqvPPmROFJGQaZhGccnsFtfXQ3XYa4/jMCJvZnbJBdA==",
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.45.1.tgz",
+      "integrity": "sha512-ujQ+sMXJkg4LRJaYreaVx7Z/VMgBBd89wGS4qMrdtfUFZ+TSY5Rs9asgjitLwzeIbhwdEhyj29zhst3L1lKsRQ==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.22.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.22.4.tgz",
-      "integrity": "sha512-xMM9ORBqu81jyMKCDP+SZDhnX2QEVQzTcC6G18KlTQEzWK8r/oNZtKuZaCcHhnsa6fEeOBionoyl5JsAbE/36Q==",
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.45.1.tgz",
+      "integrity": "sha512-FSncqHvqTm3lC6Y13xncsdOYfxGSLnP+73k815EfNmpewPs+EyM49haPS105Rh4aF5mJKywk9X0ogzLXZzN9lA==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.22.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.22.4.tgz",
-      "integrity": "sha512-aJJyYKQwbHuhTUrjWjxEvGnNNBCnmpHDvrb8JFDbeSH3m2XdHcxDd3jthAzvmoI8w/kSjd2y0udT+4okADsZIw==",
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.45.1.tgz",
+      "integrity": "sha512-2/vVn/husP5XI7Fsf/RlhDaQJ7x9zjvC81anIVbr4b/f0xtSmXQTFcGIQ/B1cXIYM6h2nAhJkdMHTnD7OtQ9Og==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.45.1.tgz",
+      "integrity": "sha512-4g1kaDxQItZsrkVTdYQ0bxu4ZIQ32cotoQbmsAnW1jAE4XCMbcBPDirX5fyUzdhVCKgPcrwWuucI8yrVRBw2+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.45.1.tgz",
+      "integrity": "sha512-L/6JsfiL74i3uK1Ti2ZFSNsp5NMiM4/kbbGEcOCps99aZx3g8SJMO1/9Y0n/qKlWZfn6sScf98lEOUe2mBvW9A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.22.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.22.4.tgz",
-      "integrity": "sha512-j63YtCIRAzbO+gC2L9dWXRh5BFetsv0j0va0Wi9epXDgU/XUi5dJKo4USTttVyK7fGw2nPWK0PbAvyliz50SCQ==",
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.45.1.tgz",
+      "integrity": "sha512-RkdOTu2jK7brlu+ZwjMIZfdV2sSYHK2qR08FUWcIoqJC2eywHbXr0L8T/pONFwkGukQqERDheaGTeedG+rra6Q==",
       "cpu": [
         "arm"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.22.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.22.4.tgz",
-      "integrity": "sha512-dJnWUgwWBX1YBRsuKKMOlXCzh2Wu1mlHzv20TpqEsfdZLb3WoJW2kIEsGwLkroYf24IrPAvOT/ZQ2OYMV6vlrg==",
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.45.1.tgz",
+      "integrity": "sha512-3kJ8pgfBt6CIIr1o+HQA7OZ9mp/zDk3ctekGl9qn/pRBgrRgfwiffaUmqioUGN9hv0OHv2gxmvdKOkARCtRb8Q==",
       "cpu": [
         "arm"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.22.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.22.4.tgz",
-      "integrity": "sha512-AdPRoNi3NKVLolCN/Sp4F4N1d98c4SBnHMKoLuiG6RXgoZ4sllseuGioszumnPGmPM2O7qaAX/IJdeDU8f26Aw==",
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.45.1.tgz",
+      "integrity": "sha512-k3dOKCfIVixWjG7OXTCOmDfJj3vbdhN0QYEqB+OuGArOChek22hn7Uy5A/gTDNAcCy5v2YcXRJ/Qcnm4/ma1xw==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.22.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.22.4.tgz",
-      "integrity": "sha512-Gl0AxBtDg8uoAn5CCqQDMqAx22Wx22pjDOjBdmG0VIWX3qUBHzYmOKh8KXHL4UpogfJ14G4wk16EQogF+v8hmA==",
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.45.1.tgz",
+      "integrity": "sha512-PmI1vxQetnM58ZmDFl9/Uk2lpBBby6B6rF4muJc65uZbxCs0EA7hhKCk2PKlmZKuyVSHAyIw3+/SiuMLxKxWog==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.45.1.tgz",
+      "integrity": "sha512-9UmI0VzGmNJ28ibHW2GpE2nF0PBQqsyiS4kcJ5vK+wuwGnV5RlqdczVocDSUfGX/Na7/XINRVoUgJyFIgipoRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.22.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.22.4.tgz",
-      "integrity": "sha512-3aVCK9xfWW1oGQpTsYJJPF6bfpWfhbRnhdlyhak2ZiyFLDaayz0EP5j9V1RVLAAxlmWKTDfS9wyRyY3hvhPoOg==",
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.45.1.tgz",
+      "integrity": "sha512-7nR2KY8oEOUTD3pBAxIBBbZr0U7U+R9HDTPNy+5nVVHDXI4ikYniH1oxQz9VoB5PbBU1CZuDGHkLJkd3zLMWsg==",
       "cpu": [
         "ppc64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.22.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.22.4.tgz",
-      "integrity": "sha512-ePYIir6VYnhgv2C5Xe9u+ico4t8sZWXschR6fMgoPUK31yQu7hTEJb7bCqivHECwIClJfKgE7zYsh1qTP3WHUA==",
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.45.1.tgz",
+      "integrity": "sha512-nlcl3jgUultKROfZijKjRQLUu9Ma0PeNv/VFHkZiKbXTBQXhpytS8CIj5/NfBeECZtY2FJQubm6ltIxm/ftxpw==",
       "cpu": [
         "riscv64"
       ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.45.1.tgz",
+      "integrity": "sha512-HJV65KLS51rW0VY6rvZkiieiBnurSzpzore1bMKAhunQiECPuxsROvyeaot/tcK3A3aGnI+qTHqisrpSgQrpgA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.22.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.22.4.tgz",
-      "integrity": "sha512-GqFJ9wLlbB9daxhVlrTe61vJtEY99/xB3C8e4ULVsVfflcpmR6c8UZXjtkMA6FhNONhj2eA5Tk9uAVw5orEs4Q==",
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.45.1.tgz",
+      "integrity": "sha512-NITBOCv3Qqc6hhwFt7jLV78VEO/il4YcBzoMGGNxznLgRQf43VQDae0aAzKiBeEPIxnDrACiMgbqjuihx08OOw==",
       "cpu": [
         "s390x"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.22.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.22.4.tgz",
-      "integrity": "sha512-87v0ol2sH9GE3cLQLNEy0K/R0pz1nvg76o8M5nhMR0+Q+BBGLnb35P0fVz4CQxHYXaAOhE8HhlkaZfsdUOlHwg==",
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.45.1.tgz",
+      "integrity": "sha512-+E/lYl6qu1zqgPEnTrs4WysQtvc/Sh4fC2nByfFExqgYrqkKWp1tWIbe+ELhixnenSpBbLXNi6vbEEJ8M7fiHw==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.22.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.22.4.tgz",
-      "integrity": "sha512-UV6FZMUgePDZrFjrNGIWzDo/vABebuXBhJEqrHxrGiU6HikPy0Z3LfdtciIttEUQfuDdCn8fqh7wiFJjCNwO+g==",
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.45.1.tgz",
+      "integrity": "sha512-a6WIAp89p3kpNoYStITT9RbTbTnqarU7D8N8F2CV+4Cl9fwCOZraLVuVFvlpsW0SbIiYtEnhCZBPLoNdRkjQFw==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.22.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.22.4.tgz",
-      "integrity": "sha512-BjI+NVVEGAXjGWYHz/vv0pBqfGoUH0IGZ0cICTn7kB9PyjrATSkX+8WkguNjWoj2qSr1im/+tTGRaY+4/PdcQw==",
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.45.1.tgz",
+      "integrity": "sha512-T5Bi/NS3fQiJeYdGvRpTAP5P02kqSOpqiopwhj0uaXB6nzs5JVi2XMJb18JUSKhCOX8+UE1UKQufyD6Or48dJg==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.22.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.22.4.tgz",
-      "integrity": "sha512-SiWG/1TuUdPvYmzmYnmd3IEifzR61Tragkbx9D3+R8mzQqDBz8v+BvZNDlkiTtI9T15KYZhP0ehn3Dld4n9J5g==",
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.45.1.tgz",
+      "integrity": "sha512-lxV2Pako3ujjuUe9jiU3/s7KSrDfH6IgTSQOnDWr9aJ92YsFd7EurmClK0ly/t8dzMkDtd04g60WX6yl0sGfdw==",
       "cpu": [
         "ia32"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.22.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.22.4.tgz",
-      "integrity": "sha512-j8pPKp53/lq9lMXN57S8cFz0MynJk8OWNuUnXct/9KCpKU7DgU3bYMJhwWmcqC0UU29p8Lr0/7KEVcaM6bf47Q==",
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.45.1.tgz",
+      "integrity": "sha512-M/fKi4sasCdM8i0aWJjCSFm2qEnYRR8AMLG2kxp6wD13+tMGA4Z1tVAuHkNRjud5SW2EM3naLuK35w9twvf6aA==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/@shikijs/core": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.6.2.tgz",
-      "integrity": "sha512-guW5JeDzZ7uwOjTfCOFZ2VtVXk5tmkMzBYbKGfXsmAH1qYOej49L5jQDcGmwd6/OgvpmWhzO2GNJkQIFnbwLPQ=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-2.5.0.tgz",
+      "integrity": "sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/engine-javascript": "2.5.0",
+        "@shikijs/engine-oniguruma": "2.5.0",
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.4"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-2.5.0.tgz",
+      "integrity": "sha512-VjnOpnQf8WuCEZtNUdjjwGUbtAVKuZkVQ/5cHy/tojVVRIRtlWMYVjyWhxOmIq05AlSOv72z7hRNRGVBgQOl0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^3.1.0"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-2.5.0.tgz",
+      "integrity": "sha512-pGd1wRATzbo/uatrCIILlAdFVKdxImWJGQ5rFiB5VZi2ve5xj3Ax9jny8QvkaV93btQEwR/rSz5ERFpC5mKNIw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-2.5.0.tgz",
+      "integrity": "sha512-Qfrrt5OsNH5R+5tJ/3uYBBZv3SuGmnRPejV9IlIbFH3HTGLDlkqgHymAlzklVmKBjAaVmkPkyikAV/sQ1wSL+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-2.5.0.tgz",
+      "integrity": "sha512-wGrk+R8tJnO0VMzmUExHR+QdSaPUl/NKs+a4cQQRWyoc3YFbUzuLEi/KWK1hj+8BfHRKm2jNhhJck1dfstJpiw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0"
+      }
     },
     "node_modules/@shikijs/transformers": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-1.6.2.tgz",
-      "integrity": "sha512-ndqTWyHnxmsLkowhKWTam26opw8hg5a34y6FAUG/Xf6E49n3MM//nenKxXiWpPYkNPl1KZnYXB1k+Ia46wjOZg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-2.5.0.tgz",
+      "integrity": "sha512-SI494W5X60CaUwgi8u4q4m4s3YAFSxln3tzNjOSYqq54wlVgz0/NbbXEb3mdLbqMBztcmS7bVTaEd2w0qMmfeg==",
+      "license": "MIT",
       "dependencies": {
-        "shiki": "1.6.2"
+        "@shikijs/core": "2.5.0",
+        "@shikijs/types": "2.5.0"
       }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-2.5.0.tgz",
+      "integrity": "sha512-ygl5yhxki9ZLNuNpPitBWvcy9fsSKKaRuO4BAlMyagszQidxcpLAr0qiW/q43DtSIDxO6hEbtYLiFZNXO/hdGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "license": "MIT"
     },
     "node_modules/@types/d3": {
       "version": "7.4.3",
@@ -1251,9 +1523,10 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "license": "MIT"
     },
     "node_modules/@types/geojson": {
       "version": "7946.0.16",
@@ -1261,24 +1534,45 @@
       "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "license": "MIT"
     },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/linkify-it": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q=="
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "license": "MIT"
     },
     "node_modules/@types/markdown-it": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.1.tgz",
-      "integrity": "sha512-4NpsnpYl2Gt1ljyBGrKMxFYAYvpqbnnkgP/i/g+NLpjEUa3obn1XJCur9YbEXKDAkaXqsR1LbDnGEJ0MmKFxfg==",
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "license": "MIT",
       "dependencies": {
         "@types/linkify-it": "^5",
         "@types/mdurl": "^2"
       }
     },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/mdurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
-      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg=="
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "license": "MIT"
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
@@ -1287,218 +1581,211 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
     "node_modules/@types/web-bluetooth": {
-      "version": "0.0.20",
-      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.20.tgz",
-      "integrity": "sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow=="
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
+      "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "license": "ISC"
     },
     "node_modules/@vitejs/plugin-vue": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.0.5.tgz",
-      "integrity": "sha512-LOjm7XeIimLBZyzinBQ6OSm3UBCNVCpLkxGC0oWmm2YPzVZoxMsdvNVimLTBzpAnR9hl/yn1SHGuRfe6/Td9rQ==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
+      "integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
+      "license": "MIT",
       "engines": {
         "node": "^18.0.0 || >=20.0.0"
       },
       "peerDependencies": {
-        "vite": "^5.0.0",
+        "vite": "^5.0.0 || ^6.0.0",
         "vue": "^3.2.25"
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.4.30",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.30.tgz",
-      "integrity": "sha512-ZL8y4Xxdh8O6PSwfdZ1IpQ24PjTAieOz3jXb/MDTfDtANcKBMxg1KLm6OX2jofsaQGYfIVzd3BAG22i56/cF1w==",
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.17.tgz",
+      "integrity": "sha512-Xe+AittLbAyV0pabcN7cP7/BenRBNcteM4aSDCtRvGw0d9OL+HG1u/XHLY/kt1q4fyMeZYXyIYrsHuPSiDPosA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.24.7",
-        "@vue/shared": "3.4.30",
+        "@babel/parser": "^7.27.5",
+        "@vue/shared": "3.5.17",
         "entities": "^4.5.0",
         "estree-walker": "^2.0.2",
-        "source-map-js": "^1.2.0"
+        "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.4.30",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.30.tgz",
-      "integrity": "sha512-+16Sd8lYr5j/owCbr9dowcNfrHd+pz+w2/b5Lt26Oz/kB90C9yNbxQ3bYOvt7rI2bxk0nqda39hVcwDFw85c2Q==",
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.17.tgz",
+      "integrity": "sha512-+2UgfLKoaNLhgfhV5Ihnk6wB4ljyW1/7wUIog2puUqajiC29Lp5R/IKDdkebh9jTbTogTbsgB+OY9cEWzG95JQ==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-core": "3.4.30",
-        "@vue/shared": "3.4.30"
+        "@vue/compiler-core": "3.5.17",
+        "@vue/shared": "3.5.17"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.4.30",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.30.tgz",
-      "integrity": "sha512-8vElKklHn/UY8+FgUFlQrYAPbtiSB2zcgeRKW7HkpSRn/JjMRmZvuOtwDx036D1aqKNSTtXkWRfqx53Qb+HmMg==",
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.17.tgz",
+      "integrity": "sha512-rQQxbRJMgTqwRugtjw0cnyQv9cP4/4BxWfTdRBkqsTfLOHWykLzbOc3C4GGzAmdMDxhzU/1Ija5bTjMVrddqww==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.24.7",
-        "@vue/compiler-core": "3.4.30",
-        "@vue/compiler-dom": "3.4.30",
-        "@vue/compiler-ssr": "3.4.30",
-        "@vue/shared": "3.4.30",
+        "@babel/parser": "^7.27.5",
+        "@vue/compiler-core": "3.5.17",
+        "@vue/compiler-dom": "3.5.17",
+        "@vue/compiler-ssr": "3.5.17",
+        "@vue/shared": "3.5.17",
         "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.10",
-        "postcss": "^8.4.38",
-        "source-map-js": "^1.2.0"
+        "magic-string": "^0.30.17",
+        "postcss": "^8.5.6",
+        "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.4.30",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.30.tgz",
-      "integrity": "sha512-ZJ56YZGXJDd6jky4mmM0rNaNP6kIbQu9LTKZDhcpddGe/3QIalB1WHHmZ6iZfFNyj5mSypTa4+qDJa5VIuxMSg==",
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.17.tgz",
+      "integrity": "sha512-hkDbA0Q20ZzGgpj5uZjb9rBzQtIHLS78mMilwrlpWk2Ep37DYntUz0PonQ6kr113vfOEdM+zTBuJDaceNIW0tQ==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.4.30",
-        "@vue/shared": "3.4.30"
+        "@vue/compiler-dom": "3.5.17",
+        "@vue/shared": "3.5.17"
       }
     },
     "node_modules/@vue/devtools-api": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.2.1.tgz",
-      "integrity": "sha512-6oNCtyFOrNdqm6GUkFujsCgFlpbsHLnZqq7edeM/+cxAbMyCWvsaCsIMUaz7AiluKLccCGEM8fhOsjaKgBvb7g==",
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.7.tgz",
+      "integrity": "sha512-lwOnNBH2e7x1fIIbVT7yF5D+YWhqELm55/4ZKf45R9T8r9dE2AIOy8HKjfqzGsoTHFbWbr337O4E0A0QADnjBg==",
+      "license": "MIT",
       "dependencies": {
-        "@vue/devtools-kit": "^7.2.1"
+        "@vue/devtools-kit": "^7.7.7"
       }
     },
     "node_modules/@vue/devtools-kit": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.2.1.tgz",
-      "integrity": "sha512-Wak/fin1X0Q8LLIfCAHBrdaaB+R6IdpSXsDByPHbQ3BmkCP0/cIo/oEGp9i0U2+gEqD4L3V9RDjNf1S34DTzQQ==",
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.7.tgz",
+      "integrity": "sha512-wgoZtxcTta65cnZ1Q6MbAfePVFxfM+gq0saaeytoph7nEa7yMXoi6sCPy4ufO111B9msnw0VOWjPEFCXuAKRHA==",
+      "license": "MIT",
       "dependencies": {
-        "@vue/devtools-shared": "^7.2.1",
+        "@vue/devtools-shared": "^7.7.7",
+        "birpc": "^2.3.0",
         "hookable": "^5.5.3",
         "mitt": "^3.0.1",
         "perfect-debounce": "^1.0.0",
-        "speakingurl": "^14.0.1"
-      },
-      "peerDependencies": {
-        "vue": "^3.0.0"
+        "speakingurl": "^14.0.1",
+        "superjson": "^2.2.2"
       }
     },
     "node_modules/@vue/devtools-shared": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.2.1.tgz",
-      "integrity": "sha512-PCJF4UknJmOal68+X9XHyVeQ+idv0LFujkTOIW30+GaMJqwFVN9LkQKX4gLqn61KkGMdJTzQ1bt7EJag3TI6AA==",
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.7.tgz",
+      "integrity": "sha512-+udSj47aRl5aKb0memBvcUG9koarqnxNM5yjuREvqwK6T3ap4mn3Zqqc17QrBFTqSMjr3HK1cvStEZpMDpfdyw==",
+      "license": "MIT",
       "dependencies": {
-        "rfdc": "^1.3.1"
+        "rfdc": "^1.4.1"
       }
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.4.30",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.30.tgz",
-      "integrity": "sha512-bVJurnCe3LS0JII8PPoAA63Zd2MBzcKrEzwdQl92eHCcxtIbxD2fhNwJpa+KkM3Y/A4T5FUnmdhgKwOf6BfbcA==",
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.17.tgz",
+      "integrity": "sha512-l/rmw2STIscWi7SNJp708FK4Kofs97zc/5aEPQh4bOsReD/8ICuBcEmS7KGwDj5ODQLYWVN2lNibKJL1z5b+Lw==",
       "license": "MIT",
       "dependencies": {
-        "@vue/shared": "3.4.30"
+        "@vue/shared": "3.5.17"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.4.30",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.30.tgz",
-      "integrity": "sha512-qaFEbnNpGz+tlnkaualomogzN8vBLkgzK55uuWjYXbYn039eOBZrWxyXWq/7qh9Bz2FPifZqGjVDl/FXiq9L2g==",
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.17.tgz",
+      "integrity": "sha512-QQLXa20dHg1R0ri4bjKeGFKEkJA7MMBxrKo2G+gJikmumRS7PTD4BOU9FKrDQWMKowz7frJJGqBffYMgQYS96Q==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.4.30",
-        "@vue/shared": "3.4.30"
+        "@vue/reactivity": "3.5.17",
+        "@vue/shared": "3.5.17"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.4.30",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.30.tgz",
-      "integrity": "sha512-tV6B4YiZRj5QsaJgw2THCy5C1H+2UeywO9tqgWEc21tn85qHEERndHN/CxlyXvSBFrpmlexCIdnqPuR9RM9thw==",
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.17.tgz",
+      "integrity": "sha512-8El0M60TcwZ1QMz4/os2MdlQECgGoVHPuLnQBU3m9h3gdNRW9xRmI8iLS4t/22OQlOE6aJvNNlBiCzPHur4H9g==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.4.30",
-        "@vue/runtime-core": "3.4.30",
-        "@vue/shared": "3.4.30",
+        "@vue/reactivity": "3.5.17",
+        "@vue/runtime-core": "3.5.17",
+        "@vue/shared": "3.5.17",
         "csstype": "^3.1.3"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.4.30",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.30.tgz",
-      "integrity": "sha512-TBD3eqR1DeDc0cMrXS/vEs/PWzq1uXxnvjoqQuDGFIEHFIwuDTX/KWAQKIBjyMWLFHEeTDGYVsYci85z2UbTDg==",
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.17.tgz",
+      "integrity": "sha512-BOHhm8HalujY6lmC3DbqF6uXN/K00uWiEeF22LfEsm9Q93XeJ/plHTepGwf6tqFcF7GA5oGSSAAUock3VvzaCA==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-ssr": "3.4.30",
-        "@vue/shared": "3.4.30"
+        "@vue/compiler-ssr": "3.5.17",
+        "@vue/shared": "3.5.17"
       },
       "peerDependencies": {
-        "vue": "3.4.30"
+        "vue": "3.5.17"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.4.30",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.30.tgz",
-      "integrity": "sha512-CLg+f8RQCHQnKvuHY9adMsMaQOcqclh6Z5V9TaoMgy0ut0tz848joZ7/CYFFyF/yZ5i2yaw7Fn498C+CNZVHIg==",
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.17.tgz",
+      "integrity": "sha512-CabR+UN630VnsJO/jHWYBC1YVXyMq94KKp6iF5MQgZJs5I8cmjw6oVMO1oDbtBkENSHSSn/UadWlW/OAgdmKrg==",
       "license": "MIT"
     },
     "node_modules/@vueuse/core": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.10.0.tgz",
-      "integrity": "sha512-vexJ/YXYs2S42B783rI95lMt3GzEwkxzC8Hb0Ndpd8rD+p+Lk/Za4bd797Ym7yq4jXqdSyj3JLChunF/vyYjUw==",
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-12.8.2.tgz",
+      "integrity": "sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ==",
+      "license": "MIT",
       "dependencies": {
-        "@types/web-bluetooth": "^0.0.20",
-        "@vueuse/metadata": "10.10.0",
-        "@vueuse/shared": "10.10.0",
-        "vue-demi": ">=0.14.7"
+        "@types/web-bluetooth": "^0.0.21",
+        "@vueuse/metadata": "12.8.2",
+        "@vueuse/shared": "12.8.2",
+        "vue": "^3.5.13"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "node_modules/@vueuse/core/node_modules/vue-demi": {
-      "version": "0.14.8",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.8.tgz",
-      "integrity": "sha512-Uuqnk9YE9SsWeReYqK2alDI5YzciATE0r2SkA6iMAtuXvNTMNACJLJEXNXaEy94ECuBe4Sk6RzRU80kjdbIo1Q==",
-      "hasInstallScript": true,
-      "bin": {
-        "vue-demi-fix": "bin/vue-demi-fix.js",
-        "vue-demi-switch": "bin/vue-demi-switch.js"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      },
-      "peerDependencies": {
-        "@vue/composition-api": "^1.0.0-rc.1",
-        "vue": "^3.0.0-0 || ^2.6.0"
-      },
-      "peerDependenciesMeta": {
-        "@vue/composition-api": {
-          "optional": true
-        }
       }
     },
     "node_modules/@vueuse/integrations": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-10.10.0.tgz",
-      "integrity": "sha512-vHGeK7X6mkdkpcm1eE9t3Cpm21pNVfZRwrjwwbrEs9XftnSgszF4831G2rei8Dt9cIYJIfFV+iyx/29muimJPQ==",
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-12.8.2.tgz",
+      "integrity": "sha512-fbGYivgK5uBTRt7p5F3zy6VrETlV9RtZjBqd1/HxGdjdckBgBM4ugP8LHpjolqTj14TXTxSK1ZfgPbHYyGuH7g==",
+      "license": "MIT",
       "dependencies": {
-        "@vueuse/core": "10.10.0",
-        "@vueuse/shared": "10.10.0",
-        "vue-demi": ">=0.14.7"
+        "@vueuse/core": "12.8.2",
+        "@vueuse/shared": "12.8.2",
+        "vue": "^3.5.13"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       },
       "peerDependencies": {
-        "async-validator": "*",
-        "axios": "*",
-        "change-case": "*",
-        "drauu": "*",
-        "focus-trap": "*",
-        "fuse.js": "*",
-        "idb-keyval": "*",
-        "jwt-decode": "*",
-        "nprogress": "*",
-        "qrcode": "*",
-        "sortablejs": "*",
-        "universal-cookie": "*"
+        "async-validator": "^4",
+        "axios": "^1",
+        "change-case": "^5",
+        "drauu": "^0.4",
+        "focus-trap": "^7",
+        "fuse.js": "^7",
+        "idb-keyval": "^6",
+        "jwt-decode": "^4",
+        "nprogress": "^0.2",
+        "qrcode": "^1.5",
+        "sortablejs": "^1",
+        "universal-cookie": "^7"
       },
       "peerDependenciesMeta": {
         "async-validator": {
@@ -1539,73 +1826,25 @@
         }
       }
     },
-    "node_modules/@vueuse/integrations/node_modules/vue-demi": {
-      "version": "0.14.8",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.8.tgz",
-      "integrity": "sha512-Uuqnk9YE9SsWeReYqK2alDI5YzciATE0r2SkA6iMAtuXvNTMNACJLJEXNXaEy94ECuBe4Sk6RzRU80kjdbIo1Q==",
-      "hasInstallScript": true,
-      "bin": {
-        "vue-demi-fix": "bin/vue-demi-fix.js",
-        "vue-demi-switch": "bin/vue-demi-switch.js"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      },
-      "peerDependencies": {
-        "@vue/composition-api": "^1.0.0-rc.1",
-        "vue": "^3.0.0-0 || ^2.6.0"
-      },
-      "peerDependenciesMeta": {
-        "@vue/composition-api": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@vueuse/metadata": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.10.0.tgz",
-      "integrity": "sha512-UNAo2sTCAW5ge6OErPEHb5z7NEAg3XcO9Cj7OK45aZXfLLH1QkexDcZD77HBi5zvEiLOm1An+p/4b5K3Worpug==",
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-12.8.2.tgz",
+      "integrity": "sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@vueuse/shared": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.10.0.tgz",
-      "integrity": "sha512-2aW33Ac0Uk0U+9yo3Ypg9s5KcR42cuehRWl7vnUHadQyFvCktseyxxEPBi1Eiq4D2yBGACOnqLZpx1eMc7g5Og==",
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-12.8.2.tgz",
+      "integrity": "sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==",
+      "license": "MIT",
       "dependencies": {
-        "vue-demi": ">=0.14.7"
+        "vue": "^3.5.13"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "node_modules/@vueuse/shared/node_modules/vue-demi": {
-      "version": "0.14.8",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.8.tgz",
-      "integrity": "sha512-Uuqnk9YE9SsWeReYqK2alDI5YzciATE0r2SkA6iMAtuXvNTMNACJLJEXNXaEy94ECuBe4Sk6RzRU80kjdbIo1Q==",
-      "hasInstallScript": true,
-      "bin": {
-        "vue-demi-fix": "bin/vue-demi-fix.js",
-        "vue-demi-switch": "bin/vue-demi-switch.js"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      },
-      "peerDependencies": {
-        "@vue/composition-api": "^1.0.0-rc.1",
-        "vue": "^3.0.0-0 || ^2.6.0"
-      },
-      "peerDependenciesMeta": {
-        "@vue/composition-api": {
-          "optional": true
-        }
       }
     },
     "node_modules/acorn": {
@@ -1621,24 +1860,27 @@
       }
     },
     "node_modules/algoliasearch": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.22.1.tgz",
-      "integrity": "sha512-jwydKFQJKIx9kIZ8Jm44SdpigFwRGPESaxZBaHSV0XWN2yBJAOT4mT7ppvlrpA4UGzz92pqFnVKr/kaZXrcreg==",
+      "version": "5.34.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.34.0.tgz",
+      "integrity": "sha512-wioVnf/8uuG8Bmywhk5qKIQ3wzCCtmdvicPRb0fa3kKYGGoewfgDqLEaET1MV2NbTc3WGpPv+AgauLVBp1nB9A==",
+      "license": "MIT",
       "dependencies": {
-        "@algolia/cache-browser-local-storage": "4.22.1",
-        "@algolia/cache-common": "4.22.1",
-        "@algolia/cache-in-memory": "4.22.1",
-        "@algolia/client-account": "4.22.1",
-        "@algolia/client-analytics": "4.22.1",
-        "@algolia/client-common": "4.22.1",
-        "@algolia/client-personalization": "4.22.1",
-        "@algolia/client-search": "4.22.1",
-        "@algolia/logger-common": "4.22.1",
-        "@algolia/logger-console": "4.22.1",
-        "@algolia/requester-browser-xhr": "4.22.1",
-        "@algolia/requester-common": "4.22.1",
-        "@algolia/requester-node-http": "4.22.1",
-        "@algolia/transporter": "4.22.1"
+        "@algolia/client-abtesting": "5.34.0",
+        "@algolia/client-analytics": "5.34.0",
+        "@algolia/client-common": "5.34.0",
+        "@algolia/client-insights": "5.34.0",
+        "@algolia/client-personalization": "5.34.0",
+        "@algolia/client-query-suggestions": "5.34.0",
+        "@algolia/client-search": "5.34.0",
+        "@algolia/ingestion": "1.34.0",
+        "@algolia/monitoring": "1.34.0",
+        "@algolia/recommend": "5.34.0",
+        "@algolia/requester-browser-xhr": "5.34.0",
+        "@algolia/requester-fetch": "5.34.0",
+        "@algolia/requester-node-http": "5.34.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/before-after-hook": {
@@ -1647,10 +1889,49 @@
       "integrity": "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==",
       "license": "Apache-2.0"
     },
+    "node_modules/birpc": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.5.0.tgz",
+      "integrity": "sha512-VSWO/W6nNQdyP520F1mhf+Lc2f8pjGQOtoHHm7Ze8Go1kX7akpVIrtTa0fn+HB0QJEDVacl6aO08YE0PgXfdnQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
     "node_modules/cairo-tm-grammar": {
       "version": "2.6.4",
       "resolved": "git+ssh://git@github.com/software-mansion-labs/cairo-tm-grammar.git#d7902374b2f4eb5cb18b5cb8db52fb5dd154806d",
       "license": "Apache-2.0"
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/chevrotain": {
       "version": "11.0.3",
@@ -1678,6 +1959,16 @@
         "chevrotain": "^11.0.0"
       }
     },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/commander": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
@@ -1691,6 +1982,21 @@
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
       "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
       "license": "MIT"
+    },
+    "node_modules/copy-anything": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-3.0.5.tgz",
+      "integrity": "sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==",
+      "license": "MIT",
+      "dependencies": {
+        "is-what": "^4.1.8"
+      },
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
     },
     "node_modules/cose-base": {
       "version": "1.0.3",
@@ -2197,6 +2503,28 @@
         "robust-predicates": "^3.0.0"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/dompurify": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.4.tgz",
@@ -2205,6 +2533,12 @@
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
+    },
+    "node_modules/emoji-regex-xs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
+      "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
+      "license": "MIT"
     },
     "node_modules/entities": {
       "version": "4.5.0",
@@ -2223,6 +2557,7 @@
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
       "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
       "hasInstallScript": true,
+      "license": "MIT",
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -2278,9 +2613,10 @@
       "license": "MIT"
     },
     "node_modules/focus-trap": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.5.4.tgz",
-      "integrity": "sha512-N7kHdlgsO/v+iD/dMoJKtsSqs5Dz/dXZVebRgJw23LDk+jMi/974zyiOYDziY2JPp8xivq9BmUGwIJMiuSBi7w==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.5.tgz",
+      "integrity": "sha512-7Ke1jyybbbPZyZXFxEftUtxFGLMpE2n6A+z//m4CRDlj0hW+o3iYSmh8nFlYMurOiJVDmJRilUQtJr08KfIxlg==",
+      "license": "MIT",
       "dependencies": {
         "tabbable": "^6.2.0"
       }
@@ -2290,6 +2626,7 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -2316,10 +2653,57 @@
       "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
       "license": "MIT"
     },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hookable": {
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
-      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ=="
+      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+      "license": "MIT"
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
@@ -2338,6 +2722,18 @@
       "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/is-what": {
+      "version": "4.1.16",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-4.1.16.tgz",
+      "integrity": "sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
       }
     },
     "node_modules/katex": {
@@ -2418,12 +2814,12 @@
       "license": "MIT"
     },
     "node_modules/magic-string": {
-      "version": "0.30.10",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.10.tgz",
-      "integrity": "sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==",
+      "version": "0.30.17",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.4.15"
+        "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
     "node_modules/mark.js": {
@@ -2441,6 +2837,27 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.0.tgz",
+      "integrity": "sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/mermaid": {
@@ -2477,15 +2894,106 @@
       "integrity": "sha512-i1L7noDNxtFyL5DmZafWy1wRVhGehQmzZaz1HiN5e7iylJMSZR7ekOV7NsIqa5qBldlLrsKv4HbgFUVlQrz8Mw==",
       "license": "MIT"
     },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/minisearch": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-6.3.0.tgz",
-      "integrity": "sha512-ihFnidEeU8iXzcVHy74dhkxh/dn8Dc08ERl0xwoMMGqp4+LvRSCgicb+zGqWthVokQKvCSxITlh3P08OzdTYCQ=="
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.1.2.tgz",
+      "integrity": "sha512-R1Pd9eF+MD5JYDDSPAp/q1ougKglm14uEkPMvQ/05RGmx6G9wvmLTrTI/Q5iPNJLYqNdsDQ7qTGIcNWR+FrHmA==",
+      "license": "MIT"
     },
     "node_modules/mitt": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
-      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
     },
     "node_modules/mlly": {
       "version": "1.7.4",
@@ -2506,9 +3014,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
-      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "funding": [
         {
           "type": "github",
@@ -2528,6 +3036,17 @@
       "resolved": "https://registry.npmjs.org/non-layered-tidy-tree-layout/-/non-layered-tidy-tree-layout-2.0.2.tgz",
       "integrity": "sha512-gkXMxRzUH+PB0ax9dUN0yYF0S25BqeAYqhgMaLUFmpXLEk7Fcu8f4emJuOAY0V8kjDICxROIKsTAKsV/v355xw==",
       "optional": true
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-3.1.1.tgz",
+      "integrity": "sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex-xs": "^1.0.0",
+        "regex": "^6.0.1",
+        "regex-recursion": "^6.0.2"
+      }
     },
     "node_modules/package-manager-detector": {
       "version": "0.2.9",
@@ -2550,12 +3069,14 @@
     "node_modules/perfect-debounce": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
-      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA=="
+      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "license": "MIT"
     },
     "node_modules/picocolors": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
-      "integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
     },
     "node_modules/pkg-types": {
       "version": "1.3.1",
@@ -2585,9 +3106,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.47",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz",
-      "integrity": "sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==",
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
       "funding": [
         {
           "type": "opencollective",
@@ -2602,9 +3123,10 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.7",
-        "picocolors": "^1.1.0",
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
       "engines": {
@@ -2612,18 +3134,19 @@
       }
     },
     "node_modules/preact": {
-      "version": "10.20.0",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.20.0.tgz",
-      "integrity": "sha512-wU7iZw2BjsaKDal3pDRDy/HpPB6cuFOnVUCcw9aIPKG98+ZrXx3F+szkos8BVME5bquyKDKvRlOJFG8kMkcAbg==",
+      "version": "10.26.9",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.26.9.tgz",
+      "integrity": "sha512-SSjF9vcnF27mJK1XyFMNJzFd5u3pQiATFqoaDy03XuN00u4ziveVVEGt5RKJrDR8MHE/wJo9Nnad56RLzS2RMA==",
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
       }
     },
     "node_modules/prettier": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.2.tgz",
-      "integrity": "sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -2635,10 +3158,45 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/regex": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.0.1.tgz",
+      "integrity": "sha512-uorlqlzAKjKQZ5P+kTJr3eeJGSVroLKoHmquUj4zHWuR+hEyNqlXsSKlYYF5F4NI6nl7tWCs0apKJ0lmfsXAPA==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "license": "MIT"
+    },
     "node_modules/rfdc": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.1.tgz",
-      "integrity": "sha512-r5a3l5HzYlIC68TpmYKlxWjmOP6wiPJ1vWv2HeLhNsRZMrCkxeqxiHlQ21oXmQ4F3SiryXBHhAD7JZqvOJjFmg=="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "license": "MIT"
     },
     "node_modules/robust-predicates": {
       "version": "3.0.2",
@@ -2646,11 +3204,12 @@
       "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg=="
     },
     "node_modules/rollup": {
-      "version": "4.22.4",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.22.4.tgz",
-      "integrity": "sha512-vD8HJ5raRcWOyymsR6Z3o6+RzfEPCnVLMFJ6vRslO1jt4LO6dUo5Qnpg7y4RkZFM2DMe3WUirkI5c16onjrc6A==",
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.45.1.tgz",
+      "integrity": "sha512-4iya7Jb76fVpQyLoiVpzUrsjQ12r3dM7fIVz+4NwoYvZOShknRmiv+iu9CClZml5ZLGb0XMcYLutK6w9tgxHDw==",
+      "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.5"
+        "@types/estree": "1.0.8"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -2660,22 +3219,26 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.22.4",
-        "@rollup/rollup-android-arm64": "4.22.4",
-        "@rollup/rollup-darwin-arm64": "4.22.4",
-        "@rollup/rollup-darwin-x64": "4.22.4",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.22.4",
-        "@rollup/rollup-linux-arm-musleabihf": "4.22.4",
-        "@rollup/rollup-linux-arm64-gnu": "4.22.4",
-        "@rollup/rollup-linux-arm64-musl": "4.22.4",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.22.4",
-        "@rollup/rollup-linux-riscv64-gnu": "4.22.4",
-        "@rollup/rollup-linux-s390x-gnu": "4.22.4",
-        "@rollup/rollup-linux-x64-gnu": "4.22.4",
-        "@rollup/rollup-linux-x64-musl": "4.22.4",
-        "@rollup/rollup-win32-arm64-msvc": "4.22.4",
-        "@rollup/rollup-win32-ia32-msvc": "4.22.4",
-        "@rollup/rollup-win32-x64-msvc": "4.22.4",
+        "@rollup/rollup-android-arm-eabi": "4.45.1",
+        "@rollup/rollup-android-arm64": "4.45.1",
+        "@rollup/rollup-darwin-arm64": "4.45.1",
+        "@rollup/rollup-darwin-x64": "4.45.1",
+        "@rollup/rollup-freebsd-arm64": "4.45.1",
+        "@rollup/rollup-freebsd-x64": "4.45.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.45.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.45.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.45.1",
+        "@rollup/rollup-linux-arm64-musl": "4.45.1",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.45.1",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.45.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.45.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.45.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.45.1",
+        "@rollup/rollup-linux-x64-gnu": "4.45.1",
+        "@rollup/rollup-linux-x64-musl": "4.45.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.45.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.45.1",
+        "@rollup/rollup-win32-x64-msvc": "4.45.1",
         "fsevents": "~2.3.2"
       }
     },
@@ -2702,9 +3265,10 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/search-insights": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.13.0.tgz",
-      "integrity": "sha512-Orrsjf9trHHxFRuo9/rzm0KIWmgzE8RMlZMzuhZOJ01Rnz3D0YBAe+V6473t6/H6c7irs6Lt48brULAiRWb3Vw==",
+      "version": "2.17.3",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
+      "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/semver": {
@@ -2719,11 +3283,19 @@
       }
     },
     "node_modules/shiki": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.6.2.tgz",
-      "integrity": "sha512-X3hSm5GzzBd/BmPmGfkueOUADLyBoZo1ojYQXhd+NU2VJn458yt4duaS0rVzC+WtqftSV7mTVvDw+OB9AHi3Eg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-2.5.0.tgz",
+      "integrity": "sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ==",
+      "license": "MIT",
       "dependencies": {
-        "@shikijs/core": "1.6.2"
+        "@shikijs/core": "2.5.0",
+        "@shikijs/engine-javascript": "2.5.0",
+        "@shikijs/engine-oniguruma": "2.5.0",
+        "@shikijs/langs": "2.5.0",
+        "@shikijs/themes": "2.5.0",
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
       }
     },
     "node_modules/source-map-js": {
@@ -2734,12 +3306,37 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/speakingurl": {
       "version": "14.0.1",
       "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
       "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/stylis": {
@@ -2748,16 +3345,39 @@
       "integrity": "sha512-osIBl6BGUmSfDkyH2mB7EFvCJntXDrLhKjHTRj/rK6xLH0yuPrHULDRQzKokSOD4VoorhtKpfcfW1GAntu8now==",
       "license": "MIT"
     },
+    "node_modules/superjson": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.2.tgz",
+      "integrity": "sha512-5JRxVqC8I8NuOUjzBbvVJAKNM8qoVuH0O77h4WInc/qC2q5IreqKxYwgkga3PfA22OayK2ikceb/B26dztPl+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "copy-anything": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/tabbable": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
-      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
+      "license": "MIT"
     },
     "node_modules/tinyexec": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
       "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
       "license": "MIT"
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/ts-dedent": {
       "version": "2.2.0",
@@ -2772,6 +3392,74 @@
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.5.4.tgz",
       "integrity": "sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ==",
       "license": "MIT"
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+      "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+      "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
+      "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/universal-user-agent": {
       "version": "7.0.2",
@@ -2790,6 +3478,34 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
+      "integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/vite": {
@@ -2852,26 +3568,29 @@
       }
     },
     "node_modules/vitepress": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.2.3.tgz",
-      "integrity": "sha512-GvEsrEeNLiDE1+fuwDAYJCYLNZDAna+EtnXlPajhv/MYeTjbNK6Bvyg6NoTdO1sbwuQJ0vuJR99bOlH53bo6lg==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.6.3.tgz",
+      "integrity": "sha512-fCkfdOk8yRZT8GD9BFqusW3+GggWYZ/rYncOfmgcDtP3ualNHCAg+Robxp2/6xfH1WwPHtGpPwv7mbA3qomtBw==",
+      "license": "MIT",
       "dependencies": {
-        "@docsearch/css": "^3.6.0",
-        "@docsearch/js": "^3.6.0",
-        "@shikijs/core": "^1.6.2",
-        "@shikijs/transformers": "^1.6.2",
-        "@types/markdown-it": "^14.1.1",
-        "@vitejs/plugin-vue": "^5.0.5",
-        "@vue/devtools-api": "^7.2.1",
-        "@vue/shared": "^3.4.27",
-        "@vueuse/core": "^10.10.0",
-        "@vueuse/integrations": "^10.10.0",
-        "focus-trap": "^7.5.4",
+        "@docsearch/css": "3.8.2",
+        "@docsearch/js": "3.8.2",
+        "@iconify-json/simple-icons": "^1.2.21",
+        "@shikijs/core": "^2.1.0",
+        "@shikijs/transformers": "^2.1.0",
+        "@shikijs/types": "^2.1.0",
+        "@types/markdown-it": "^14.1.2",
+        "@vitejs/plugin-vue": "^5.2.1",
+        "@vue/devtools-api": "^7.7.0",
+        "@vue/shared": "^3.5.13",
+        "@vueuse/core": "^12.4.0",
+        "@vueuse/integrations": "^12.4.0",
+        "focus-trap": "^7.6.4",
         "mark.js": "8.11.1",
-        "minisearch": "^6.3.0",
-        "shiki": "^1.6.2",
-        "vite": "^5.2.12",
-        "vue": "^3.4.27"
+        "minisearch": "^7.1.1",
+        "shiki": "^2.1.0",
+        "vite": "^5.4.14",
+        "vue": "^3.5.13"
       },
       "bin": {
         "vitepress": "bin/vitepress.js"
@@ -2952,16 +3671,16 @@
       "license": "MIT"
     },
     "node_modules/vue": {
-      "version": "3.4.30",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.30.tgz",
-      "integrity": "sha512-NcxtKCwkdf1zPsr7Y8+QlDBCGqxvjLXF2EX+yi76rV5rrz90Y6gK1cq0olIhdWGgrlhs9ElHuhi9t3+W5sG5Xw==",
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.17.tgz",
+      "integrity": "sha512-LbHV3xPN9BeljML+Xctq4lbz2lVHCR6DtbpTf5XIO6gugpXUN49j2QQPcMj086r9+AkJ0FfUT8xjulKKBkkr9g==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.4.30",
-        "@vue/compiler-sfc": "3.4.30",
-        "@vue/runtime-dom": "3.4.30",
-        "@vue/server-renderer": "3.4.30",
-        "@vue/shared": "3.4.30"
+        "@vue/compiler-dom": "3.5.17",
+        "@vue/compiler-sfc": "3.5.17",
+        "@vue/runtime-dom": "3.5.17",
+        "@vue/server-renderer": "3.5.17",
+        "@vue/shared": "3.5.17"
       },
       "peerDependencies": {
         "typescript": "*"
@@ -2970,6 +3689,16 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/website/package.json
+++ b/website/package.json
@@ -14,10 +14,10 @@
     "@octokit/core": "6.1.4",
     "cairo-tm-grammar": "github:software-mansion-labs/cairo-tm-grammar",
     "mermaid": "11.4.1",
-    "prettier": "3.3.2",
+    "prettier": "3.6.2",
     "semver": "7.6.2",
-    "vitepress": "1.2.3",
+    "vitepress": "1.6.3",
     "vitepress-plugin-mermaid": "2.0.17",
-    "vue": "3.4.30"
+    "vue": "3.5.17"
   }
 }


### PR DESCRIPTION
- **Set dev inlining strategy to avoid**
- **Update test expectations**
- **Prepare release `2.12.0-rc.2`**
- **upgrade vitepress, vue and prettier (#2423)**
- **add oracle docs (#2421)**
- **fix markdown in creating-executable-package.md (#2433)**
- **Change error message and add a warning for executable target (#2436)**
- **Snforge-scarb-plugin fingerprint hack (#2441)**
- **Save fingerprint digests on the first calculation (#2442)**
- **Fix ScarbCommand error message on Scarb exiting with error (#2453)**
- **Prepare `scarb-metadata` release `v1.15.1` (#2454)**
- **Set release as alias for default in inlining-strategy deserializer (#2457)**
- **Bump deno_task_shell from 0.25.2 to 0.25.3 (#2460)**
- **Rewrite token stream spans to start at zero, for optimized get_text method (#2448)**
- **Update docs for inlining-strategy**
- **Prepare release `2.12.0-rc.3`**
