### PR TITLE
Make proc macros expand first

### DIFF
--- a/scarb/src/compiler/plugin/builtin.rs
+++ b/scarb/src/compiler/plugin/builtin.rs
@@ -46,10 +46,6 @@ impl CairoPlugin for BuiltinExecutablePlugin {
     fn instantiate(&self) -> Result<Box<dyn CairoPluginInstance>> {
         Ok(Box::new(BuiltinExecutablePluginInstance))
     }
-
-    fn post_proc_macros(&self) -> bool {
-        true
-    }
 }
 
 struct BuiltinExecutablePluginInstance;

--- a/scarb/src/compiler/plugin/collection.rs
+++ b/scarb/src/compiler/plugin/collection.rs
@@ -159,7 +159,6 @@ struct PluginSuiteAssembler {
     base: PluginSuite,
     builtin: PluginSuite,
     proc_macro: PluginSuite,
-    post_proc_macros: PluginSuite,
 }
 
 impl Default for PluginSuiteAssembler {
@@ -168,31 +167,24 @@ impl Default for PluginSuiteAssembler {
             base: get_default_plugin_suite(),
             builtin: Default::default(),
             proc_macro: Default::default(),
-            post_proc_macros: Default::default(),
         }
     }
 }
 
 impl PluginSuiteAssembler {
     pub fn add_builtin(&mut self, plugin: &dyn CairoPlugin) -> Result<()> {
-        let post_proc_macros = plugin.post_proc_macros();
         let instance = plugin.instantiate()?;
         let suite = instance.plugin_suite();
-        if post_proc_macros {
-            self.post_proc_macros.add(suite);
-        } else {
-            self.builtin.add(suite);
-        }
+        self.builtin.add(suite);
         Ok(())
     }
     pub fn add_proc_macro(&mut self, suite: PluginSuite) {
         self.proc_macro.add(suite);
     }
     pub fn assemble(self) -> PluginSuite {
-        let mut suite = self.base;
+        let mut suite = self.proc_macro;
+        suite.add(self.base);
         suite.add(self.builtin);
-        suite.add(self.proc_macro);
-        suite.add(self.post_proc_macros);
         suite
     }
 }

--- a/scarb/src/compiler/plugin/mod.rs
+++ b/scarb/src/compiler/plugin/mod.rs
@@ -46,9 +46,6 @@ pub fn fetch_cairo_plugin(package: &Package, ws: &Workspace<'_>) -> Result<()> {
 pub trait CairoPlugin: Sync {
     fn id(&self) -> PackageId;
     fn instantiate(&self) -> Result<Box<dyn CairoPluginInstance>>;
-    fn post_proc_macros(&self) -> bool {
-        false
-    }
 }
 
 pub trait CairoPluginInstance {

--- a/scarb/tests/proc_macro_v1.rs
+++ b/scarb/tests/proc_macro_v1.rs
@@ -1425,12 +1425,12 @@ fn can_be_expanded() {
 
             #[derive(CustomDerive, Drop)]
             struct SomeType {}
-            impl SomeTypeDrop<> of core::traits::Drop<SomeType>;
             impl SomeImpl of Hello<SomeType> {
                 fn world(self: @SomeType) -> u32 {
                     32
                 }
             }
+            impl SomeTypeDrop<> of core::traits::Drop<SomeType>;
             fn main() -> u32 {
                 let x = 34;
                 let a = SomeType {};

--- a/scarb/tests/proc_macro_v2_expand.rs
+++ b/scarb/tests/proc_macro_v2_expand.rs
@@ -680,12 +680,12 @@ fn can_be_expanded() {
 
             #[derive(CustomDerive, Drop)]
             struct SomeType {}
-            impl SomeTypeDrop<> of core::traits::Drop<SomeType>;
             impl SomeImpl of Hello<SomeType> {
                 fn world(self: @SomeType) -> u32 {
                     32
                 }
             }
+            impl SomeTypeDrop<> of core::traits::Drop<SomeType>;
             fn main() -> u32 {
                 let x = 34;
                 let a = SomeType {};


### PR DESCRIPTION
This fixes

```cairo
#[derive(Drop)]
#[type_hash(name: "My Struct")]
pub struct MyStruct { }
```