### PR TITLE
Test `scarb update` in audit and regular context

### DIFF
--- a/scarb/tests/audits.rs
+++ b/scarb/tests/audits.rs
@@ -22,7 +22,7 @@ fn require_audits_allows_non_audited_dev_dep() {
         .name("hello_world")
         .version("1.0.0")
         .dev_dep("foo", Dep.version("1.0.0").registry(&registry))
-        .lib_cairo(indoc! {r#"fn hello() -> felt252 { 0 }"#})
+        .lib_cairo(r#"fn hello() -> felt252 { 0 }"#)
         .manifest_extra(
             r#"
             [workspace]
@@ -326,7 +326,7 @@ fn will_update_to_audited_version_only() {
         .name("hello_world")
         .version("1.0.0")
         .dep("foo", Dep.version("1.0.0").registry(&registry))
-        .lib_cairo(indoc! {r#"fn hello() -> felt252 { 0 }"#})
+        .lib_cairo(r#"fn hello() -> felt252 { 0 }"#)
         .manifest_extra(
             r#"
             [security]

--- a/scarb/tests/audits.rs
+++ b/scarb/tests/audits.rs
@@ -338,7 +338,7 @@ fn will_update_to_audited_version_only() {
     audit(registry.t.child("index/3/f/foo.json").path(), "1.0.0").unwrap();
 
     Scarb::quick_snapbox()
-        .arg("build")
+        .arg("fetch")
         .current_dir(&t)
         .assert()
         .success();

--- a/scarb/tests/audits.rs
+++ b/scarb/tests/audits.rs
@@ -329,7 +329,7 @@ fn will_update_to_audited_version_only() {
         .lib_cairo(r#"fn hello() -> felt252 { 0 }"#)
         .manifest_extra(
             r#"
-            [security]
+            [workspace]
             require-audits = true
         "#,
         )

--- a/scarb/tests/local_registry.rs
+++ b/scarb/tests/local_registry.rs
@@ -69,7 +69,6 @@ fn update() {
         version = "1.0.0"
     "#}));
 
-    // Publish a new version of bar.
     registry.publish(|t| {
         ProjectBuilder::start()
             .name("bar")

--- a/scarb/tests/local_registry.rs
+++ b/scarb/tests/local_registry.rs
@@ -38,6 +38,60 @@ fn usage() {
 }
 
 #[test]
+fn update() {
+    let mut registry = LocalRegistry::create();
+    registry.publish(|t| {
+        ProjectBuilder::start()
+            .name("bar")
+            .version("1.0.0")
+            .lib_cairo(r#"fn f() -> felt252 { 0 }"#)
+            .build(t);
+    });
+
+    let t = TempDir::new().unwrap();
+    ProjectBuilder::start()
+        .name("foo")
+        .version("0.1.0")
+        .dep("bar", Dep.version("1").registry(&registry))
+        .lib_cairo(r#"fn f() -> felt252 { bar::f() }"#)
+        .build(&t);
+
+    Scarb::quick_snapbox()
+        .arg("fetch")
+        .current_dir(&t)
+        .assert()
+        .success();
+
+    let lockfile = t.child("Scarb.lock");
+    lockfile.assert(predicates::str::contains(indoc! {r#"
+        [[package]]
+        name = "bar"
+        version = "1.0.0"
+    "#}));
+
+    // Publish a new version of bar.
+    registry.publish(|t| {
+        ProjectBuilder::start()
+            .name("bar")
+            .version("1.1.0")
+            .lib_cairo(r#"fn f() -> felt252 { 42 }"#)
+            .build(t);
+    });
+
+    Scarb::quick_snapbox()
+        .arg("update")
+        .current_dir(&t)
+        .assert()
+        .success();
+
+    lockfile.assert(predicates::str::contains(indoc! {r#"
+        [[package]]
+        name = "bar"
+        version = "1.1.0"
+    "#}));
+}
+
+#[test]
 fn not_found() {
     let mut registry = LocalRegistry::create();
     registry.publish(|t| {


### PR DESCRIPTION
Adds test for `scarb update`:
- in regular context (no such test was present for registry deps)
- in audits context

## Stack

- #2560
- #2561
- #2617
- #2563
- #2562 
- #2566
- #2575
- #2576