### PR TITLE
new stable dtolnay/rust-toolchain fix style

### DIFF
--- a/scarb/src/ops/proc_macro_server/methods/expand_derive.rs
+++ b/scarb/src/ops/proc_macro_server/methods/expand_derive.rs
@@ -84,8 +84,8 @@ impl Handler for ExpandDerive {
 
             current_width = current_width + TextWidth::from_str(&result.token_stream.to_string());
 
-            if result.code_mappings.is_some() {
-                code_mappings.extend(result.code_mappings.unwrap());
+            if let Some(mappings) = result.code_mappings {
+                code_mappings.extend(mappings);
             }
 
             // Register diagnostics.


### PR DESCRIPTION
fixes clippy::unnecessary-unwrap

☝️ Breaks in the newest stable [Rust toolchain version 1.93.0](https://blog.rust-lang.org/2026/01/22/Rust-1.93.0/), released on January 23, 2026 causing all check-rust jobs to fail ([example](https://github.com/software-mansion/scarb/actions/runs/21271142975/job/61221362422))