### PR TITLE
Refactor yanked version filtering in line with audit filtering

### DIFF
--- a/scarb/src/core/manifest/summary.rs
+++ b/scarb/src/core/manifest/summary.rs
@@ -31,6 +31,8 @@ pub struct SummaryInner {
     #[builder(default)]
     pub checksum: Option<Checksum>,
     #[builder(default = false)]
+    pub yanked: bool,
+    #[builder(default = false)]
     pub audited: bool,
 }
 

--- a/scarb/src/core/source/id.rs
+++ b/scarb/src/core/source/id.rs
@@ -9,9 +9,9 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use smol_str::SmolStr;
 use url::Url;
 
+use crate::core::Config;
 use crate::core::registry::DEFAULT_REGISTRY_INDEX;
 use crate::core::source::Source;
-use crate::core::Config;
 use crate::internal::fsx::PathBufUtf8Ext;
 use crate::internal::static_hash_cache::StaticHashCache;
 use crate::sources::canonical_url::CanonicalUrl;

--- a/scarb/src/core/source/id.rs
+++ b/scarb/src/core/source/id.rs
@@ -1,4 +1,3 @@
-use std::collections::HashSet;
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;
@@ -12,7 +11,7 @@ use url::Url;
 
 use crate::core::registry::DEFAULT_REGISTRY_INDEX;
 use crate::core::source::Source;
-use crate::core::{Config, PackageId};
+use crate::core::Config;
 use crate::internal::fsx::PathBufUtf8Ext;
 use crate::internal::static_hash_cache::StaticHashCache;
 use crate::sources::canonical_url::CanonicalUrl;
@@ -385,20 +384,12 @@ impl SourceId {
     }
 
     /// Creates an implementation of `Source` corresponding to this ID.
-    pub fn load<'c>(
-        self,
-        config: &'c Config,
-        yanked_whitelist: &HashSet<PackageId>,
-    ) -> Result<Arc<dyn Source + 'c>> {
+    pub fn load<'c>(self, config: &'c Config) -> Result<Arc<dyn Source + 'c>> {
         use crate::sources::*;
         match self.kind {
             SourceKind::Path => Ok(Arc::new(PathSource::new(self, config))),
             SourceKind::Git(_) => Ok(Arc::new(GitSource::new(self, config)?)),
-            SourceKind::Registry => Ok(Arc::new(RegistrySource::new(
-                self,
-                config,
-                yanked_whitelist,
-            )?)),
+            SourceKind::Registry => Ok(Arc::new(RegistrySource::new(self, config)?)),
             SourceKind::Std => Ok(Arc::new(StandardLibSource::new(config))),
         }
     }

--- a/scarb/src/ops/resolve.rs
+++ b/scarb/src/ops/resolve.rs
@@ -328,6 +328,7 @@ pub fn resolve_workspace_with_opts(
                 &patched,
                 &patch_map,
                 lockfile,
+                yanked_whitelist,
                 require_audits,
             )
             .await?;

--- a/scarb/src/ops/resolve.rs
+++ b/scarb/src/ops/resolve.rs
@@ -319,7 +319,7 @@ pub fn resolve_workspace_with_opts(
                 (lockfile, yanked_whitelist)
             };
 
-            let source_map = SourceMap::preloaded(ws.members(), ws.config(), yanked_whitelist);
+            let source_map = SourceMap::preloaded(ws.members(), ws.config());
             let cached = RegistryCache::new(&source_map);
             let patched = RegistryPatcher::new(&cached, &patch_map);
 

--- a/scarb/src/resolver/mod.rs
+++ b/scarb/src/resolver/mod.rs
@@ -318,12 +318,14 @@ mod tests {
 
         let lockfile = Lockfile::new(locks.iter().cloned());
         let patch_map = PatchMap::new();
+        let yanked_whitelist = Default::default();
         let require_audits = false;
         runtime.block_on(super::resolve(
             &summaries,
             &registry,
             &patch_map,
             lockfile,
+            yanked_whitelist,
             require_audits,
         ))
     }

--- a/scarb/src/resolver/mod.rs
+++ b/scarb/src/resolver/mod.rs
@@ -130,6 +130,7 @@ pub async fn resolve(
 }
 
 /// Run dependency resolution with PubGrub algorithm.
+#[allow(clippy::too_many_arguments)]
 fn scarb_resolver(
     state: Arc<ResolverState>,
     request_sink: mpsc::Sender<Request>,

--- a/scarb/src/resolver/mod.rs
+++ b/scarb/src/resolver/mod.rs
@@ -70,6 +70,7 @@ pub async fn resolve(
     registry: &dyn Registry,
     patch_map: &PatchMap,
     lockfile: Lockfile,
+    yanked_whitelist: HashSet<PackageId>,
     require_audits: bool,
 ) -> anyhow::Result<Resolve> {
     let state = Arc::new(ResolverState::default());
@@ -112,6 +113,7 @@ pub async fn resolve(
                 cloned_patch_map,
                 cloned_lockfile,
                 main_package_ids,
+                yanked_whitelist,
                 require_audits,
             )
         })?;
@@ -135,6 +137,7 @@ fn scarb_resolver(
     patch_map: PatchMap,
     lockfile: Lockfile,
     main_package_ids: HashSet<PackageId>,
+    yanked_whitelist: HashSet<PackageId>,
     require_audits: bool,
 ) {
     let result = || {
@@ -144,6 +147,7 @@ fn scarb_resolver(
             request_sink,
             patch_map,
             lockfile,
+            yanked_whitelist,
             require_audits,
         );
 

--- a/scarb/tests/yanked.rs
+++ b/scarb/tests/yanked.rs
@@ -79,10 +79,8 @@ fn will_not_use_yanked_version() {
         .assert()
         .failure()
         .stdout_matches(indoc! {r#"
-        error: cannot get dependencies of `hello_world@1.0.0`
-
-        Caused by:
-            cannot find package `foo ^1.0.0`
+        error: version solving failed:
+        Because there is no version of foo in >=1.0.0, <2.0.0 and hello_world 1.0.0 depends on foo >=1.0.0, <2.0.0, hello_world 1.0.0 is forbidden.
         "#});
 
     registry.publish(|t| {


### PR DESCRIPTION
Use the same approach as applied to audit status filtering in #2561

## Stack

- #2560
- #2561
- #2617
- #2563
- #2562 
- #2566
- #2575
- #2576