### PR TITLE
Fix completions_block install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -539,17 +539,17 @@ add_completions_to_profile() {
   */zsh)
     _profile=$HOME/.zshrc
     _pref_shell=zsh
-    add_completions_block_to_profile "$_profile" zsh_completion_block
+    add_completions_block_to_profile "$_profile" zsh_completions_block
     ;;
   */bash)
     _profile=$HOME/.bashrc
     _pref_shell=bash
-    add_completions_block_to_profile "$_profile" bash_completion_block
+    add_completions_block_to_profile "$_profile" bash_completions_block
     ;;
   */fish)
     _profile=$HOME/.config/fish/config.fish
     _pref_shell=fish
-    add_completions_block_to_profile "$_profile" fish_completion_block
+    add_completions_block_to_profile "$_profile" fish_completions_block
     ;;
   *)
     echo \


### PR DESCRIPTION
Running install.sh fails with the following error:

```
install.sh: line 573: bash_completion_block: command not found
```

This is because its trying to execute the function `bash_completion_block`, but the actual name is `bash_completions_block`.

This PR update the script with the correct function names.

With this PR, the instalation doesn't fail:

```
Scarb has been successfully installed and should be already available in your PATH.
Run 'scarb --version' to verify your installation. Happy coding!
```

