### PR TITLE
implement incremental cache for scarb lint

### DIFF
--- a/scarb/src/compiler/incremental/compilation.rs
+++ b/scarb/src/compiler/incremental/compilation.rs
@@ -182,7 +182,7 @@ pub fn save_incremental_artifacts(
 }
 
 #[tracing::instrument(skip_all, level = "trace")]
-fn save_component_cache(
+pub(crate) fn save_component_cache(
     fingerprint: &Fingerprint,
     db: &dyn LoweringGroup,
     unit: &CairoCompilationUnit,
@@ -235,7 +235,7 @@ fn save_component_cache(
     Ok(())
 }
 
-trait IncrementalArtifactsProvider {
+pub(crate) trait IncrementalArtifactsProvider {
     fn fingerprint_dirname(&self, fingerprint: &Fingerprint) -> String;
 
     fn cache_filename(&self, fingerprint: &Fingerprint) -> String;

--- a/scarb/src/compiler/incremental/mod.rs
+++ b/scarb/src/compiler/incremental/mod.rs
@@ -1,5 +1,5 @@
-mod compilation;
-mod fingerprint;
+pub(crate) mod compilation;
+pub(crate) mod fingerprint;
 mod source;
 
 pub use compilation::{load_incremental_artifacts, save_incremental_artifacts};


### PR DESCRIPTION
closes https://github.com/software-mansion/scarb/issues/2452

scarb lint profiling results for comparison 👇 
- [before_changes.json](https://github.com/user-attachments/files/21860175/before_changes.json)
- [nothing_cached.json](https://github.com/user-attachments/files/21860177/nothing_cached.json)
- [with_cached_deps.json](https://github.com/user-attachments/files/21860188/with_cached_deps.json)

This is not ideal how the repetitive code grows for `LinterAnalysisDatabase` and `RootDatabase` so see proposed solution 👉  [next in stack ](https://github.com/software-mansion/scarb/pull/2542)

