### PR TITLE
docs: add breaking behavior config for formatting

### DIFF
--- a/website/docs/guides/formatting.md
+++ b/website/docs/guides/formatting.md
@@ -54,6 +54,16 @@ sort-module-level-items = true
   Control how multi-element collections (i.e. arrays, tuples) are broken into lines: `SingleBreakPoint` or `LineByLine`\
   **Default:** `{ tuple = "LineByLine", fixed_array = "SingleBreakPoint", macro_call = "SingleBreakPoint" }`
 
+- `merge-use-items`
+  
+  Consolidate multiple `use` statements that import from the same module into a single statement.\
+  **Default:** `true`
+
+- `allow-duplicate-uses`
+
+  Allow duplicate `use` statements instead of automatically removing them.\
+  **Default:** `false`
+
 ## Ignoring files
 
 By default, Scarb will format all files with a `.cairo` extension from the directory containing the manifest file


### PR DESCRIPTION
Add documentation to explain how the [default](https://github.com/starkware-libs/cairo/blob/06db3a9d8d3b1392edf65750d566bd1438947ce1/crates/cairo-lang-formatter/src/lib.rs#L181) formatting for line breaks can be overridden.