### PR TITLE
Ignore flaky https_something_happens on windows runners

### DIFF
--- a/scarb/tests/git_source_network.rs
+++ b/scarb/tests/git_source_network.rs
@@ -9,6 +9,10 @@ use scarb_test_support::command::Scarb;
 use scarb_test_support::project_builder::{Dep, DepBuilder, ProjectBuilder};
 
 #[test]
+#[cfg_attr(
+    not(target_family = "unix"),
+    ignore = "TODO(#2483): This test case is flaky on windows runners."
+)]
 fn https_something_happens() {
     thread::scope(|ts| {
         let server = TcpListener::bind("127.0.0.1:0").unwrap();


### PR DESCRIPTION
Getting tired of failed runs, I don't think it makes sense to keep running this test on windows