### PR TITLE
Add --open flag to scarb doc command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5348,6 +5348,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
+name = "normpath"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf23ab2b905654b4cb177e30b629937b3868311d4e1cba859f899c041046e69b"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "ntest"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5508,6 +5517,17 @@ dependencies = [
  "dashmap",
  "futures",
  "tokio",
+]
+
+[[package]]
+name = "opener"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb9024962ab91e00c89d2a14352a8d0fc1a64346bf96f1839b45c09149564e47"
+dependencies = [
+ "bstr",
+ "normpath",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6939,6 +6959,7 @@ dependencies = [
  "indoc",
  "itertools 0.14.0",
  "mimalloc",
+ "opener",
  "salsa",
  "scarb-extensions-cli",
  "scarb-metadata 1.15.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,7 @@ mdbook-driver = "0.5"
 mimalloc = "0.1.48"
 ntest = "0.9"
 once_cell = "1"
+opener = "0.8.3"
 pathdiff = { version = "0.2", features = ["camino"] }
 petgraph = "0.8"
 predicates = "3"

--- a/extensions/scarb-doc/Cargo.toml
+++ b/extensions/scarb-doc/Cargo.toml
@@ -25,6 +25,7 @@ expect-test.workspace = true
 indoc.workspace = true
 itertools.workspace = true
 mimalloc.workspace = true
+opener.workspace = true
 scarb-metadata = { path = "../../scarb-metadata" }
 scarb-ui = { path = "../../utils/scarb-ui" }
 scarb-extensions-cli = { path = "../../utils/scarb-extensions-cli", default-features = false, features = ["doc"] }

--- a/utils/scarb-extensions-cli/src/doc.rs
+++ b/utils/scarb-extensions-cli/src/doc.rs
@@ -45,6 +45,12 @@ pub struct Args {
     #[arg(long, default_value_t = false)]
     pub build: bool,
 
+    /// Open the generated documentation in a browser.
+    ///
+    /// Implies `--build`.
+    #[arg(long, default_value_t = false)]
+    pub open: bool,
+
     /// Specifies features to enable.
     #[command(flatten)]
     pub features: FeaturesSpec,


### PR DESCRIPTION
This commit adds a new  flag to the  command.
When provided, this flag enforces documentation building (equivalent to ) and then attempts to open the generated documentation in the default browser using the  crate.

- Added  crate dependency.
- Updated  struct in  to include  flag.
- Updated  to handle  flag and open the index.html file.
- Added integration test for the new flag.