### PR TITLE
Warmup cached lowerings in parallel

### DIFF
--- a/scarb/src/compiler/incremental/compilation.rs
+++ b/scarb/src/compiler/incremental/compilation.rs
@@ -5,11 +5,11 @@ use crate::compiler::{CairoCompilationUnit, CompilationUnitComponent};
 use crate::core::Workspace;
 use crate::internal::fsx;
 use anyhow::{Context, Result};
-use cairo_lang_compiler::db::RootDatabase;
 use cairo_lang_filesystem::db::{CrateConfiguration, FilesGroup};
 use cairo_lang_filesystem::ids::{BlobLongId, CrateInput};
 use cairo_lang_filesystem::set_crate_config;
 use cairo_lang_lowering::cache::generate_crate_cache;
+use cairo_lang_lowering::db::LoweringGroup;
 use cairo_lang_utils::Intern;
 use itertools::Itertools;
 use salsa::{Database, par_map};
@@ -45,7 +45,7 @@ impl IncrementalContext {
 #[tracing::instrument(skip_all, level = "info")]
 pub fn load_incremental_artifacts(
     unit: &CairoCompilationUnit,
-    db: &mut RootDatabase,
+    db: &mut dyn Database,
     ws: &Workspace<'_>,
 ) -> Result<IncrementalContext> {
     if !incremental_allowed(unit) {
@@ -116,6 +116,15 @@ pub fn load_incremental_artifacts(
             })
             .collect_vec()
     };
+
+    // Warmup loaded crates cache in parallel.
+    let _: Vec<()> = par_map(
+        db,
+        CrateInput::into_crate_ids(db, cached_crates.clone()),
+        |db, crate_id| {
+            db.cached_multi_lowerings(crate_id);
+        },
+    );
 
     Ok(IncrementalContext::Enabled {
         fingerprints,


### PR DESCRIPTION
Small example:
```
Before:
Benchmark 1: /Users/maciektr/Projects/scarb/target/release/scarb build -w --test
  Time (mean ± σ):     790.0 ms ±  40.5 ms    [User: 633.8 ms, System: 84.2 ms]
  Range (min … max):   746.6 ms … 837.5 ms    4 runs

After:
Benchmark 1: /Users/maciektr/Projects/scarb/target/release/scarb build -w --test
  Time (mean ± σ):     723.9 ms ±  39.9 ms    [User: 669.2 ms, System: 83.3 ms]
  Range (min … max):   696.9 ms … 781.6 ms    4 runs
```
OZ:
```
Before:
Benchmark 1: /Users/maciektr/Projects/scarb/target/release/scarb build -w --test
  Time (mean ± σ):     37.873 s ±  0.288 s    [User: 59.813 s, System: 4.263 s]
  Range (min … max):   37.491 s … 38.109 s    4 runs

After:
Benchmark 1: /Users/maciektr/Projects/scarb/target/release/scarb build -w --test
  Time (mean ± σ):     31.320 s ±  0.279 s    [User: 61.208 s, System: 4.757 s]
  Range (min … max):   31.023 s … 31.625 s    4 runs
```

We will need to use those caches anyway, so we can force db to load them eagerly at start, avoiding any locking during compilation.

