### PR TITLE
Save information about warnings in cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6984,6 +6984,7 @@ dependencies = [
  "anyhow",
  "assert_fs",
  "async-trait",
+ "bincode",
  "cairo-lang-compiler",
  "cairo-lang-defs",
  "cairo-lang-diagnostics",

--- a/scarb/Cargo.toml
+++ b/scarb/Cargo.toml
@@ -16,6 +16,7 @@ repository.workspace = true
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
+bincode.workspace = true
 cairo-lang-compiler.workspace = true
 cairo-lang-defs.workspace = true
 cairo-lang-diagnostics.workspace = true

--- a/scarb/src/compiler/compilers/executable.rs
+++ b/scarb/src/compiler/compilers/executable.rs
@@ -1,6 +1,7 @@
 use crate::compiler::db::{has_plugin, is_executable_plugin};
 use crate::compiler::helpers::write_json;
 use crate::compiler::helpers::{build_compiler_config, collect_main_crate_ids};
+use crate::compiler::incremental::IncrementalContext;
 use crate::compiler::{CairoCompilationUnit, CompilationUnitAttributes, Compiler};
 use crate::core::{PackageName, TargetKind, Utf8PathWorkspaceExt, Workspace};
 use crate::internal::offloader::Offloader;
@@ -13,7 +14,7 @@ use cairo_lang_executable::compile::{
 };
 use cairo_lang_executable::executable::Executable;
 use cairo_lang_executable_plugin::{EXECUTABLE_PREFIX, EXECUTABLE_RAW_ATTR};
-use cairo_lang_filesystem::ids::{CrateId, CrateInput};
+use cairo_lang_filesystem::ids::CrateId;
 use cairo_lang_lowering::ids::ConcreteFunctionWithBodyId;
 use cairo_lang_sierra_generator::executables::find_executable_function_ids;
 use camino::Utf8Path;
@@ -40,7 +41,7 @@ impl Compiler for ExecutableCompiler {
     fn compile(
         &self,
         unit: &CairoCompilationUnit,
-        cached_crates: &[CrateInput],
+        ctx: &IncrementalContext,
         _offloader: &Offloader<'_>,
         db: &mut RootDatabase,
         ws: &Workspace<'_>,
@@ -64,7 +65,7 @@ impl Compiler for ExecutableCompiler {
 
         let target_dir = unit.target_dir(ws);
         let main_crate_ids = collect_main_crate_ids(unit, db);
-        let compiler_config = build_compiler_config(db, unit, &main_crate_ids, cached_crates, ws);
+        let compiler_config = build_compiler_config(db, unit, &main_crate_ids, ctx, ws);
         let span = trace_span!("compile_executable");
         let executable = {
             let _guard = span.enter();

--- a/scarb/src/compiler/compilers/lib.rs
+++ b/scarb/src/compiler/compilers/lib.rs
@@ -3,7 +3,6 @@ use cairo_lang_compiler::CompilerConfig;
 use cairo_lang_compiler::db::RootDatabase;
 use cairo_lang_defs::db::DefsGroup;
 use cairo_lang_defs::plugin::MacroPlugin;
-use cairo_lang_filesystem::ids::CrateInput;
 use cairo_lang_sierra::program::VersionedProgram;
 use cairo_lang_sierra_to_casm::compiler::SierraToCasmConfig;
 use cairo_lang_sierra_to_casm::metadata::{calc_metadata, calc_metadata_ap_change_only};
@@ -17,6 +16,7 @@ use tracing::{debug, trace_span};
 use crate::compiler::helpers::{
     build_compiler_config, collect_main_crate_ids, write_json, write_string,
 };
+use crate::compiler::incremental::IncrementalContext;
 use crate::compiler::{CairoCompilationUnit, CompilationUnitAttributes, Compiler};
 use crate::core::{TargetKind, Utf8PathWorkspaceExt, Workspace};
 use crate::internal::offloader::Offloader;
@@ -49,7 +49,7 @@ impl Compiler for LibCompiler {
     fn compile(
         &self,
         unit: &CairoCompilationUnit,
-        cached_crates: &[CrateInput],
+        ctx: &IncrementalContext,
         offloader: &Offloader<'_>,
         db: &mut RootDatabase,
         ws: &Workspace<'_>,
@@ -66,7 +66,7 @@ impl Compiler for LibCompiler {
 
         let main_crate_ids = collect_main_crate_ids(unit, db);
 
-        let compiler_config = build_compiler_config(db, unit, &main_crate_ids, cached_crates, ws);
+        let compiler_config = build_compiler_config(db, unit, &main_crate_ids, ctx, ws);
 
         validate_compiler_config(db, &compiler_config, unit, ws);
 

--- a/scarb/src/compiler/compilers/starknet_contract/compiler.rs
+++ b/scarb/src/compiler/compilers/starknet_contract/compiler.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result, ensure};
 use cairo_lang_compiler::db::RootDatabase;
 use cairo_lang_defs::db::DefsGroup;
 use cairo_lang_defs::ids::{ModuleId, NamedLanguageElementId};
-use cairo_lang_filesystem::ids::{CrateId, CrateInput, CrateLongId, SmolStrId};
+use cairo_lang_filesystem::ids::{CrateId, CrateLongId, SmolStrId};
 use cairo_lang_semantic::db::SemanticGroup;
 use cairo_lang_semantic::items::module::ModuleSemantic;
 use cairo_lang_semantic::items::us::SemanticUseEx;
@@ -27,6 +27,7 @@ use crate::compiler::compilers::starknet_contract::contract_selector::GLOB_PATH_
 use crate::compiler::compilers::starknet_contract::validations::check_allowed_libfuncs;
 use crate::compiler::compilers::{ArtifactsWriter, ensure_gas_enabled};
 use crate::compiler::helpers::{build_compiler_config, collect_main_crate_ids};
+use crate::compiler::incremental::IncrementalContext;
 use crate::compiler::{CairoCompilationUnit, CompilationUnitAttributes, Compiler};
 use crate::core::{TargetKind, Workspace};
 use crate::internal::offloader::Offloader;
@@ -78,7 +79,7 @@ impl Compiler for StarknetContractCompiler {
     fn compile(
         &self,
         unit: &CairoCompilationUnit,
-        cached_crates: &[CrateInput],
+        ctx: &IncrementalContext,
         offloader: &Offloader<'_>,
         db: &mut RootDatabase,
         ws: &Workspace<'_>,
@@ -107,7 +108,7 @@ impl Compiler for StarknetContractCompiler {
 
         let main_crate_ids = collect_main_crate_ids(unit, db);
 
-        let compiler_config = build_compiler_config(db, unit, &main_crate_ids, cached_crates, ws);
+        let compiler_config = build_compiler_config(db, unit, &main_crate_ids, ctx, ws);
 
         let contracts = find_project_contracts(
             db,

--- a/scarb/src/compiler/compilers/test.rs
+++ b/scarb/src/compiler/compilers/test.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use cairo_lang_compiler::db::RootDatabase;
 use cairo_lang_compiler::diagnostics::DiagnosticsReporter;
-use cairo_lang_filesystem::ids::{CrateId, CrateInput, CrateLongId, SmolStrId};
+use cairo_lang_filesystem::ids::{CrateId, CrateLongId, SmolStrId};
 use cairo_lang_sierra::program::VersionedProgram;
 use cairo_lang_starknet::compile::compile_prepared_db;
 use cairo_lang_starknet::contract::ContractDeclaration;
@@ -16,6 +16,7 @@ use crate::compiler::compilers::{
     Artifacts, ArtifactsWriter, ContractSelector, ensure_gas_enabled, find_project_contracts,
 };
 use crate::compiler::helpers::{build_compiler_config, collect_main_crate_ids, write_json};
+use crate::compiler::incremental::IncrementalContext;
 use crate::compiler::{CairoCompilationUnit, CompilationUnitAttributes, Compiler};
 use crate::core::{PackageName, SourceId, TargetKind, TestTargetProps, Workspace};
 use crate::flock::Filesystem;
@@ -31,7 +32,7 @@ impl Compiler for TestCompiler {
     fn compile(
         &self,
         unit: &CairoCompilationUnit,
-        cached_crates: &[CrateInput],
+        ctx: &IncrementalContext,
         offloader: &Offloader<'_>,
         db: &mut RootDatabase,
         ws: &Workspace<'_>,
@@ -62,8 +63,7 @@ impl Compiler for TestCompiler {
         };
 
         let diagnostics_reporter =
-            build_compiler_config(db, unit, &test_crate_ids, cached_crates, ws)
-                .diagnostics_reporter;
+            build_compiler_config(db, unit, &test_crate_ids, ctx, ws).diagnostics_reporter;
 
         let span = trace_span!("compile_test");
         let test_compilation = {
@@ -129,13 +129,13 @@ impl Compiler for TestCompiler {
             compile_contracts(
                 ContractsCompilationArgs {
                     main_crate_ids: test_crate_ids,
-                    cached_crates: cached_crates.to_vec(),
                     contracts,
                     build_external_contracts,
                 },
                 target_dir,
                 unit,
                 offloader,
+                ctx,
                 db,
                 ws,
             )?;
@@ -147,7 +147,6 @@ impl Compiler for TestCompiler {
 
 struct ContractsCompilationArgs<'db> {
     main_crate_ids: Vec<CrateId<'db>>,
-    cached_crates: Vec<CrateInput>,
     contracts: Vec<ContractDeclaration<'db>>,
     build_external_contracts: Option<Vec<ContractSelector>>,
 }
@@ -157,12 +156,12 @@ fn compile_contracts<'db>(
     target_dir: Filesystem,
     unit: &CairoCompilationUnit,
     offloader: &Offloader<'_>,
+    ctx: &IncrementalContext,
     db: &'db RootDatabase,
     ws: &Workspace<'_>,
 ) -> Result<()> {
     let ContractsCompilationArgs {
         main_crate_ids,
-        cached_crates,
         contracts,
         build_external_contracts,
     } = args;
@@ -172,7 +171,7 @@ fn compile_contracts<'db>(
         build_external_contracts,
         ..StarknetContractProps::default()
     };
-    let mut compiler_config = build_compiler_config(db, unit, &main_crate_ids, &cached_crates, ws);
+    let mut compiler_config = build_compiler_config(db, unit, &main_crate_ids, ctx, ws);
     // We already did check the Db for diagnostics when compiling tests, so we can ignore them here.
     compiler_config.diagnostics_reporter = DiagnosticsReporter::ignoring()
         .allow_warnings()

--- a/scarb/src/compiler/helpers.rs
+++ b/scarb/src/compiler/helpers.rs
@@ -1,5 +1,6 @@
 //! Various utility functions helpful for interacting with Cairo compiler.
 
+use crate::compiler::incremental::IncrementalContext;
 use crate::compiler::{CairoCompilationUnit, CompilationUnitAttributes};
 use crate::core::{InliningStrategy, Workspace};
 use crate::flock::Filesystem;
@@ -9,7 +10,7 @@ use cairo_lang_compiler::db::RootDatabase;
 use cairo_lang_compiler::diagnostics::DiagnosticsReporter;
 use cairo_lang_diagnostics::{FormattedDiagnosticEntry, Severity};
 use cairo_lang_filesystem::db::FilesGroup;
-use cairo_lang_filesystem::ids::{CrateId, CrateInput};
+use cairo_lang_filesystem::ids::CrateId;
 use itertools::Itertools;
 use serde::Serialize;
 use std::collections::HashSet;
@@ -45,7 +46,7 @@ pub fn build_compiler_config<'c, 'db>(
     db: &'db RootDatabase,
     unit: &CairoCompilationUnit,
     main_crate_ids: &[CrateId<'db>],
-    cached_crates: &[CrateInput],
+    ctx: &IncrementalContext,
     ws: &Workspace<'c>,
 ) -> CompilerConfig<'c>
 where
@@ -63,7 +64,8 @@ where
     // we should not use it in the first place.
     // We also skip showing warnings produced for dependency crates.
     let crates_to_check = db.crates().iter().filter(|crate_id| {
-        !cached_crates.contains(&crate_id.long(db).clone().into_crate_input(db))
+        !ctx.cached_crates()
+            .contains(&crate_id.long(db).clone().into_crate_input(db))
     });
     // Note we may need to add the main crates to display warnings generated from them.
     // This is because warnings do not fail compilation, so we can produce caches for crates with them.

--- a/scarb/src/compiler/helpers.rs
+++ b/scarb/src/compiler/helpers.rs
@@ -46,7 +46,7 @@ pub fn build_compiler_config<'c, 'db>(
     db: &'db RootDatabase,
     unit: &CairoCompilationUnit,
     main_crate_ids: &[CrateId<'db>],
-    ctx: &IncrementalContext,
+    ctx: &'db IncrementalContext,
     ws: &Workspace<'c>,
 ) -> CompilerConfig<'c>
 where
@@ -81,7 +81,15 @@ where
         if ws.config().ui().verbosity().should_print_warnings()
             && unit.compiler_config.allow_warnings
         {
-            crates_to_check.chain(main_crate_ids).copied().collect()
+            crates_to_check
+                .chain(main_crate_ids.iter().filter(|c| {
+                    // If we saved information about crate warnings, we can use it here to decide
+                    // whether we should calculate diagnostics for it.
+                    ctx.cached_crates_with_warnings()
+                        .contains(&c.long(db).clone().into_crate_input(db))
+                }))
+                .copied()
+                .collect()
         } else {
             crates_to_check.copied().collect()
         };
@@ -102,6 +110,7 @@ where
                     }
                 }
                 Severity::Warning => {
+                    ctx.report_warnings();
                     if let Some(code) = entry.error_code() {
                         config.ui().warn_with_code(code.as_str(), msg)
                     } else {

--- a/scarb/src/compiler/incremental/compilation.rs
+++ b/scarb/src/compiler/incremental/compilation.rs
@@ -3,7 +3,6 @@ use crate::compiler::incremental::fingerprint::{
 };
 use crate::compiler::{CairoCompilationUnit, CompilationUnitComponent};
 use crate::core::Workspace;
-use crate::internal::fsx;
 use anyhow::{Context, Result};
 use cairo_lang_filesystem::db::{CrateConfiguration, FilesGroup};
 use cairo_lang_filesystem::ids::{BlobLongId, CrateInput};
@@ -13,9 +12,10 @@ use cairo_lang_lowering::db::LoweringGroup;
 use cairo_lang_utils::Intern;
 use itertools::Itertools;
 use salsa::{Database, par_map};
-use std::io::Write;
+use std::io::{BufReader, Write};
 use std::ops::Deref;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::{env, mem};
 use tokio::task::spawn_blocking;
 use tracing::{debug, error, trace_span};
@@ -27,19 +27,76 @@ pub enum IncrementalContext {
     Enabled {
         fingerprints: UnitFingerprint,
         cached_crates: Vec<CrateInput>,
+        cached_crates_with_warnings: Vec<CrateInput>,
+        warnings_found: AtomicBool,
     },
 }
 
 impl IncrementalContext {
+    pub fn fingerprints(&self) -> Option<&UnitFingerprint> {
+        match self {
+            IncrementalContext::Disabled => None,
+            IncrementalContext::Enabled {
+                fingerprints,
+                cached_crates_with_warnings: _,
+                warnings_found: _,
+                cached_crates: _,
+            } => Some(fingerprints),
+        }
+    }
+
     pub fn cached_crates(&self) -> &[CrateInput] {
         match self {
             IncrementalContext::Disabled => &[],
             IncrementalContext::Enabled {
                 fingerprints: _,
+                cached_crates_with_warnings: _,
+                warnings_found: _,
                 cached_crates,
             } => cached_crates,
         }
     }
+    pub fn cached_crates_with_warnings(&self) -> &[CrateInput] {
+        match self {
+            IncrementalContext::Disabled => &[],
+            IncrementalContext::Enabled {
+                fingerprints: _,
+                cached_crates: _,
+                warnings_found: _,
+                cached_crates_with_warnings,
+            } => cached_crates_with_warnings,
+        }
+    }
+
+    pub fn report_warnings(&self) {
+        match self {
+            IncrementalContext::Disabled => {}
+            IncrementalContext::Enabled {
+                fingerprints: _,
+                cached_crates: _,
+                warnings_found,
+                cached_crates_with_warnings: _,
+            } => warnings_found.store(true, Ordering::Release),
+        }
+    }
+
+    pub fn warnings_found(&self) -> bool {
+        match self {
+            IncrementalContext::Disabled => false,
+            IncrementalContext::Enabled {
+                fingerprints: _,
+                cached_crates: _,
+                warnings_found,
+                cached_crates_with_warnings: _,
+            } => warnings_found.load(Ordering::Acquire),
+        }
+    }
+}
+
+#[derive(bincode::Encode, bincode::Decode)]
+pub struct ScarbComponentCache {
+    pub has_warnings: bool,
+    pub blob: Vec<u8>,
 }
 
 #[tracing::instrument(skip_all, level = "info")]
@@ -88,6 +145,7 @@ pub fn load_incremental_artifacts(
     })?;
 
     let span = trace_span!("set_crate_configs");
+    let mut cached_crates_with_warnings = Vec::new();
     let cached_crates = {
         let _guard = span.enter();
 
@@ -98,6 +156,7 @@ pub fn load_incremental_artifacts(
                 CrateCache::Loaded {
                     component,
                     blob_content,
+                    has_warnings,
                 } => {
                     let crate_id = component.crate_id(db);
                     if let Some(core_conf) = db.crate_config(crate_id) {
@@ -110,6 +169,9 @@ pub fn load_incremental_artifacts(
                                 cache_file: Some(BlobLongId::Virtual(blob_content).intern(db)),
                             })
                         );
+                    }
+                    if has_warnings {
+                        cached_crates_with_warnings.push(component.crate_input(db));
                     }
                     Some(component.crate_input(db))
                 }
@@ -131,6 +193,8 @@ pub fn load_incremental_artifacts(
     Ok(IncrementalContext::Enabled {
         fingerprints,
         cached_crates,
+        cached_crates_with_warnings,
+        warnings_found: AtomicBool::new(false),
     })
 }
 
@@ -172,17 +236,18 @@ fn load_component_cache(
         );
         let cache_dir = unit.incremental_cache_dir(ws);
         // Lock the cache file for reading.
-        let _guard = cache_dir.open_ro(
+        let file = cache_dir.open_ro(
             component.cache_filename(fingerprint),
             &component.cache_filename(fingerprint),
             ws.config(),
-        );
-        let cache_dir = cache_dir.path_unchecked();
-        let cache_file = cache_dir.join(component.cache_filename(fingerprint));
-        let blob_content = fsx::read(cache_file)?;
+        )?;
+        let reader = BufReader::new(file.deref());
+        let decoded: ScarbComponentCache =
+            bincode::decode_from_reader(reader, bincode::config::standard())?;
         Ok(CrateCache::Loaded {
             component,
-            blob_content,
+            has_warnings: decoded.has_warnings,
+            blob_content: decoded.blob,
         })
     } else {
         Ok(CrateCache::None)
@@ -193,6 +258,7 @@ enum CrateCache {
     None,
     Loaded {
         component: CompilationUnitComponent,
+        has_warnings: bool,
         blob_content: Vec<u8>,
     },
 }
@@ -204,11 +270,8 @@ pub fn save_incremental_artifacts(
     ctx: IncrementalContext,
     ws: &Workspace<'_>,
 ) -> Result<()> {
-    let IncrementalContext::Enabled {
-        fingerprints,
-        cached_crates: _,
-    } = ctx
-    else {
+    let warnings_found = ctx.warnings_found();
+    let Some(fingerprints) = ctx.fingerprints() else {
         return Ok(());
     };
 
@@ -231,12 +294,13 @@ pub fn save_incremental_artifacts(
                     unreachable!("we iterate through components not plugins");
                 }
             };
-            save_component_cache(fingerprint, group, unit, component, ws).with_context(|| {
-                format!(
-                    "failed to save cache for `{}` component",
-                    component.target_name()
-                )
-            })
+            save_component_cache(fingerprint, group, unit, component, warnings_found, ws)
+                .with_context(|| {
+                    format!(
+                        "failed to save cache for `{}` component",
+                        component.target_name()
+                    )
+                })
         });
     results.into_iter().collect::<Result<Vec<_>>>()?;
 
@@ -249,6 +313,7 @@ fn save_component_cache(
     db: &dyn Database,
     unit: &CairoCompilationUnit,
     component: &CompilationUnitComponent,
+    warnings_found: bool,
     ws: &Workspace<'_>,
 ) -> Result<()> {
     let fingerprint_digest = fingerprint.digest();
@@ -282,6 +347,11 @@ fn save_component_cache(
                 return Ok(());
             }
         };
+        let component_cache = ScarbComponentCache {
+            has_warnings: warnings_found,
+            blob: cache_blob,
+        };
+        let cache_blob = bincode::encode_to_vec(component_cache, bincode::config::standard())?;
         let fingerprint_dir = unit.fingerprint_dir(ws);
         let fingerprint_dir = fingerprint_dir.child(component.fingerprint_dirname(fingerprint));
         let fingerprint_file = fingerprint_dir.create_rw(

--- a/scarb/src/compiler/incremental/mod.rs
+++ b/scarb/src/compiler/incremental/mod.rs
@@ -2,4 +2,4 @@ mod compilation;
 mod fingerprint;
 mod source;
 
-pub use compilation::{load_incremental_artifacts, save_incremental_artifacts};
+pub use compilation::{IncrementalContext, load_incremental_artifacts, save_incremental_artifacts};

--- a/scarb/src/compiler/mod.rs
+++ b/scarb/src/compiler/mod.rs
@@ -1,12 +1,11 @@
+use crate::compiler::incremental::IncrementalContext;
+use crate::core::{TargetKind, Workspace};
+use crate::internal::offloader::Offloader;
 use anyhow::Result;
 use cairo_lang_compiler::db::RootDatabase;
-use cairo_lang_filesystem::ids::CrateInput;
 pub use compilation_unit::*;
 pub use profile::*;
 pub use repository::*;
-
-use crate::core::{TargetKind, Workspace};
-use crate::internal::offloader::Offloader;
 
 mod compilation_unit;
 mod compilers;
@@ -24,7 +23,7 @@ pub trait Compiler: Sync {
     fn compile(
         &self,
         unit: &CairoCompilationUnit,
-        cached_crates: &[CrateInput],
+        ctx: &IncrementalContext,
         offloader: &Offloader<'_>,
         db: &mut RootDatabase,
         ws: &Workspace<'_>,

--- a/scarb/src/compiler/repository.rs
+++ b/scarb/src/compiler/repository.rs
@@ -57,7 +57,7 @@ impl CompilerRepository {
             bail!("unknown compiler for target `{target_kind}`");
         };
         let ctx = load_incremental_artifacts(&unit, db, ws)?;
-        compiler.compile(&unit, ctx.cached_crates(), offloader, db, ws)?;
+        compiler.compile(&unit, &ctx, offloader, db, ws)?;
         save_incremental_artifacts(&unit, db, ctx, ws)?;
         Ok(())
     }

--- a/scarb/src/ops/compile.rs
+++ b/scarb/src/ops/compile.rs
@@ -2,6 +2,7 @@ use crate::compiler::db::{
     ScarbDatabase, build_scarb_root_database, has_plugin, is_starknet_plugin,
 };
 use crate::compiler::helpers::{build_compiler_config, collect_main_crate_ids};
+use crate::compiler::incremental::IncrementalContext;
 use crate::compiler::plugin::proc_macro;
 use crate::compiler::{CairoCompilationUnit, CompilationUnit, CompilationUnitAttributes};
 use crate::core::{
@@ -326,7 +327,13 @@ fn check_unit(unit: CompilationUnit, ws: &Workspace<'_>) -> Result<()> {
                 build_scarb_root_database(&unit, ws, Default::default())?;
             let main_crate_ids = collect_main_crate_ids(&unit, &db);
             check_starknet_dependency(&unit, ws, &db, &package_name);
-            let mut compiler_config = build_compiler_config(&db, &unit, &main_crate_ids, &[], ws);
+            let mut compiler_config = build_compiler_config(
+                &db,
+                &unit,
+                &main_crate_ids,
+                &IncrementalContext::Disabled,
+                ws,
+            );
             let result = compiler_config
                 .diagnostics_reporter
                 .ensure(&db)

--- a/scarb/src/ops/expand.rs
+++ b/scarb/src/ops/expand.rs
@@ -1,5 +1,6 @@
 use crate::compiler::db::{ScarbDatabase, build_scarb_root_database};
 use crate::compiler::helpers::{build_compiler_config, write_string};
+use crate::compiler::incremental::IncrementalContext;
 use crate::compiler::{CairoCompilationUnit, CompilationUnit, CompilationUnitAttributes};
 use crate::core::{Package, PackageId, TargetKind, Workspace};
 use crate::ops;
@@ -167,8 +168,13 @@ fn do_expand(
     let ScarbDatabase { db, .. } =
         build_scarb_root_database(compilation_unit, ws, Default::default())?;
     let main_crate_id = compilation_unit.main_component().crate_id(&db);
-    let mut compiler_config =
-        build_compiler_config(&db, compilation_unit, &[main_crate_id], &[], ws);
+    let mut compiler_config = build_compiler_config(
+        &db,
+        compilation_unit,
+        &[main_crate_id],
+        &IncrementalContext::Disabled,
+        ws,
+    );
     // Report diagnostics, but do not fail.
     let _ = compiler_config.diagnostics_reporter.check(&db);
     let main_module = ModuleId::CrateRoot(main_crate_id);


### PR DESCRIPTION
This way we can skip calculating diagnostics for main crates.