### PR TITLE
generate mdx file content

### DIFF
--- a/extensions/scarb-doc/src/docs_generation.rs
+++ b/extensions/scarb-doc/src/docs_generation.rs
@@ -7,6 +7,7 @@ use crate::types::other_types::{
 };
 use cairo_lang_doc::parser::DocumentationCommentToken;
 
+pub mod common;
 pub mod markdown;
 
 #[derive(Default)]
@@ -27,7 +28,6 @@ struct TopLevelItems<'a, 'db> {
 
 // Trait for items with no descendants.
 // Used to enforce constraints on generic implementations of traits like `MarkdownDocItem`.
-
 trait PrimitiveDocItem: DocItem {}
 
 impl PrimitiveDocItem for Constant<'_> {}
@@ -36,7 +36,9 @@ impl PrimitiveDocItem for ExternType<'_> {}
 impl PrimitiveDocItem for FreeFunction<'_> {}
 impl PrimitiveDocItem for ImplAlias<'_> {}
 impl PrimitiveDocItem for TypeAlias<'_> {}
+impl PrimitiveDocItem for MacroDeclaration<'_> {}
 
+// Trait for items which file path resolutions is relative to their parent.
 trait SubPathDocItem: DocItem {}
 
 impl SubPathDocItem for Member<'_> {}
@@ -47,7 +49,6 @@ impl SubPathDocItem for ImplType<'_> {}
 impl SubPathDocItem for ImplConstant<'_> {}
 impl SubPathDocItem for TraitConstant<'_> {}
 impl SubPathDocItem for TraitType<'_> {}
-impl SubPathDocItem for MacroDeclaration<'_> {}
 
 // Trait for items that have their own documentation page.
 // Used to enforce constraints on generic implementations of traits like `TopLevelMarkdownDocItem`.

--- a/extensions/scarb-doc/src/docs_generation/common.rs
+++ b/extensions/scarb-doc/src/docs_generation/common.rs
@@ -1,0 +1,67 @@
+use crate::docs_generation::markdown::IndexMap;
+use scarb_extensions_cli::doc::OutputFormat;
+use std::sync::OnceLock;
+
+pub type Filename = String;
+pub type GeneratedFile = (Filename, String);
+
+/// Stores `SUMMARY.md` files data: filepath, chapter name and list indent.
+pub type SummaryIndexMap = IndexMap<String, SummaryListItem>;
+
+pub struct SummaryListItem {
+    /// A SUMMARY.md chapter title.
+    pub chapter: String,
+    /// List item indent in the SUMMARY.md file.
+    pub nesting_level: usize,
+}
+
+impl SummaryListItem {
+    pub fn new(chapter: String, nesting_level: usize) -> Self {
+        Self {
+            chapter,
+            nesting_level,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutputFilesExtension {
+    Md,
+    Mdx,
+    Json,
+}
+
+impl OutputFilesExtension {
+    pub const fn get_string(&self) -> &'static str {
+        match self {
+            OutputFilesExtension::Md => ".md",
+            OutputFilesExtension::Mdx => ".mdx",
+            OutputFilesExtension::Json => ".json",
+        }
+    }
+}
+
+impl From<OutputFormat> for OutputFilesExtension {
+    fn from(format: OutputFormat) -> Self {
+        match format {
+            OutputFormat::Markdown => OutputFilesExtension::Md,
+            OutputFormat::Mdx => OutputFilesExtension::Mdx,
+            OutputFormat::Json => OutputFilesExtension::Json,
+        }
+    }
+}
+
+// Global, run-scoped output extension accessor.
+static OUTPUT_EXTENSION: OnceLock<&'static str> = OnceLock::new();
+
+pub fn set_output_extension(ext: OutputFormat) {
+    let _ = OUTPUT_EXTENSION.set(OutputFilesExtension::from(ext).get_string());
+}
+
+fn extension() -> &'static str {
+    OUTPUT_EXTENSION.get().copied().unwrap()
+}
+
+pub fn get_filename_with_extension(filename: &str) -> String {
+    format!("{filename}{}", extension())
+}

--- a/extensions/scarb-doc/src/docs_generation/markdown/summary.rs
+++ b/extensions/scarb-doc/src/docs_generation/markdown/summary.rs
@@ -2,6 +2,7 @@ pub mod content;
 pub mod files;
 pub mod group_files;
 
+use crate::docs_generation::common::OutputFilesExtension;
 use crate::docs_generation::markdown::context::MarkdownGenerationContext;
 use crate::docs_generation::markdown::summary::content::{
     generate_foreign_crates_summary_content, generate_global_groups_summary_content,
@@ -18,9 +19,10 @@ use group_files::generate_global_groups_summary_files;
 
 pub fn generate_summary_file_content(
     crate_: &Crate,
+    output_format: OutputFilesExtension,
 ) -> Result<(SummaryIndexMap, Vec<(String, String)>)> {
     let mut summary_index_map = SummaryIndexMap::new();
-    let context = MarkdownGenerationContext::from_crate(crate_);
+    let context = MarkdownGenerationContext::from_crate(crate_, output_format);
 
     generate_module_summary_content(&crate_.root_module, 0, &mut summary_index_map);
     generate_foreign_crates_summary_content(&crate_.foreign_crates, &mut summary_index_map);

--- a/extensions/scarb-doc/src/docs_generation/markdown/summary/files.rs
+++ b/extensions/scarb-doc/src/docs_generation/markdown/summary/files.rs
@@ -1,11 +1,11 @@
+use crate::docs_generation::common::Filename;
 use crate::docs_generation::markdown::context::MarkdownGenerationContext;
 use crate::docs_generation::markdown::traits::{
     MarkdownDocItem, TopLevelMarkdownDocItem,
     generate_markdown_table_summary_for_top_level_subitems,
 };
 use crate::docs_generation::markdown::{
-    BASE_HEADER_LEVEL, BASE_MODULE_CHAPTER_PREFIX, Filename, SummaryIndexMap,
-    get_filename_with_extension,
+    BASE_HEADER_LEVEL, BASE_MODULE_CHAPTER_PREFIX, SummaryIndexMap, get_filename_with_extension,
 };
 use crate::docs_generation::{DocItem, TopLevelItems};
 use crate::types::module_type::Module;

--- a/extensions/scarb-doc/src/types/groups.rs
+++ b/extensions/scarb-doc/src/types/groups.rs
@@ -1,4 +1,4 @@
-use crate::docs_generation::markdown::get_filename_with_extension;
+use crate::docs_generation::common::get_filename_with_extension;
 use crate::types::module_type::{Module, ModulePubUses};
 use crate::types::other_types::{
     Constant, Enum, ExternFunction, ExternType, FreeFunction, Impl, ImplAlias, MacroDeclaration,

--- a/extensions/scarb-doc/tests/data/hello_world_doc_groups_reeksports/src/hello_world-macro_module-macro_definition.md
+++ b/extensions/scarb-doc/tests/data/hello_world_doc_groups_reeksports/src/hello_world-macro_module-macro_definition.md
@@ -1,6 +1,6 @@
 # macro_definition
 
-Fully qualified path: [hello_world](./hello_world.md)::[macro_module](./hello_world-macro_module.md)::[macro_definition](./hello_world-macro_module.md#macro_definition)
+Fully qualified path: [hello_world](./hello_world.md)::[macro_module](./hello_world-macro_module.md)::[macro_definition](./hello_world-macro_module-macro_definition.md)
 
 <pre><code class="language-cairo">macro macro_definition {
     ($name:ident) =&gt; { ... };

--- a/extensions/scarb-doc/tests/data/hello_world_no_features_mdx/src/hello_world-Circle.mdx
+++ b/extensions/scarb-doc/tests/data/hello_world_no_features_mdx/src/hello_world-Circle.mdx
@@ -1,22 +1,28 @@
-# Circle
+---
+ title: "hello_world::Circle"
+---
 
 Circle struct with radius field
 
-Fully qualified path: [hello_world](./hello_world.mdx)::[Circle](./hello_world-Circle.mdx)
+## Signature
 
-<pre><code class="language-cairo">#[derive(Drop, Serde, PartialEq)]
+```rust
+#[derive(Drop, Serde, PartialEq)]
 struct Circle {
     radius: u32,
-}</code></pre>
+}
+```
 
 ## Members
 
-### radius
+## radius
 
 Radius of the circle
 
-Fully qualified path: [hello_world](./hello_world.mdx)::[Circle](./hello_world-Circle.mdx)::[radius](./hello_world-Circle.mdx#radius)
+## Signature
 
-<pre><code class="language-cairo">radius: u32</code></pre>
+```rust
+radius: u32
+```
 
 

--- a/extensions/scarb-doc/tests/data/hello_world_no_features_mdx/src/hello_world-CircleDrop.mdx
+++ b/extensions/scarb-doc/tests/data/hello_world_no_features_mdx/src/hello_world-CircleDrop.mdx
@@ -1,6 +1,10 @@
-# CircleDrop
+---
+ title: "hello_world::CircleDrop"
+---
 
-Fully qualified path: [hello_world](./hello_world.mdx)::[CircleDrop](./hello_world-CircleDrop.mdx)
+## Signature
 
-<pre><code class="language-cairo">impl CircleDrop of Drop&lt;<a href="hello_world-Circle.html">Circle</a>&gt;;</code></pre>
+```rust
+impl CircleDrop of Drop<Circle>;
+```
 

--- a/extensions/scarb-doc/tests/data/hello_world_no_features_mdx/src/hello_world-CirclePartialEq.mdx
+++ b/extensions/scarb-doc/tests/data/hello_world_no_features_mdx/src/hello_world-CirclePartialEq.mdx
@@ -1,15 +1,21 @@
-# CirclePartialEq
+---
+ title: "hello_world::CirclePartialEq"
+---
 
-Fully qualified path: [hello_world](./hello_world.mdx)::[CirclePartialEq](./hello_world-CirclePartialEq.mdx)
+## Signature
 
-<pre><code class="language-cairo">impl CirclePartialEq of PartialEq&lt;<a href="hello_world-Circle.html">Circle</a>&gt;;</code></pre>
+```rust
+impl CirclePartialEq of PartialEq<Circle>;
+```
 
 ## Impl functions
 
-### eq
+## eq
 
-Fully qualified path: [hello_world](./hello_world.mdx)::[CirclePartialEq](./hello_world-CirclePartialEq.mdx)::[eq](./hello_world-CirclePartialEq.mdx#eq)
+## Signature
 
-<pre><code class="language-cairo">fn eq(lhs: Circle, rhs: Circle) -&gt; bool</code></pre>
+```rust
+fn eq(lhs: Circle, rhs: Circle) -> bool
+```
 
 

--- a/extensions/scarb-doc/tests/data/hello_world_no_features_mdx/src/hello_world-CircleSerde.mdx
+++ b/extensions/scarb-doc/tests/data/hello_world_no_features_mdx/src/hello_world-CircleSerde.mdx
@@ -1,22 +1,30 @@
-# CircleSerde
+---
+ title: "hello_world::CircleSerde"
+---
 
-Fully qualified path: [hello_world](./hello_world.mdx)::[CircleSerde](./hello_world-CircleSerde.mdx)
+## Signature
 
-<pre><code class="language-cairo">impl CircleSerde of Serde&lt;<a href="hello_world-Circle.html">Circle</a>&gt;;</code></pre>
+```rust
+impl CircleSerde of Serde<Circle>;
+```
 
 ## Impl functions
 
-### serialize
+## serialize
 
-Fully qualified path: [hello_world](./hello_world.mdx)::[CircleSerde](./hello_world-CircleSerde.mdx)::[serialize](./hello_world-CircleSerde.mdx#serialize)
+## Signature
 
-<pre><code class="language-cairo">fn serialize(self: Circle, ref output: Array&lt;felt252&gt;)</code></pre>
+```rust
+fn serialize(self: Circle, ref output: Array<felt252>)
+```
 
 
-### deserialize
+## deserialize
 
-Fully qualified path: [hello_world](./hello_world.mdx)::[CircleSerde](./hello_world-CircleSerde.mdx)::[deserialize](./hello_world-CircleSerde.mdx#deserialize)
+## Signature
 
-<pre><code class="language-cairo">fn deserialize(ref serialized: Span&lt;felt252&gt;) -&gt; Option&lt;Circle&gt;</code></pre>
+```rust
+fn deserialize(ref serialized: Span<felt252>) -> Option<Circle>
+```
 
 

--- a/extensions/scarb-doc/tests/data/hello_world_no_features_mdx/src/hello_world-CircleShape.mdx
+++ b/extensions/scarb-doc/tests/data/hello_world_no_features_mdx/src/hello_world-CircleShape.mdx
@@ -1,41 +1,51 @@
-# CircleShape
+---
+ title: "hello_world::CircleShape"
+---
 
 Implementation of the Shape trait for Circle
 
-Fully qualified path: [hello_world](./hello_world.mdx)::[CircleShape](./hello_world-CircleShape.mdx)
+## Signature
 
-<pre><code class="language-cairo">impl CircleShape of Shape&lt;<a href="hello_world-Circle.html">Circle</a>&gt;;</code></pre>
+```rust
+impl CircleShape of Shape<Circle>;
+```
 
 ## Impl constants
 
-### SHAPE_CONST
+## SHAPE_CONST
 
 Shape constant
 
-Fully qualified path: [hello_world](./hello_world.mdx)::[CircleShape](./hello_world-CircleShape.mdx)::[SHAPE_CONST](./hello_world-CircleShape.mdx#shape_const)
+## Signature
 
-<pre><code class="language-cairo">const SHAPE_CONST: felt252 = &apos;xyz&apos;;</code></pre>
+```rust
+const SHAPE_CONST: felt252 = 'xyz';
+```
 
 
 ## Impl functions
 
-### area
+## area
 
 Implementation of the area method for Circle
 
-Fully qualified path: [hello_world](./hello_world.mdx)::[CircleShape](./hello_world-CircleShape.mdx)::[area](./hello_world-CircleShape.mdx#area)
+## Signature
 
-<pre><code class="language-cairo">fn area(self: <a href="hello_world-Circle.html">Circle</a>) -&gt; u32</code></pre>
+```rust
+fn area(self: Circle) -> u32
+```
 
 
 ## Impl types
 
-### ShapePair
+## ShapePair
 
 Type alias for a pair of circles
 
-Fully qualified path: [hello_world](./hello_world.mdx)::[CircleShape](./hello_world-CircleShape.mdx)::[ShapePair](./hello_world-CircleShape.mdx#shapepair)
+## Signature
 
-<pre><code class="language-cairo">type ShapePair = (<a href="hello_world-Circle.html">Circle</a>, <a href="hello_world-Circle.html">Circle</a>);</code></pre>
+```rust
+type ShapePair = (Circle, Circle);
+```
 
 

--- a/extensions/scarb-doc/tests/data/hello_world_no_features_mdx/src/hello_world-Color.mdx
+++ b/extensions/scarb-doc/tests/data/hello_world_no_features_mdx/src/hello_world-Color.mdx
@@ -1,41 +1,51 @@
-# Color
+---
+ title: "hello_world::Color"
+---
 
 Color enum with Red, Green, and Blue variants
 
-Fully qualified path: [hello_world](./hello_world.mdx)::[Color](./hello_world-Color.mdx)
+## Signature
 
-<pre><code class="language-cairo">enum Color {
+```rust
+enum Color {
     Red,
     Green,
     Blue,
-}</code></pre>
+}
+```
 
 ## Variants
 
-### Red
+## Red
 
 Red color
 
-Fully qualified path: [hello_world](./hello_world.mdx)::[Color](./hello_world-Color.mdx)::[Red](./hello_world-Color.mdx#red)
+## Signature
 
-<pre><code class="language-cairo">Red</code></pre>
+```rust
+Red
+```
 
 
-### Green
+## Green
 
 Green color
 
-Fully qualified path: [hello_world](./hello_world.mdx)::[Color](./hello_world-Color.mdx)::[Green](./hello_world-Color.mdx#green)
+## Signature
 
-<pre><code class="language-cairo">Green</code></pre>
+```rust
+Green
+```
 
 
-### Blue
+## Blue
 
 Blue color
 
-Fully qualified path: [hello_world](./hello_world.mdx)::[Color](./hello_world-Color.mdx)::[Blue](./hello_world-Color.mdx#blue)
+## Signature
 
-<pre><code class="language-cairo">Blue</code></pre>
+```rust
+Blue
+```
 
 

--- a/extensions/scarb-doc/tests/data/hello_world_no_features_mdx/src/hello_world-FOO.mdx
+++ b/extensions/scarb-doc/tests/data/hello_world_no_features_mdx/src/hello_world-FOO.mdx
@@ -1,8 +1,12 @@
-# FOO
+---
+ title: "hello_world::FOO"
+---
 
 FOO constant with value 42
 
-Fully qualified path: [hello_world](./hello_world.mdx)::[FOO](./hello_world-FOO.mdx)
+## Signature
 
-<pre><code class="language-cairo">const FOO: u32 = 42;</code></pre>
+```rust
+const FOO: u32 = 42;
+```
 

--- a/extensions/scarb-doc/tests/data/hello_world_no_features_mdx/src/hello_world-Pair.mdx
+++ b/extensions/scarb-doc/tests/data/hello_world_no_features_mdx/src/hello_world-Pair.mdx
@@ -1,8 +1,12 @@
-# Pair
+---
+ title: "hello_world::Pair"
+---
 
 Pair type alias for a tuple of two u32 values
 
-Fully qualified path: [hello_world](./hello_world.mdx)::[Pair](./hello_world-Pair.mdx)
+## Signature
 
-<pre><code class="language-cairo">type Pair = (u32, u32);</code></pre>
+```rust
+type Pair = (u32, u32);
+```
 

--- a/extensions/scarb-doc/tests/data/hello_world_no_features_mdx/src/hello_world-Shape.mdx
+++ b/extensions/scarb-doc/tests/data/hello_world_no_features_mdx/src/hello_world-Shape.mdx
@@ -1,41 +1,51 @@
-# Shape
+---
+ title: "hello_world::Shape"
+---
 
 Shape trait for objects that have an area
 
-Fully qualified path: [hello_world](./hello_world.mdx)::[Shape](./hello_world-Shape.mdx)
+## Signature
 
-<pre><code class="language-cairo">trait Shape&lt;T&gt;</code></pre>
+```rust
+trait Shape<T>
+```
 
 ## Trait constants
 
-### SHAPE_CONST
+## SHAPE_CONST
 
 Constant for the shape type
 
-Fully qualified path: [hello_world](./hello_world.mdx)::[Shape](./hello_world-Shape.mdx)::[SHAPE_CONST](./hello_world-Shape.mdx#shape_const)
+## Signature
 
-<pre><code class="language-cairo">const SHAPE_CONST: felt252;</code></pre>
+```rust
+const SHAPE_CONST: felt252;
+```
 
 
 ## Trait functions
 
-### area
+## area
 
 Calculate the area of the shape
 
-Fully qualified path: [hello_world](./hello_world.mdx)::[Shape](./hello_world-Shape.mdx)::[area](./hello_world-Shape.mdx#area)
+## Signature
 
-<pre><code class="language-cairo">fn area(self: T) -&gt; u32</code></pre>
+```rust
+fn area(self: T) -> u32
+```
 
 
 ## Trait types
 
-### ShapePair
+## ShapePair
 
 Type alias for a pair of shapes
 
-Fully qualified path: [hello_world](./hello_world.mdx)::[Shape](./hello_world-Shape.mdx)::[ShapePair](./hello_world-Shape.mdx#shapepair)
+## Signature
 
-<pre><code class="language-cairo">type ShapePair;</code></pre>
+```rust
+type ShapePair;
+```
 
 

--- a/extensions/scarb-doc/tests/data/hello_world_no_features_mdx/src/hello_world-fib.mdx
+++ b/extensions/scarb-doc/tests/data/hello_world_no_features_mdx/src/hello_world-fib.mdx
@@ -1,10 +1,14 @@
-# fib
+---
+ title: "hello_world::fib"
+---
 
 Calculate the nth Fibonacci number
 # Arguments
 - `n` - The index of the Fibonacci number to calculate
 
-Fully qualified path: [hello_world](./hello_world.mdx)::[fib](./hello_world-fib.mdx)
+## Signature
 
-<pre><code class="language-cairo">fn fib(mut n: u32) -&gt; u32</code></pre>
+```rust
+fn fib(mut n: u32) -> u32
+```
 

--- a/extensions/scarb-doc/tests/data/hello_world_no_features_mdx/src/hello_world-main.mdx
+++ b/extensions/scarb-doc/tests/data/hello_world_no_features_mdx/src/hello_world-main.mdx
@@ -1,8 +1,12 @@
-# main
+---
+ title: "hello_world::main"
+---
 
 Main function that calculates the 16th Fibonacci number
 
-Fully qualified path: [hello_world](./hello_world.mdx)::[main](./hello_world-main.mdx)
+## Signature
 
-<pre><code class="language-cairo">fn main() -&gt; u32</code></pre>
+```rust
+fn main() -> u32
+```
 

--- a/extensions/scarb-doc/tests/data/hello_world_no_features_mdx/src/hello_world-tests-it_works.mdx
+++ b/extensions/scarb-doc/tests/data/hello_world_no_features_mdx/src/hello_world-tests-it_works.mdx
@@ -1,9 +1,13 @@
-# it_works
+---
+ title: "hello_world::tests::it_works"
+---
 
 Really
 works.
 
-Fully qualified path: [hello_world](./hello_world.mdx)::[tests](./hello_world-tests.mdx)::[it_works](./hello_world-tests-it_works.mdx)
+## Signature
 
-<pre><code class="language-cairo">fn it_works()</code></pre>
+```rust
+fn it_works()
+```
 

--- a/extensions/scarb-doc/tests/data/hello_world_no_features_mdx/src/hello_world-tests.mdx
+++ b/extensions/scarb-doc/tests/data/hello_world_no_features_mdx/src/hello_world-tests.mdx
@@ -1,8 +1,8 @@
-# tests
+---
+ title: "hello_world::tests"
+---
 
 Tests module
-
-Fully qualified path: [hello_world](./hello_world.mdx)::[tests](./hello_world-tests.mdx)
 
 
 ## [Free functions](./hello_world-tests-free_functions.mdx)

--- a/extensions/scarb-doc/tests/data/hello_world_no_features_mdx/src/hello_world.mdx
+++ b/extensions/scarb-doc/tests/data/hello_world_no_features_mdx/src/hello_world.mdx
@@ -1,8 +1,8 @@
-# hello_world
+---
+ title: "hello_world"
+---
 
 Fibonacci sequence calculator
-
-Fully qualified path: [hello_world](./hello_world.mdx)
 
 
 ## [Modules](./hello_world-modules.mdx)


### PR DESCRIPTION
closes https://github.com/software-mansion/scarb/issues/2794

- I decided to treat the `.mdx` as a special case of markdown, this aligns with the [mdx idea](https://mdxjs.com/#:~:text=Markdown%20for%20the%0Acomponent%20era) and saves us from writing and maintaining a lot of additional code that would not differ significantly from what's already implemented for markdown output 