### PR TITLE
Disable default features for reqwest again

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,7 @@ quote = "1"
 ra_ap_toolchain = "0.0.301"
 rayon = "1.11.0"
 redb = "2.6.3"
-reqwest = { version = "0.12", features = ["gzip", "brotli", "deflate", "json", "stream", "multipart"] }
+reqwest = { version = "0.12", default-features = false, features = ["gzip", "brotli", "deflate", "json", "stream", "multipart"] }
 salsa = "=0.24.0"
 semver = { version = "1", features = ["serde"] }
 semver-pubgrub = { git = "https://github.com/software-mansion-labs/semver-pubgrub.git" }


### PR DESCRIPTION
In #2732 default features were mistakenly re-enabled, which caused `native-tls` crate used by `reqwest` to start looking for `libssl` dynamic libraries on Linux systems. We're using `cross`, which doesn't provide these on its base build images, and we deliberately didn't do anything with this because we decided to use `rustls-tls` instead of `openssl`. That feature modification in turn was done in `scarb/Cargo.toml`. This re-enabling in workspace `Cargo.toml` broke this.