### PR TITLE
fix: get all matching tags

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -125,7 +125,10 @@ jobs:
           NIGHTLY_VERSION=$(cargo xtask get-nightly-version)
 
           if [ "${{ inputs.is_dev }}" = "true" ]; then
-            EXISTING_TAGS=$(gh api repos/software-mansion/scarb-nightlies/tags --jq '.[] | select(.name | startswith("'"$NIGHTLY_TAG"'")) | .name')
+            EXISTING_TAGS=$(gh api repos/software-mansion/scarb-nightlies/tags \
+            --paginate \
+            --jq '.[] | select(.name | startswith("'"$NIGHTLY_TAG"'")) | .name'
+            )
 
             if [[ -n "$EXISTING_TAGS" ]]; then
               HIGHEST_TAG=$(echo "$EXISTING_TAGS" | sort -V | tail -n 1)


### PR DESCRIPTION
Problem: 
`dev-` tags are not fetched

Solution: 
add [--paginate](https://cli.github.com/manual/gh_api#:~:text=for%20the%20request-,%2D%2Dpaginate,-Make%20additional%20HTTP) flag to fetch all pages 