### PR TITLE
scarb doc: one db across workspace

### DIFF
--- a/extensions/scarb-doc/src/db.rs
+++ b/extensions/scarb-doc/src/db.rs
@@ -24,11 +24,14 @@ pub struct ScarbDocDatabase {
     storage: salsa::Storage<Self>,
 }
 
+impl Default for ScarbDocDatabase {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ScarbDocDatabase {
-    pub fn new(
-        project_config: ProjectConfig,
-        crates_with_starknet: Vec<&CompilationUnitComponentMetadata>,
-    ) -> Self {
+    pub fn new() -> Self {
         let mut db = Self {
             storage: Default::default(),
         };
@@ -40,8 +43,6 @@ impl ScarbDocDatabase {
 
         db.use_cfg(&Self::initial_cfg_set());
         db.set_default_plugins_from_suite(get_default_plugin_suite());
-        db.apply_project_config(project_config);
-        db.apply_starknet_plugin(crates_with_starknet);
 
         db
     }
@@ -50,11 +51,11 @@ impl ScarbDocDatabase {
         CfgSet::from_iter([Cfg::name("doc")])
     }
 
-    fn apply_project_config(&mut self, config: ProjectConfig) {
+    pub fn apply_project_config(&mut self, config: ProjectConfig) {
         update_crate_roots_from_project_config(self, &config);
     }
 
-    fn apply_starknet_plugin(&mut self, components: Vec<&CompilationUnitComponentMetadata>) {
+    pub fn apply_starknet_plugin(&mut self, components: Vec<&CompilationUnitComponentMetadata>) {
         for component in components {
             let plugin_suite = [get_default_plugin_suite(), starknet_plugin_suite()]
                 .into_iter()

--- a/extensions/scarb-doc/src/linking.rs
+++ b/extensions/scarb-doc/src/linking.rs
@@ -6,6 +6,14 @@ use scarb_ui::Ui;
 use std::ops::Range;
 use std::path::{Path, PathBuf};
 
+pub struct RemoteDocLinkingParams<'a> {
+    pub workspace_root: &'a Utf8PathBuf,
+    pub repo_root: &'a Option<PathBuf>,
+    pub commit_hash: &'a Option<String>,
+    pub disable_linking: bool,
+    pub remote_base_url: &'a Option<String>,
+}
+
 /// A data holder necessary for creating documentation links to a remote repository.
 #[derive(Clone)]
 pub enum RemoteDocLinkingData {


### PR DESCRIPTION
- What 
Performance improvement for documentation generation in workspace. 

- Why 
Performance is not crucial for scarb doc though certainly a nice-to-see. The reason why I troubled myself with that at all is that it alignes with couple of improvements I have discussed with @Arcticae that will follow this PR. 

Benchmarking results 👇

1️⃣ **Alexandria:** 

BEFORE (current implementation)
```
➜ alexandria git:(main) ✗ hyperfine --warmup=1 '/Users/kingacepielik/starkware/scarb/target/release/scarb doc --disable-remote-linking -p alexandria_encoding;
'
Benchmark 1: /Users/kingacepielik/starkware/scarb/target/release/scarb doc --disable-remote-linking -p alexandria_encoding;
 Time (mean ± σ):   491.6 ms ±  4.6 ms  [User: 377.3 ms, System: 103.3 ms]
 Range (min … max):  487.4 ms … 503.5 ms  10 runs

➜ alexandria git:(main) ✗ hyperfine --warmup=1 '/Users/kingacepielik/starkware/scarb/target/release/scarb doc --disable-remote-linking --workspace --exclude alexandria_macros';
Benchmark 1: /Users/kingacepielik/starkware/scarb/target/release/scarb doc --disable-remote-linking --workspace --exclude alexandria_macros
 Time (mean ± σ):   2.828 s ±  0.064 s  [User: 2.584 s, System: 0.225 s]
 Range (min … max):   2.766 s …  2.980 s  10 runs
```

AFTER (the PR)
```
➜ alexandria git:(main) ✗ hyperfine --warmup=1 '/Users/kingacepielik/starkware/scarb/target_one_db/release/scarb doc --disable-remote-linking -p alexandria_encoding;
'
Benchmark 1: /Users/kingacepielik/starkware/scarb/target_one_db/release/scarb doc --disable-remote-linking -p alexandria_encoding;
 Time (mean ± σ):   516.6 ms ±  65.5 ms  [User: 383.9 ms, System: 120.0 ms]
 Range (min … max):  489.3 ms … 700.8 ms  10 runs
 Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.

➜ alexandria git:(main) ✗ hyperfine --warmup=1 '/Users/kingacepielik/starkware/scarb/target_one_db/release/scarb doc --disable-remote-linking --workspace --exclude alexandria_macros';
Benchmark 1: /Users/kingacepielik/starkware/scarb/target_one_db/release/scarb doc --disable-remote-linking --workspace --exclude alexandria_macros
 Time (mean ± σ):   1.851 s ±  0.078 s  [User: 1.617 s, System: 0.211 s]
 Range (min … max):   1.758 s …  2.034 s  10 runs
```

2️⃣ **Corelib**

BEFORE (current implementation)
```
Benchmark 1: /Users/kingacepielik/starkware/scarb/target/release/scarb doc --disable-remote-linking --workspace
 Time (mean ± σ):   454.6 ms ±  24.3 ms  [User: 373.9 ms, System: 74.6 ms]
 Range (min … max):  439.6 ms … 520.3 ms  10 runs
 Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.
 
Benchmark 1: /Users/kingacepielik/starkware/scarb/target/release/scarb doc --disable-remote-linking
 Time (mean ± σ):   441.9 ms ±  3.2 ms  [User: 365.8 ms, System: 71.5 ms]
 Range (min … max):  434.2 ms … 447.1 ms  10 runs
 ```
 
 AFTER (the PR)
 ```
Benchmark 1: /Users/kingacepielik/starkware/scarb/target_one_db/release/scarb doc --disable-remote-linking --workspace
 Time (mean ± σ):   441.9 ms ±  35.1 ms  [User: 358.9 ms, System: 70.2 ms]
 Range (min … max):  424.7 ms … 539.6 ms  10 runs
 Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.
 
Benchmark 1: /Users/kingacepielik/starkware/scarb/target_one_db/release/scarb doc --disable-remote-linking
 Time (mean ± σ):   429.3 ms ±  8.8 ms  [User: 357.7 ms, System: 68.4 ms]
 Range (min … max):  423.1 ms … 452.4 ms  10 runs 
 ```
 
 3️⃣ **Openzeppelin**
 BEFORE (current implementation)
 ```
Benchmark 1: /Users/kingacepielik/starkware/scarb/target/release/scarb doc --disable-remote-linking --workspace --exclude openzeppelin_macros --exclude openzeppelin_test_common
 Time (mean ± σ):   10.904 s ±  0.255 s  [User: 10.199 s, System: 0.632 s]
 Range (min … max):  10.648 s … 11.575 s  10 runs
 
Benchmark 1: /Users/kingacepielik/starkware/scarb/target/release/scarb doc --disable-remote-linking
 Time (mean ± σ):   2.336 s ±  0.013 s  [User: 2.053 s, System: 0.241 s]
 Range (min … max):   2.310 s …  2.351 s  10 runs
 ```
 
  AFTER (the PR)
 ```
Benchmark 1: /Users/kingacepielik/starkware/scarb/target_one_db/release/scarb doc --disable-remote-linking --workspace --exclude openzeppelin_macros --exclude openzeppelin_test_common
 Time (mean ± σ):   4.791 s ±  0.292 s  [User: 4.172 s, System: 0.565 s]
 Range (min … max):   4.663 s …  5.615 s  10 runs
 Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.
 
Benchmark 1: /Users/kingacepielik/starkware/scarb/target_one_db/release/scarb doc --disable-remote-linking
 Time (mean ± σ):   2.339 s ±  0.017 s  [User: 2.056 s, System: 0.244 s]
 Range (min … max):   2.308 s …  2.359 s  10 runs
```
