### PR TITLE
Use macro defined fingerprint in digest calculation

### DIFF
--- a/scarb/src/compiler/plugin/collection.rs
+++ b/scarb/src/compiler/plugin/collection.rs
@@ -1,3 +1,4 @@
+use crate::compiler::plugin::proc_macro::InstanceLoader;
 use std::{collections::HashMap, sync::Arc};
 
 use anyhow::{Result, ensure};
@@ -193,7 +194,6 @@ fn collect_proc_macros(
     workspace: &Workspace<'_>,
     unit: &CairoCompilationUnit,
 ) -> Result<HashMap<CompilationUnitComponentId, Vec<Arc<ProcMacroInstance>>>> {
-    let proc_macro_repository = workspace.config().proc_macro_repository();
     let mut proc_macros_for_components = HashMap::new();
 
     for component in unit.components.iter() {
@@ -214,12 +214,7 @@ fn collect_proc_macros(
                 continue;
             }
 
-            let proc_macro =
-                plugin.prebuilt.clone().map(Ok).unwrap_or_else(|| {
-                    proc_macro_repository.get_or_load(plugin, workspace.config())
-                })?;
-
-            component_proc_macro_instances.push(proc_macro);
+            component_proc_macro_instances.push(plugin.instantiate(workspace.config())?);
         }
 
         proc_macros_for_components.insert(component.id.clone(), component_proc_macro_instances);

--- a/scarb/src/compiler/plugin/proc_macro/mod.rs
+++ b/scarb/src/compiler/plugin/proc_macro/mod.rs
@@ -10,6 +10,7 @@ pub mod v2;
 
 pub use compilation::{check_unit, compile_unit, fetch_crate};
 pub use expansion::*;
+pub use ffi::InstanceLoader;
 pub use host::*;
 pub use instance::*;
 pub use repository::*;

--- a/scarb/tests/incremental.rs
+++ b/scarb/tests/incremental.rs
@@ -461,6 +461,114 @@ fn snforge_scarb_plugin_nondeterminism_hack() {
     assert_ne!(digest(hello_component_id.as_str()), hello_digest);
 }
 
+#[test]
+fn fingerprint_callback_can_force_recompilation() {
+    let cache_dir = TempDir::new().unwrap().child("c");
+    let temp = TempDir::new().unwrap();
+    let t = temp.child("plugin_package");
+    CairoPluginProjectBuilder::default()
+        .name("plugin_package")
+        .add_dep(r#"xxhash-rust = { version = "0.8", features = ["xxh3"] }"#)
+        .lib_rs(indoc! {r##"
+        use cairo_lang_macro::{fingerprint, ProcMacroResult, TokenStream, attribute_macro, TokenTree, Token, TextSpan};
+        use std::hash::{Hash, Hasher};
+
+        #[fingerprint]
+        fn some_value() -> u64 {
+            12
+        }
+
+        #[fingerprint]
+        fn env_hash() -> u64 {
+            let mut hasher = xxhash_rust::xxh3::Xxh3::default();
+            std::env::var("TEST_ENV").unwrap().hash(&mut hasher);
+            hasher.finish()
+        }
+
+        #[attribute_macro]
+        pub fn some(_attr: TokenStream, token_stream: TokenStream) -> ProcMacroResult {
+            let new_token_string = token_stream.to_string().replace("12", "34");
+            let token_stream = TokenStream::new(vec![TokenTree::Ident(Token::new(
+                new_token_string.clone(),
+                TextSpan { start: 0, end: new_token_string.len() as u32 },
+            ))]);
+            ProcMacroResult::new(token_stream)
+        }
+        "##})
+        .build(&t);
+    let project = temp.child("hello");
+    ProjectBuilder::start()
+        .name("hello")
+        .version("1.0.0")
+        .dep("plugin_package", &t)
+        .lib_cairo(indoc! {r#"
+            #[some]
+            fn main() -> felt252 { 12 }
+        "#})
+        .build(&project);
+
+    Scarb::quick_snapbox()
+        .scarb_cache(&cache_dir)
+        .arg("build")
+        // Disable output from Cargo.
+        .env("CARGO_TERM_QUIET", "true")
+        .env("TEST_ENV", "FIRST_VALUE")
+        .current_dir(&project)
+        .assert()
+        .success()
+        .stdout_matches(indoc! {r#"
+            [..] Compiling plugin_package v1.0.0 ([..]Scarb.toml)
+            [..] Compiling hello v1.0.0 ([..]Scarb.toml)
+            [..]Finished `dev` profile target(s) in [..]
+        "#});
+
+    let fingerprints = || project.child("target/dev/.fingerprint").files();
+    // Note we do not emit cache artifacts for macros, so we don't need their fingerprint files either.
+    assert_eq!(fingerprints().len(), 2); // core, hello
+
+    let component_id = component_id_factory(project.child("target/dev/"));
+    let digest = digest_factory(project.child("target/dev/"));
+
+    let hello_component_id = component_id("hello");
+    let hello_digest = digest(hello_component_id.as_str());
+
+    // Rebuild without changing the macro.
+    Scarb::quick_snapbox()
+        .scarb_cache(&cache_dir)
+        .arg("build")
+        // Disable output from Cargo.
+        .env("CARGO_TERM_QUIET", "true")
+        .env("TEST_ENV", "FIRST_VALUE")
+        .current_dir(&project)
+        .assert()
+        .success()
+        .stdout_matches(indoc! {r#"
+            [..] Compiling plugin_package v1.0.0 ([..]Scarb.toml)
+            [..] Compiling hello v1.0.0 ([..]Scarb.toml)
+            [..]Finished `dev` profile target(s) in [..]
+        "#});
+    assert_eq!(fingerprints().len(), 2);
+    assert_eq!(digest(hello_component_id.as_str()), hello_digest);
+
+    // Rebuild with change env var.
+    Scarb::quick_snapbox()
+        .scarb_cache(&cache_dir)
+        .arg("build")
+        // Disable output from Cargo.
+        .env("CARGO_TERM_QUIET", "true")
+        .env("TEST_ENV", "SECOND_VALUE")
+        .current_dir(&project)
+        .assert()
+        .success()
+        .stdout_matches(indoc! {r#"
+            [..] Compiling plugin_package v1.0.0 ([..]Scarb.toml)
+            [..] Compiling hello v1.0.0 ([..]Scarb.toml)
+            [..]Finished `dev` profile target(s) in [..]
+        "#});
+    assert_eq!(fingerprints().len(), 2);
+    assert_ne!(digest(hello_component_id.as_str()), hello_digest);
+}
+
 fn component_id_factory(target_dir: ChildPath) -> impl Fn(&str) -> String {
     move |name: &str| {
         let component_id = target_dir


### PR DESCRIPTION
Move proc macro repository access to a trait

Use macro defined fingerprint in digest calculation

Add a test case