### PR TITLE
Refactor file lock guards

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2645,18 +2645,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs4"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f9df8a11882c4e3335eb2d18a0137c505d9ca927470b0cac9c6f0ae07d28f7"
-dependencies = [
- "async-trait",
- "rustix 0.38.44",
- "tokio",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3256,7 +3244,7 @@ dependencies = [
  "itoa",
  "libc",
  "memmap2",
- "rustix 1.0.8",
+ "rustix",
  "smallvec",
  "thiserror 2.0.12",
 ]
@@ -3423,7 +3411,7 @@ dependencies = [
  "gix-command",
  "gix-config-value",
  "parking_lot",
- "rustix 1.0.8",
+ "rustix",
  "thiserror 2.0.12",
 ]
 
@@ -4715,12 +4703,6 @@ dependencies = [
  "quote",
  "syn 2.0.104",
 ]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -6342,19 +6324,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags 2.9.1",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
@@ -6362,7 +6331,7 @@ dependencies = [
  "bitflags 2.9.1",
  "errno",
  "libc",
- "linux-raw-sys 0.9.4",
+ "linux-raw-sys",
  "windows-sys 0.60.2",
 ]
 
@@ -6475,7 +6444,6 @@ dependencies = [
  "dunce",
  "expect-test",
  "flate2",
- "fs4",
  "fs_extra",
  "futures",
  "gix",
@@ -7860,7 +7828,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
- "rustix 1.0.8",
+ "rustix",
  "windows-sys 0.59.0",
 ]
 
@@ -7899,7 +7867,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
 dependencies = [
- "rustix 1.0.8",
+ "rustix",
  "windows-sys 0.59.0",
 ]
 
@@ -8889,7 +8857,7 @@ checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
 dependencies = [
  "either",
  "env_home",
- "rustix 1.0.8",
+ "rustix",
  "winsafe",
 ]
 
@@ -8900,7 +8868,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
 dependencies = [
  "env_home",
- "rustix 1.0.8",
+ "rustix",
  "winsafe",
 ]
 
@@ -9271,7 +9239,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af3a19837351dc82ba89f8a125e22a3c475f05aba604acc023d62b2739ae2909"
 dependencies = [
  "libc",
- "rustix 1.0.8",
+ "rustix",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,6 @@ directories = "5"
 dunce = "1"
 expect-test = "1.5"
 flate2 = { version = "1.1.2", default-features = false, features = ["zlib"] }
-fs4 = { version = "0.7", features = ["tokio"] }
 fs_extra = "1"
 futures = { version = "0.3", default-features = false, features = ["std", "async-await", "executor"] }
 gix = ">=0.55"

--- a/scarb/Cargo.toml
+++ b/scarb/Cargo.toml
@@ -53,7 +53,6 @@ dialoguer.workspace = true
 directories.workspace = true
 dunce.workspace = true
 flate2.workspace = true
-fs4.workspace = true
 futures.workspace = true
 gix-path.workspace = true
 gix.workspace = true

--- a/scarb/src/core/registry/client/http.rs
+++ b/scarb/src/core/registry/client/http.rs
@@ -23,7 +23,7 @@ use crate::core::registry::client::{
 };
 use crate::core::registry::index::{IndexConfig, IndexRecords};
 use crate::core::{Config, Package, PackageId, PackageName, SourceId};
-use crate::flock::{FileLockGuard, Filesystem};
+use crate::flock::{Filesystem, LockedFile};
 
 // TODO(mkaput): Progressbar.
 
@@ -112,7 +112,7 @@ impl RegistryClient for HttpRegistryClient<'_> {
         &self,
         package: PackageId,
         create_scratch_file: CreateScratchFileCallback,
-    ) -> Result<RegistryDownload<FileLockGuard>> {
+    ) -> Result<RegistryDownload<LockedFile>> {
         let index_config = self.index_config.load().await?;
         let dl_url = index_config.dl.expand(package.into())?;
 
@@ -152,7 +152,7 @@ impl RegistryClient for HttpRegistryClient<'_> {
         Ok(self.index_config.load().await?.upload.is_some())
     }
 
-    async fn publish(&self, package: Package, tarball: FileLockGuard) -> Result<RegistryUpload> {
+    async fn publish(&self, package: Package, tarball: LockedFile) -> Result<RegistryUpload> {
         let auth_token = env::var("SCARB_REGISTRY_AUTH_TOKEN").map_err(|_| {
             anyhow!(
                 "missing authentication token. \

--- a/scarb/src/core/registry/client/local.rs
+++ b/scarb/src/core/registry/client/local.rs
@@ -6,7 +6,6 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Error, Result, ensure};
 use async_trait::async_trait;
-use fs4::FileExt;
 use tokio::task::spawn_blocking;
 use tracing::trace;
 use url::Url;
@@ -218,7 +217,7 @@ fn edit_records(records_path: &Path, func: impl FnOnce(&mut IndexRecords)) -> Re
         .open(records_path)
         .context("failed to open file")?;
 
-    file.lock_exclusive()
+    file.lock()
         .context("failed to acquire exclusive file access")?;
 
     let is_empty = file.metadata().context("failed to read metadata")?.len() == 0;

--- a/scarb/src/core/registry/client/local.rs
+++ b/scarb/src/core/registry/client/local.rs
@@ -15,7 +15,7 @@ use crate::core::registry::client::{
 };
 use crate::core::registry::index::{IndexDependency, IndexRecord, IndexRecords, TemplateUrl};
 use crate::core::{Checksum, Config, Digest, Package, PackageId, PackageName, Summary};
-use crate::flock::{FileLockGuard, Filesystem};
+use crate::flock::{Filesystem, LockedFile};
 use crate::internal::fsx;
 use crate::internal::fsx::PathBufUtf8Ext;
 
@@ -132,7 +132,7 @@ impl RegistryClient for LocalRegistryClient<'_> {
         &self,
         package: PackageId,
         _: CreateScratchFileCallback,
-    ) -> Result<RegistryDownload<FileLockGuard>> {
+    ) -> Result<RegistryDownload<LockedFile>> {
         let dl_path = self.dl_path(package).try_into_utf8()?;
         let base_path = dl_path
             .parent()
@@ -150,7 +150,7 @@ impl RegistryClient for LocalRegistryClient<'_> {
         Ok(true)
     }
 
-    async fn publish(&self, package: Package, tarball: FileLockGuard) -> Result<RegistryUpload> {
+    async fn publish(&self, package: Package, tarball: LockedFile) -> Result<RegistryUpload> {
         let summary = package.manifest.summary.clone();
         let records_path = self.records_path(&summary.package_id.name);
         let dl_path = self.dl_path(summary.package_id);
@@ -163,7 +163,7 @@ impl RegistryClient for LocalRegistryClient<'_> {
 
 fn publish_impl(
     summary: Summary,
-    tarball: FileLockGuard,
+    tarball: LockedFile,
     records_path: PathBuf,
     dl_path: PathBuf,
 ) -> Result<RegistryUpload, Error> {

--- a/scarb/src/core/registry/client/mod.rs
+++ b/scarb/src/core/registry/client/mod.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 
 use crate::core::registry::index::IndexRecords;
 use crate::core::{Config, Package, PackageId, PackageName};
-use crate::flock::FileLockGuard;
+use crate::flock::LockedFile;
 
 pub mod cache;
 pub mod http;
@@ -42,7 +42,7 @@ pub enum RegistryUpload {
     Success,
 }
 
-pub type CreateScratchFileCallback = Box<dyn FnOnce(&Config) -> Result<FileLockGuard> + Send>;
+pub type CreateScratchFileCallback = Box<dyn FnOnce(&Config) -> Result<LockedFile> + Send>;
 
 #[async_trait]
 pub trait RegistryClient: Send + Sync {
@@ -62,7 +62,7 @@ pub trait RegistryClient: Send + Sync {
 
     /// Download the package `.tar.zst` file.
     ///
-    /// Returns a [`FileLockGuard`] to the downloaded `.tar.zst` file.
+    /// Returns a [`LockedFile`] to the downloaded `.tar.zst` file.
     ///
     /// ## Callbacks
     ///
@@ -80,7 +80,7 @@ pub trait RegistryClient: Send + Sync {
         &self,
         package: PackageId,
         create_scratch_file: CreateScratchFileCallback,
-    ) -> Result<RegistryDownload<FileLockGuard>>;
+    ) -> Result<RegistryDownload<LockedFile>>;
 
     /// State whether packages can be published to this registry.
     ///
@@ -97,5 +97,5 @@ pub trait RegistryClient: Send + Sync {
     /// The `package` argument must correspond to just packaged `tarball` file.
     /// The client is free to use information within `package` to send to the registry.
     /// Package source is not required to match the registry the package is published to.
-    async fn publish(&self, package: Package, tarball: FileLockGuard) -> Result<RegistryUpload>;
+    async fn publish(&self, package: Package, tarball: LockedFile) -> Result<RegistryUpload>;
 }

--- a/scarb/src/flock.rs
+++ b/scarb/src/flock.rs
@@ -23,6 +23,10 @@ pub enum FileLockKind {
     Exclusive,
 }
 
+/// Represents a file that has been locked for exclusive or shared access.
+///
+/// The struct holds both the locked file handle and the path to the file.
+/// The file becomes unlocked when this object is dropped.
 #[derive(Debug)]
 pub struct LockedFile {
     // NOTE: File will become unlocked when this structure is dropped.
@@ -79,6 +83,7 @@ impl DerefMut for LockedFile {
     }
 }
 
+/// An async version of [`LockedFile`].
 #[derive(Debug)]
 pub struct AsyncLockedFile {
     // NOTE: File will become unlocked when this structure is dropped.
@@ -125,7 +130,7 @@ pub struct AdvisoryLock<'f> {
     description: String,
     file_lock: Mutex<
         // This Arc is shared between all guards within the process.
-        // Here it is Weak, because AdvisoryLock itself does not keep the lock
+        // Here it is Weak because AdvisoryLock itself doesn't keep the lock
         // (only guards do).
         Weak<LockedFile>,
     >,
@@ -142,7 +147,7 @@ impl AdvisoryLock<'_> {
     ///
     /// This lock is global per-process and can be acquired recursively.
     /// An RAII structure is returned to release the lock, and if this process abnormally
-    /// terminates the lock is also released.
+    /// terminates, the lock is also released.
     pub async fn acquire_async(&self) -> Result<AdvisoryLockGuard> {
         let mut slot = self.file_lock.lock().await;
 
@@ -153,7 +158,7 @@ impl AdvisoryLock<'_> {
                 let path = self.path.clone();
                 let description = self.description.clone();
 
-                // HACK: We know that we will not use &Config outside scope of this function,
+                // HACK: We know that we will not use &Config outside the scope of this function,
                 //   but `tokio::spawn_blocking` lifetime bounds force us to think so.
                 let config: &'static Config = unsafe { mem::transmute(self.config) };
                 let lock = tokio::task::spawn_blocking(move || {
@@ -173,7 +178,7 @@ impl AdvisoryLock<'_> {
 
 /// A [`Filesystem`] is intended to be a globally shared, hence locked, resource in Scarb.
 ///
-/// The [`Utf8Path`] of a file system cannot be learned unless it's done in a locked fashion,
+/// The [`Utf8Path`] of a file system can't be learned unless it is done in a locked fashion,
 /// and otherwise functions on this structure are prepared to handle concurrent invocations across
 /// multiple instances of Scarb and its extensions.
 ///
@@ -193,7 +198,7 @@ impl Filesystem {
 
     /// Creates a new [`Filesystem`] to be rooted at the given path.
     ///
-    /// This variant uses [`create_output_dir::create_output_dir`] function to create root
+    /// This variant uses [`create_output_dir::create_output_dir`] function to create the root
     /// directory.
     pub fn new_output_dir(root: Utf8PathBuf) -> Self {
         Self {
@@ -217,12 +222,12 @@ impl Filesystem {
         }
     }
 
-    /// Get path to this [`Filesystem`] root without ensuring the path exists.
+    /// Get a path to this [`Filesystem`] root without ensuring the path exists.
     pub fn path_unchecked(&self) -> &Utf8Path {
         self.root.as_unchecked()
     }
 
-    /// Get path to this [`Filesystem`] root, ensuring the path exists.
+    /// Get a path to this [`Filesystem`] root, ensuring the path exists.
     pub fn path_existent(&self) -> Result<&Utf8Path> {
         self.root.as_existent()
     }
@@ -235,9 +240,9 @@ impl Filesystem {
     /// Opens exclusive access to a [`File`], returning the locked version of it.
     ///
     /// This function will create a file at `path` if it doesn't already exist (including
-    /// intermediate directories) else if it does exist, it will be truncated. It will then acquire
+    /// intermediate directories), else if it does exist, it will be truncated. It will then acquire
     /// an exclusive lock on `path`. If the process must block waiting for the lock, the
-    /// `description` annotated with _blocking_ status message is printed to [`Config::ui`].
+    /// `description` annotated with a _blocking_ status message is printed to [`Config::ui`].
     ///
     /// The returned file can be accessed to look at the path and also has read/write access to
     /// the underlying file.
@@ -262,10 +267,10 @@ impl Filesystem {
 
     /// Opens shared access to a [`File`], returning the locked version of it.
     ///
-    /// This function will fail if `path` doesn't already exist, but if it does then it will
+    /// This function will fail if `path` doesn't already exist, but if it does, then it will
     /// acquire a shared lock on `path`.
-    /// If the process must block waiting for the lock, the `description` annotated with _blocking_
-    /// status message is printed to [`Config::ui`].
+    /// If the process must block waiting for the lock, the `description` annotated with
+    /// a _blocking_ status message is printed to [`Config::ui`].
     ///
     /// The returned file can be accessed to look at the path and also has read
     /// access to the underlying file.
@@ -287,10 +292,10 @@ impl Filesystem {
 
     /// Opens exclusive access to a [`File`], returning the locked version of it.
     ///
-    /// This function will fail if `path` doesn't already exist, but if it does then it will
+    /// This function will fail if `path` doesn't already exist, but if it does, then it will
     /// acquire an exclusive lock on `path`.
-    /// If the process must block waiting for the lock, the `description` annotated with _blocking_
-    /// status message is printed to [`Config::ui`].
+    /// If the process must block waiting for the lock, the `description` annotated with
+    /// a _blocking_ status message is printed to [`Config::ui`].
     ///
     /// The returned file can be accessed to look at the path and also has read
     /// access to the underlying file.
@@ -373,8 +378,8 @@ impl Filesystem {
     /// Remove the directory underlying this filesystem and create it again.
     ///
     /// # Safety
-    /// This is very simple internal method meant to be used in very specific use-cases, so its
-    /// implementation does not handle all cases.
+    /// This is a very simple internal method meant to be used in very specific use-cases, so its
+    /// implementation doesn't handle all cases.
     /// 1. Panics if this is an output filesystem.
     /// 2. Child filesystems will stop working properly after recreation.
     pub(crate) unsafe fn recreate(&self) -> Result<()> {
@@ -395,7 +400,7 @@ impl Filesystem {
         self.path_unchecked().join(OK_FILE).exists()
     }
 
-    /// Marks this filesystem as being properly set up (whatever this means is up to user),
+    /// Marks this filesystem as being properly set up (whatever this means is up to the user),
     /// by creating a `.scarb-ok` file.
     pub fn mark_ok(&self) -> Result<()> {
         let _ = fsx::create(self.path_existent()?.join(OK_FILE))?;
@@ -417,17 +422,17 @@ impl fmt::Debug for Filesystem {
     }
 }
 
-/// The following sequence of if statements & advisory locks implements a file system-based
-/// mutex, that synchronizes extraction logic. The first condition checks if extraction has
+/// The following sequence of if statements and advisory locks implements a file-system-based
+/// mutex that synchronises extraction logic. The first condition checks if extraction has
 /// happened in the past. If not, then we acquire the advisory lock (which means waiting for
-/// our time slice to do the job). Successful lock acquisition does not mean though that we
+/// our time slice to do the job). Successful lock acquisition doesn't mean, though, that we
 /// still have to perform the extraction! While we waited for our time slice, another process
 /// could just do the extraction! The second condition prevents repeating the work.
 ///
-/// This is actually very important for correctness. The another process that performed
-/// the extraction, will highly probably soon try to read the extracted files. If we recreate
-/// the filesystem now, we will cause that process to crash. That's what happened on Windows
-/// in examples tests, when the second condition was missing.
+/// This is actually very important for correctness. Another process that performed the extraction
+/// will highly probably soon try to read the extracted files. If we recreate the filesystem now,
+/// we will cause that process to crash. That is what happened on Windows in example tests
+/// when the second condition was missing.
 macro_rules! protected_run_if_not_ok {
     ($fs:expr, $lock:expr, $body:block) => {{
         let fs: &$crate::flock::Filesystem = $fs;

--- a/scarb/src/ops/lockfile.rs
+++ b/scarb/src/ops/lockfile.rs
@@ -16,7 +16,7 @@ pub fn read_lockfile(ws: &Workspace<'_>) -> Result<Lockfile> {
         .open(ws.lockfile_path())
         .context("failed to open lockfile")?;
 
-    file.lock()
+    file.lock_shared()
         .context("failed to acquire shared lockfile access")?;
 
     let mut content = String::new();

--- a/scarb/src/ops/lockfile.rs
+++ b/scarb/src/ops/lockfile.rs
@@ -2,7 +2,6 @@ use crate::core::Workspace;
 use crate::core::lockfile::Lockfile;
 use anyhow::{Context, Result};
 use camino::Utf8PathBuf;
-use fs4::FileExt;
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Write};
 use std::str::FromStr;
@@ -17,7 +16,8 @@ pub fn read_lockfile(ws: &Workspace<'_>) -> Result<Lockfile> {
         .open(ws.lockfile_path())
         .context("failed to open lockfile")?;
 
-    FileExt::lock_shared(&file).context("failed to acquire shared lockfile access")?;
+    file.lock()
+        .context("failed to acquire shared lockfile access")?;
 
     let mut content = String::new();
     file.read_to_string(&mut content)?;
@@ -29,7 +29,7 @@ pub fn read_lockfile(ws: &Workspace<'_>) -> Result<Lockfile> {
 pub async fn write_lockfile(lockfile: Lockfile, lockfile_path: Utf8PathBuf) -> Result<()> {
     let mut file = File::create(lockfile_path).context("failed to create lockfile")?;
 
-    file.lock_exclusive()
+    file.lock()
         .context("failed to acquire exclusive lockfile access")?;
 
     file.write_all(lockfile.render()?.as_bytes())

--- a/scarb/src/ops/package.rs
+++ b/scarb/src/ops/package.rs
@@ -20,7 +20,7 @@ use crate::compiler::plugin::proc_macro::compilation::{
 use crate::core::publishing::manifest_normalization::prepare_manifest_for_publish;
 use crate::core::publishing::source::list_source_files;
 use crate::core::{Config, Package, PackageId, PackageName, Target, TargetKind, Workspace};
-use crate::flock::{FileLockGuard, Filesystem};
+use crate::flock::{Filesystem, LockedFile};
 use crate::internal::restricted_names;
 use crate::{
     CARGO_LOCKFILE_FILE_NAME, CARGO_MANIFEST_FILE_NAME, DEFAULT_LICENSE_FILE_NAME,
@@ -79,7 +79,7 @@ pub fn package(
     packages: &[PackageId],
     opts: &PackageOpts,
     ws: &Workspace<'_>,
-) -> Result<Vec<FileLockGuard>> {
+) -> Result<Vec<LockedFile>> {
     before_package(ws)?;
 
     packages
@@ -92,7 +92,7 @@ pub fn package_one(
     package_id: PackageId,
     opts: &PackageOpts,
     ws: &Workspace<'_>,
-) -> Result<FileLockGuard> {
+) -> Result<LockedFile> {
     package(&[package_id], opts, ws).map(|mut v| v.pop().unwrap())
 }
 
@@ -158,7 +158,7 @@ fn package_one_impl(
     pkg_id: PackageId,
     opts: &PackageOpts,
     ws: &Workspace<'_>,
-) -> Result<FileLockGuard> {
+) -> Result<LockedFile> {
     let pkg = ws.fetch_package(&pkg_id)?;
 
     ws.config()
@@ -410,11 +410,11 @@ fn prepare_archive_recipe(
 
 fn run_verify(
     pkg: &Package,
-    tar: FileLockGuard,
+    tar: LockedFile,
     ws: &Workspace<'_>,
     features: ops::FeaturesOpts,
     ignore_cairo_version: bool,
-) -> Result<FileLockGuard> {
+) -> Result<LockedFile> {
     ws.config()
         .ui()
         .print(Status::new("Verifying", &pkg.id.tarball_name()));

--- a/scarb/src/sources/registry.rs
+++ b/scarb/src/sources/registry.rs
@@ -17,7 +17,7 @@ use crate::core::{
     Checksum, Config, DependencyVersionReq, ManifestDependency, Package, PackageId, SourceId,
     Summary,
 };
-use crate::flock::FileLockGuard;
+use crate::flock::LockedFile;
 use crate::sources::PathSource;
 use std::collections::HashSet;
 
@@ -156,7 +156,7 @@ impl RegistrySource<'_> {
     async fn load_package(
         &self,
         id: PackageId,
-        archive: FileLockGuard,
+        archive: LockedFile,
         checksum: Checksum,
     ) -> Result<Package> {
         self.config


### PR DESCRIPTION
1. Rust 1.89.0 brought all features that we used from fs4 into std 🎉
2. It turns out we don't have to explicitly unlock files because they are going to already be unlocked then the file is closed - which happens when we drop guards.
3. Renamed `(Async)FileLockGuard` to `(Async)LockedFile` because it's better naming now