### PR TITLE
feat: minor adjustment file embeding support in scarb doc, update docs

### DIFF
--- a/extensions/scarb-doc/src/docs_generation/markdown.rs
+++ b/extensions/scarb-doc/src/docs_generation/markdown.rs
@@ -23,7 +23,7 @@ pub const GROUP_CHAPTER_PREFIX: &str = "- ###";
 /// Prefixes that indicate the start of complex markdown structures,
 /// such as tables. These should be avoided in brief documentation to maintain simple text
 /// formatting and prevent disruption of the layout.
-const SHORT_DOCUMENTATION_AVOID_PREFIXES: &[&str] = &["#", "\n\n", "```\n", "- ", "1.  "];
+const SHORT_DOCUMENTATION_AVOID_PREFIXES: &[&str] = &["#", "\n\n", "```", "- ", "1.  ", "{{#"];
 
 type Filename = String;
 type GeneratedFile = (Filename, String);

--- a/extensions/scarb-doc/tests/data/hello_world_sub_package_no_features/src/hello_world-sub_package-free_functions.md
+++ b/extensions/scarb-doc/tests/data/hello_world_sub_package_no_features/src/hello_world-sub_package-free_functions.md
@@ -3,5 +3,5 @@
 
 | | |
 |:---|:---|
-| [test](./hello_world_sub_package-test.md) | Function that prints "test" to stdout with endline. Can invoke it like that: ```cairo     fn main() {         test();     } ``` |
+| [test](./hello_world_sub_package-test.md) | Function that prints "test" to stdout with endline. Can invoke it like that:... |
 | [main](./hello_world_sub_package-main.md) | Main function that cairo runs as a binary entrypoint. |

--- a/extensions/scarb-doc/tests/data/hello_world_sub_package_no_features/src/hello_world_sub_package.md
+++ b/extensions/scarb-doc/tests/data/hello_world_sub_package_no_features/src/hello_world_sub_package.md
@@ -9,5 +9,5 @@ Fully qualified path: [hello_world_sub_package](./hello_world_sub_package.md)
 
 | | |
 |:---|:---|
-| [test](./hello_world_sub_package-test.md) | Function that prints "test" to stdout with endline. Can invoke it like that: ```cairo     fn main() {         test();     } ``` |
+| [test](./hello_world_sub_package-test.md) | Function that prints "test" to stdout with endline. Can invoke it like that:... |
 | [main](./hello_world_sub_package-main.md) | Main function that cairo runs as a binary entrypoint. |

--- a/extensions/scarb-doc/tests/data/hello_world_sub_package_with_features/src/hello_world-sub_package-free_functions.md
+++ b/extensions/scarb-doc/tests/data/hello_world_sub_package_with_features/src/hello_world-sub_package-free_functions.md
@@ -3,5 +3,5 @@
 
 | | |
 |:---|:---|
-| [test](./hello_world_sub_package-test.md) | Function that prints "test" to stdout with endline. Can invoke it like that: ```cairo     fn main() {         test();     }... |
+| [test](./hello_world_sub_package-test.md) | Function that prints "test" to stdout with endline. Can invoke it like that:... |
 | [main](./hello_world_sub_package-main.md) | Main function that cairo runs as a binary entrypoint. |

--- a/extensions/scarb-doc/tests/data/hello_world_sub_package_with_features/src/hello_world_sub_package.md
+++ b/extensions/scarb-doc/tests/data/hello_world_sub_package_with_features/src/hello_world_sub_package.md
@@ -9,5 +9,5 @@ Fully qualified path: [hello_world_sub_package](./hello_world_sub_package.md)
 
 | | |
 |:---|:---|
-| [test](./hello_world_sub_package-test.md) | Function that prints "test" to stdout with endline. Can invoke it like that: ```cairo     fn main() {         test();     }... |
+| [test](./hello_world_sub_package-test.md) | Function that prints "test" to stdout with endline. Can invoke it like that:... |
 | [main](./hello_world_sub_package-main.md) | Main function that cairo runs as a binary entrypoint. |

--- a/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-free_functions.md
+++ b/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world-free_functions.md
@@ -4,5 +4,5 @@
 | | |
 |:---|:---|
 | [main](./hello_world-main.md) | Main function that calculates the 16th Fibonacci number |
-| [test](./hello_world-test.md) | Function that prints "test" to stdout with endline. Can invoke it like that: ```cairo     fn main() {         test();     } ``` |
+| [test](./hello_world-test.md) | Function that prints "test" to stdout with endline. Can invoke it like that:... |
 | [fib](./hello_world-fib.md) | Calculate the nth Fibonacci number... |

--- a/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world.md
+++ b/extensions/scarb-doc/tests/data/hello_world_with_features/src/hello_world.md
@@ -22,7 +22,7 @@ Fully qualified path: [hello_world](./hello_world.md)
 | | |
 |:---|:---|
 | [main](./hello_world-main.md) | Main function that calculates the 16th Fibonacci number |
-| [test](./hello_world-test.md) | Function that prints "test" to stdout with endline. Can invoke it like that: ```cairo     fn main() {         test();     } ``` |
+| [test](./hello_world-test.md) | Function that prints "test" to stdout with endline. Can invoke it like that:... |
 | [fib](./hello_world-fib.md) | Calculate the nth Fibonacci number... |
 
 ## [Structs](./hello_world-structs.md)

--- a/website/docs/extensions/documentation-generation.md
+++ b/website/docs/extensions/documentation-generation.md
@@ -35,6 +35,19 @@ Alternatively, you can do this manually with the following steps:
 - Run `mdbook build` (or `mdbook serve`) inside the generated documentation target (`/target/doc/<PACKAGE-NAME>`).
   By default, mdBook generated documentation doesn't support Cairo code highlighting. To make it work, just replace the generated `book/highlight.js` with [this](https://github.com/software-mansion/scarb/tree/main/extensions/scarb-mdbook/theme) one.
 
+### Supported mdbook syntax
+
+- Code blocks
+- Inline code
+- Tables
+- Links
+- Lists
+- Headings
+- Bold and italic
+- Rules
+- Strikethrough
+- File embedding
+
 ## Examples
 
 Let's take, for example, a simple Cairo project initialized using `scarb new`. Let's change the code inside `lib.cairo` to:
@@ -88,7 +101,3 @@ After running `scarb doc`, inside the target directory, you will see the generat
 - The `book.toml` which contains settings for describing how to build your book.
 
 Running `scarb doc --output-format json` will result in a single JSON file inside the target directory with collected documentation inside.
-
-Check out the link below to see how a bigger project would look like:
-
-- [The Cairo Core Library Docs](https://docs.cairo-lang.org/core/)


### PR DESCRIPTION
closes https://github.com/software-mansion/scarb/issues/2536

`pulldown_cmark` does not recognise file embedding md markers, however it does work out of the box because it is interpreted correctly by mdbook, so basically no changes are required for it to work

implemented changes & why:
- the marker is added to the `SHORT_DOCUMENTATION_AVOID_PREFIXES` to avoid weird formatting results in the doc summarising (tables) webpage 
-  also, I did change the ```\n prefix, it was useless as the language is always enforced by [parser](https://github.com/starkware-libs/cairo/blob/53bec47f3938a7b732489856cdffe67b6f2c0a79/crates/cairo-lang-doc/src/parser.rs#L192)
- doc: I think it can be useful to specify the officialy supported mdbook syntax, let me know if you don't agree or have different idea 🙏 
- doc: removed the `The Cairo Core Library Docs` link - it is not relevant anymore 
- I think adding a test for that case for files embeddings is irrelevant as this is already covered by paragraph formatting. 