### PR TITLE
Fix scarb-execute test case path assert on windows

### DIFF
--- a/extensions/scarb-execute/src/lib.rs
+++ b/extensions/scarb-execute/src/lib.rs
@@ -267,10 +267,9 @@ pub fn execute(
             Set `sierra = true` under your `[executable]` target in the config and try again.",
             build_target.name
         );
-        let executable_sierra_path = Utf8PathBuf::from(format!(
-            "{}/{}.executable.sierra.json",
-            &scarb_build_dir, &build_target.name
-        ));
+        let executable_sierra_path = scarb_build_dir
+            .join(&build_target.name)
+            .with_extension("executable.sierra.json");
         ensure!(
             executable_sierra_path.exists(),
             "Missing sierra code for executable `{0}`, file {executable_sierra_path} does not exist. \

--- a/extensions/scarb-execute/tests/build.rs
+++ b/extensions/scarb-execute/tests/build.rs
@@ -7,6 +7,7 @@ use scarb_test_support::command::Scarb;
 use scarb_test_support::fsx::ChildPathEx;
 use scarb_test_support::predicates::is_file_empty;
 use scarb_test_support::project_builder::ProjectBuilder;
+use snapbox::{Assert, Substitutions};
 
 fn executable_project_builder() -> ProjectBuilder {
     ProjectBuilder::start()
@@ -533,12 +534,14 @@ fn no_build_artifact_for_profiler_trace_file() {
     if artifact_path.exists() {
         std::fs::remove_file(&artifact_path).unwrap();
     }
-    Scarb::quick_snapbox()
+    let assert = Scarb::quick_snapbox()
         .arg("execute")
         .arg("--no-build")
         .arg("--save-profiler-trace-data")
         .current_dir(&t)
-        .assert()
+        .assert();
+    let assert = assert.with_assert(Assert::default().substitutions(Substitutions::default()));
+    assert
         .failure()
         .stdout_matches(indoc! {r#"
         [..]Executing hello


### PR DESCRIPTION
Fix failing windows tests: https://github.com/software-mansion/scarb/actions/runs/18603199937/job/53047706430

```
    thread 'no_build_artifact_for_profiler_trace_file' panicked at extensions\scarb-execute\tests\build.rs:543:10:

    --- Expected
    ++++ actual:   stdout
       1    1 | [..]Executing hello
       2    2 | Saving output to: target/execute/hello/execution1
       3      - error: Missing sierra code for executable `hello`, file [..]hello.executable.sierra.json does not exist. help: run `scarb build` to compile the package and try again.
            3 + error: Missing sierra code for executable `hello`, file C:/Users/runneradmin/AppData/Local/Temp/.tmpZxR9Pq/target/dev/hello[EXE]cutable.sierra.json does not exist. help: run `scarb build` to compile the package and try again.
```