### PR TITLE
Support runnable code blocks in docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7063,6 +7063,7 @@ dependencies = [
  "cairo-lang-utils",
  "camino",
  "clap",
+ "console",
  "expect-test",
  "gix",
  "indoc",
@@ -7070,14 +7071,15 @@ dependencies = [
  "mimalloc",
  "opener",
  "salsa",
+ "scarb-build-metadata",
  "scarb-extensions-cli",
  "scarb-metadata 1.15.1",
  "scarb-test-support",
  "scarb-ui",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
- "walkdir",
 ]
 
 [[package]]

--- a/extensions/scarb-doc/Cargo.toml
+++ b/extensions/scarb-doc/Cargo.toml
@@ -10,8 +10,6 @@ repository.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-camino.workspace = true
-clap.workspace = true
 cairo-lang-compiler.workspace = true
 cairo-lang-defs.workspace = true
 cairo-lang-diagnostics.workspace = true
@@ -22,21 +20,25 @@ cairo-lang-semantic.workspace = true
 cairo-lang-starknet.workspace = true
 cairo-lang-syntax.workspace = true
 cairo-lang-utils.workspace = true
+camino.workspace = true
+clap.workspace = true
+console.workspace = true
 expect-test.workspace = true
 gix.workspace = true
 indoc.workspace = true
 itertools.workspace = true
 mimalloc.workspace = true
 opener.workspace = true
+salsa.workspace = true
+scarb-build-metadata = { path = "../../utils/scarb-build-metadata" }
+scarb-extensions-cli = { path = "../../utils/scarb-extensions-cli", default-features = false, features = ["doc"] }
 scarb-metadata = { path = "../../scarb-metadata" }
 scarb-ui = { path = "../../utils/scarb-ui" }
-scarb-extensions-cli = { path = "../../utils/scarb-extensions-cli", default-features = false, features = ["doc"] }
 serde.workspace = true
 serde_json.workspace = true
-salsa.workspace = true
+tempfile.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
 assert_fs.workspace = true
 scarb-test-support = { path = "../../utils/scarb-test-support" }
-walkdir.workspace = true

--- a/extensions/scarb-doc/src/doc_test.rs
+++ b/extensions/scarb-doc/src/doc_test.rs
@@ -1,0 +1,4 @@
+pub mod code_blocks;
+pub mod runner;
+mod ui;
+mod workspace;

--- a/extensions/scarb-doc/src/doc_test/code_blocks.rs
+++ b/extensions/scarb-doc/src/doc_test/code_blocks.rs
@@ -1,0 +1,278 @@
+use crate::doc_test::runner::RunStrategy;
+use crate::types::crate_type::Crate;
+use crate::types::module_type::Module;
+use cairo_lang_doc::parser::DocumentationCommentToken;
+use itertools::Itertools;
+use std::collections::HashMap;
+use std::str::from_utf8;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
+pub struct CodeBlockId {
+    pub item_full_path: String,
+    pub close_token_idx: usize,
+    /// Index of this block in the item's documentation.
+    pub block_index: usize,
+}
+
+impl CodeBlockId {
+    pub fn new(item_full_path: String, block_index: usize, close_token_idx: usize) -> Self {
+        Self {
+            item_full_path,
+            block_index,
+            close_token_idx,
+        }
+    }
+
+    // TODO: (#2888): Display exact code block location when running doc-tests
+    pub fn display_name(&self, total_blocks_in_item: usize) -> String {
+        if total_blocks_in_item <= 1 {
+            self.item_full_path.clone()
+        } else {
+            format!("{} (example {})", self.item_full_path, self.block_index + 1)
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CodeBlockAttribute {
+    Cairo,
+    Runnable,
+    Ignore,
+    NoRun,
+    CompileFail,
+    ShouldPanic,
+    Other(String),
+}
+
+impl From<&str> for CodeBlockAttribute {
+    fn from(string: &str) -> Self {
+        match string.to_lowercase().as_str() {
+            "cairo" => CodeBlockAttribute::Cairo,
+            "runnable" => CodeBlockAttribute::Runnable,
+            "ignore" => CodeBlockAttribute::Ignore,
+            "no_run" => CodeBlockAttribute::NoRun,
+            "should_panic" => CodeBlockAttribute::ShouldPanic,
+            "compile_fail" => CodeBlockAttribute::CompileFail,
+            _ => CodeBlockAttribute::Other(string.to_string()),
+        }
+    }
+}
+
+/// Represents code block extracted from doc comments.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CodeBlock {
+    pub id: CodeBlockId,
+    pub content: String,
+    pub attributes: Vec<CodeBlockAttribute>,
+}
+
+impl CodeBlock {
+    pub fn new(id: CodeBlockId, content: String, info_string: &str) -> Self {
+        let attributes = Self::parse_attributes(info_string);
+        Self {
+            id,
+            content,
+            attributes,
+        }
+    }
+
+    fn parse_attributes(info_string: &str) -> Vec<CodeBlockAttribute> {
+        info_string
+            .split(',')
+            .map(|attr| attr.trim())
+            .filter(|attr| !attr.is_empty())
+            .dedup()
+            .map(Into::into)
+            .collect()
+    }
+
+    // TODO(#3096): default to Cairo unless specified otherwise
+    fn is_cairo(&self) -> bool {
+        self.attributes.contains(&CodeBlockAttribute::Cairo)
+    }
+
+    pub fn run_strategy(&self) -> RunStrategy {
+        if self.attributes.contains(&CodeBlockAttribute::Ignore) {
+            return RunStrategy::Ignore;
+        }
+        // TODO: drop the `runnable` attribute requirement; default to runnable for Cairo blocks
+        if !self.is_cairo() || !self.attributes.contains(&CodeBlockAttribute::Runnable) {
+            return RunStrategy::Ignore;
+        }
+        if self.attributes.contains(&CodeBlockAttribute::NoRun)
+            || self.attributes.contains(&CodeBlockAttribute::CompileFail)
+        {
+            return RunStrategy::Build;
+        }
+        RunStrategy::Execute
+    }
+}
+
+pub fn collect_code_blocks(crate_: &Crate<'_>) -> Vec<CodeBlock> {
+    let mut runnable_code_blocks = Vec::new();
+    collect_from_module(&crate_.root_module, &mut runnable_code_blocks);
+    for module in &crate_.foreign_crates {
+        collect_from_module(module, &mut runnable_code_blocks);
+    }
+    runnable_code_blocks.sort_by_key(|block| block.id.clone());
+    runnable_code_blocks.dedup_by_key(|block| block.id.clone());
+    runnable_code_blocks
+}
+
+/// Counts the number of code blocks per documented item. Used to generate display names
+/// for code blocks, allowing to distinguish between multiple code blocks in the same item.
+///
+/// Returns the mapping from `item_full_path` to the number of code blocks in that item.
+pub fn count_blocks_per_item(code_blocks: &[CodeBlock]) -> HashMap<String, usize> {
+    let mut counts = HashMap::new();
+    for block in code_blocks {
+        *counts.entry(block.id.item_full_path.clone()).or_insert(0) += 1;
+    }
+    counts
+}
+
+fn collect_from_module(module: &Module<'_>, runnable_code_blocks: &mut Vec<CodeBlock>) {
+    for &item_data in module.get_all_item_ids().values() {
+        for block in &item_data.code_blocks() {
+            runnable_code_blocks.push(block.clone());
+        }
+    }
+    for &item_data in module.pub_uses.get_all_item_ids().values() {
+        for block in &item_data.code_blocks() {
+            runnable_code_blocks.push(block.clone());
+        }
+    }
+}
+
+pub fn collect_code_blocks_from_tokens(
+    doc_tokens: &Option<Vec<DocumentationCommentToken>>,
+    full_path: &str,
+) -> Vec<CodeBlock> {
+    let Some(tokens) = doc_tokens else {
+        return Vec::new();
+    };
+
+    #[derive(Debug)]
+    struct CodeFence {
+        token_idx: usize,
+        char: u8,
+        len: usize,
+        info_string: String,
+    }
+
+    let mut code_blocks = Vec::new();
+    let mut current_fence: Option<CodeFence> = None;
+    let mut block_index: usize = 0;
+
+    for (idx, token) in tokens.iter().enumerate() {
+        let content = match token {
+            DocumentationCommentToken::Content(content) => content.trim(),
+            DocumentationCommentToken::Link(_) => continue,
+        };
+        if content.is_empty() {
+            continue;
+        }
+        match current_fence {
+            // Handle potential closing fence.
+            Some(ref opening) => {
+                if is_matching_closing_fence(content, opening.char, opening.len) {
+                    let end_idx = idx;
+                    let body = get_block_body(tokens, opening.token_idx + 1, end_idx);
+
+                    // Skip empty code blocks.
+                    if !body.is_empty() {
+                        let id = CodeBlockId::new(full_path.to_string(), block_index, end_idx);
+                        code_blocks.push(CodeBlock::new(
+                            id,
+                            body.to_string(),
+                            &opening.info_string,
+                        ));
+                        block_index += 1;
+                    }
+                    current_fence = None;
+                }
+            }
+            // Handle potential opening fence.
+            None => {
+                if let Some((len, char)) = scan_code_fence(content.as_bytes()) {
+                    let bytes = content.as_bytes();
+                    let after = &bytes[len..];
+                    let info_string = from_utf8(after).unwrap_or("").trim().to_string();
+
+                    current_fence = Some(CodeFence {
+                        token_idx: idx,
+                        char,
+                        len,
+                        info_string,
+                    });
+                }
+            }
+        }
+    }
+    // There may be an unterminated fence at this point, but this is allowed from the spec perspective, so we ignore it.
+    code_blocks
+}
+
+fn get_block_body(
+    tokens: &[DocumentationCommentToken],
+    start_idx: usize,
+    end_idx: usize,
+) -> String {
+    tokens[start_idx..end_idx]
+        .iter()
+        .filter_map(|token| match token {
+            DocumentationCommentToken::Content(content) => Some(content.as_str()),
+            DocumentationCommentToken::Link(_) => None,
+        })
+        .collect::<Vec<_>>()
+        .join("")
+        .trim()
+        .to_string()
+}
+
+/// Checks if the given `content` is a closing fence matching the given opening fence.
+fn is_matching_closing_fence(content: &str, opening_char: u8, opening_len: usize) -> bool {
+    let bytes = content.as_bytes();
+    let Some((len, ch)) = scan_code_fence(bytes) else {
+        return false;
+    };
+    ch == opening_char
+        && len >= opening_len
+        && bytes[len..]
+            .iter()
+            .all(|&b| matches!(b, b' ' | b'\t' | b'\r' | b'\n'))
+}
+
+/// Copied from `pulldown-cmark`:
+/// https://github.com/pulldown-cmark/pulldown-cmark/blob/a574ea8a5e6fda7bc26542a612130a2b458a68a7/pulldown-cmark/src/scanners.rs#L744
+fn scan_code_fence(data: &[u8]) -> Option<(usize, u8)> {
+    let c = *data.first()?;
+    if !(c == b'`' || c == b'~') {
+        return None;
+    }
+    let i = 1 + scan_ch_repeat(&data[1..], c);
+    if i >= 3 {
+        if c == b'`' {
+            let suffix = &data[i..];
+            let next_line = i + scan_nextline(suffix);
+            // FIXME: make sure this is correct
+            if suffix[..(next_line - i)].contains(&b'`') {
+                return None;
+            }
+        }
+        Some((i, c))
+    } else {
+        None
+    }
+}
+
+fn scan_ch_repeat(data: &[u8], c: u8) -> usize {
+    data.iter().take_while(|&&b| b == c).count()
+}
+
+fn scan_nextline(bytes: &[u8]) -> usize {
+    bytes
+        .iter()
+        .position(|&b| b == b'\n')
+        .map_or(bytes.len(), |x| x + 1)
+}

--- a/extensions/scarb-doc/src/doc_test/runner.rs
+++ b/extensions/scarb-doc/src/doc_test/runner.rs
@@ -1,0 +1,380 @@
+use crate::AdditionalMetadata;
+use crate::doc_test::code_blocks::{
+    CodeBlock, CodeBlockAttribute, CodeBlockId, count_blocks_per_item,
+};
+use crate::doc_test::ui::TestResultStatus;
+use crate::doc_test::workspace::DocTestWorkspace;
+use anyhow::{Context, Result};
+use itertools::Itertools;
+use scarb_metadata::ScarbCommand;
+use scarb_ui::Ui;
+use scarb_ui::components::{NewLine, Status};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::process::{Command, Stdio};
+use tempfile::TempDir;
+use tempfile::tempdir;
+
+pub type ExecutionResults = HashMap<CodeBlockId, ExecutionResult>;
+
+#[derive(Debug, Clone)]
+pub struct ExecutionResult {
+    pub status: TestStatus,
+    pub print_output: String,
+    pub program_output: String,
+    pub outcome: ExecutionOutcome,
+}
+
+impl ExecutionResult {
+    pub fn as_markdown(&self) -> String {
+        let mut output = String::new();
+        if !self.print_output.is_empty() {
+            output.push_str("\nOutput:\n```\n");
+            output.push_str(&self.print_output);
+            output.push_str("\n```\n");
+        }
+        if !self.program_output.is_empty() {
+            output.push_str("\nResult:\n```\n");
+            output.push_str(&self.program_output);
+            output.push_str("\n```\n");
+        }
+        if output.is_empty() && self.outcome == ExecutionOutcome::RunSuccess {
+            output.push_str("\n*No output.*\n");
+        }
+        output
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct TestSummary {
+    pub passed: usize,
+    pub failed: usize,
+    pub ignored: usize,
+}
+
+impl TestSummary {
+    pub fn is_ok(&self) -> bool {
+        self.failed == 0
+    }
+
+    pub fn is_fail(&self) -> bool {
+        self.failed > 0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TestStatus {
+    Passed,
+    Failed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExecutionOutcome {
+    BuildSuccess,
+    RunSuccess,
+    CompileError,
+    RuntimeError,
+    None,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RunStrategy {
+    Ignore,
+    Build,
+    Execute,
+}
+
+/// A runner for executing ([`CodeBlock`]) examples found in documentation of a single package.
+/// Uses the target package as a dependency and runs each code block in an isolated temporary workspace.
+/// Relies on `scarb build` and `scarb execute` commands to build and run the examples,
+/// based on the requested [`RunStrategy`] for the given code block.
+///
+/// Note: it is expected examples (`code_blocks`) that this runner executes only depend on the target package and standard libraries.
+pub struct TestRunner<'a> {
+    /// Metadata of the target package whose documentation is being tested.
+    metadata: &'a AdditionalMetadata,
+    has_lib_target: bool,
+    ui: Ui,
+    /// Target directory shared between all doc test runs within one package.
+    /// This allows speeding up doc tests compilation by sharing incremental caches.
+    target_dir: TempDir,
+}
+
+impl<'a> TestRunner<'a> {
+    pub fn new(metadata: &'a AdditionalMetadata, has_lib_target: bool, ui: Ui) -> Result<Self> {
+        let target_dir =
+            tempdir().context("failed to create directory for doc tests target directory")?;
+        Ok(Self {
+            metadata,
+            has_lib_target,
+            ui,
+            target_dir,
+        })
+    }
+
+    pub fn run_all(&self, code_blocks: &[CodeBlock]) -> Result<(TestSummary, ExecutionResults)> {
+        let pkg_name = &self.metadata.name;
+
+        let mut results = HashMap::new();
+        let mut summary = TestSummary::default();
+        let mut failed_names = Vec::new();
+        let blocks_per_item = count_blocks_per_item(code_blocks);
+
+        self.ui.print(Status::new(
+            "Running",
+            &format!("{} doc examples for `{pkg_name}`", code_blocks.len()),
+        ));
+
+        let mut idx = 0;
+        for block in code_blocks {
+            let strategy = block.run_strategy();
+            let total_in_item = *blocks_per_item.get(&block.id.item_full_path).unwrap_or(&1);
+            let display_name = block.id.display_name(total_in_item);
+
+            match strategy {
+                RunStrategy::Ignore => {
+                    summary.ignored += 1;
+                    self.ui
+                        .print(TestResultStatus::Ignored.display_for(&display_name));
+                }
+                _ => {
+                    idx += 1;
+                    match self.run_single(block, strategy, idx) {
+                        Ok(res) => match res.status {
+                            TestStatus::Passed => {
+                                summary.passed += 1;
+                                self.ui
+                                    .print(TestResultStatus::Ok.display_for(&display_name));
+                                results.insert(block.id.clone(), res);
+                            }
+                            TestStatus::Failed => {
+                                summary.failed += 1;
+                                self.ui.print(res.print_output.clone());
+                                self.ui.print(res.program_output.clone());
+                                self.ui
+                                    .print(TestResultStatus::Failed.display_for(&display_name));
+                                failed_names.push(display_name);
+                            }
+                        },
+                        Err(e) => {
+                            summary.failed += 1;
+                            self.ui
+                                .print(TestResultStatus::Failed.display_for(&display_name));
+                            failed_names.push(display_name);
+                            self.ui.error(format!("Error running example: {:#}", e));
+                        }
+                    }
+                }
+            }
+        }
+        // TODO(#3097): add struct with `impl Message` to display this
+        if !failed_names.is_empty() {
+            self.ui.print("\nfailures:");
+            for display_name in &failed_names {
+                self.ui.print(format!("    {}", display_name));
+            }
+        }
+        self.ui.print(NewLine::new());
+        self.ui.print(summary.clone());
+
+        Ok((summary, results))
+    }
+
+    fn run_single(
+        &self,
+        code_block: &CodeBlock,
+        strategy: RunStrategy,
+        index: usize,
+    ) -> Result<ExecutionResult> {
+        let ws = DocTestWorkspace::new(
+            self.metadata,
+            index,
+            code_block,
+            self.has_lib_target,
+            &self.ui,
+        )?;
+        let (actual, print_output, program_output) = self.run_single_inner(&ws, strategy)?;
+
+        let status = match (strategy, actual) {
+            (RunStrategy::Build, ExecutionOutcome::CompileError) => {
+                if code_block
+                    .attributes
+                    .contains(&CodeBlockAttribute::CompileFail)
+                {
+                    TestStatus::Passed
+                } else {
+                    TestStatus::Failed
+                }
+            }
+            (RunStrategy::Build, ExecutionOutcome::BuildSuccess) => {
+                if code_block
+                    .attributes
+                    .contains(&CodeBlockAttribute::CompileFail)
+                {
+                    self.ui
+                        .error("Test compiled successfully, but it's marked `compile_fail`.");
+                    TestStatus::Failed
+                } else {
+                    TestStatus::Passed
+                }
+            }
+            (RunStrategy::Execute, ExecutionOutcome::RunSuccess) => {
+                if code_block
+                    .attributes
+                    .contains(&CodeBlockAttribute::ShouldPanic)
+                {
+                    self.ui
+                        .error("Test executable succeeded, but it's marked `should_panic`.");
+                    TestStatus::Failed
+                } else {
+                    TestStatus::Passed
+                }
+            }
+            (RunStrategy::Execute, ExecutionOutcome::RuntimeError) => {
+                if code_block
+                    .attributes
+                    .contains(&CodeBlockAttribute::ShouldPanic)
+                {
+                    TestStatus::Passed
+                } else {
+                    TestStatus::Failed
+                }
+            }
+            _ => TestStatus::Failed,
+        };
+
+        Ok(ExecutionResult {
+            outcome: actual,
+            status,
+            print_output,
+            program_output,
+        })
+    }
+
+    fn run_single_inner(
+        &self,
+        ws: &DocTestWorkspace,
+        strategy: RunStrategy,
+    ) -> Result<(ExecutionOutcome, String, String)> {
+        if strategy == RunStrategy::Ignore {
+            unreachable!("the code block should be filtered out before reaching here");
+        }
+        let build_result = ScarbCommand::new()
+            .arg("build")
+            .current_dir(ws.root())
+            .env("SCARB_TARGET_DIR", self.target_dir.path())
+            .env("SCARB_UI_VERBOSITY", self.ui.verbosity().to_string())
+            .env("SCARB_MANIFEST_PATH", ws.manifest_path().as_str())
+            .env("SCARB_ALL_FEATURES", "true")
+            .run();
+
+        if build_result.is_err() {
+            return Ok((ExecutionOutcome::CompileError, String::new(), String::new()));
+        } else if strategy == RunStrategy::Build {
+            return Ok((ExecutionOutcome::BuildSuccess, String::new(), String::new()));
+        }
+
+        let scarb_path = std::env::var("SCARB").unwrap_or_else(|_| "scarb".to_string());
+        let run_result = Command::new(scarb_path)
+            .args([
+                "--json",
+                "execute",
+                "--no-build",
+                "--output=none",
+                "--print-program-output",
+            ])
+            .current_dir(ws.root())
+            .env("SCARB_TARGET_DIR", self.target_dir.path())
+            .env("SCARB_UI_VERBOSITY", "no-warnings")
+            .env("SCARB_MANIFEST_PATH", ws.manifest_path().as_str())
+            .env("SCARB_ALL_FEATURES", "true")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .output();
+
+        match run_result {
+            Err(_) => Ok((ExecutionOutcome::RuntimeError, String::new(), String::new())),
+            Ok(output) if !output.status.success() => {
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                let print_output = parse_print_output(&stdout);
+                let error_message = parse_last_error_message(&stdout);
+
+                Ok((ExecutionOutcome::RuntimeError, print_output, error_message))
+            }
+            Ok(output) => {
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                let print_output = parse_print_output(&stdout);
+                let program_output = parse_program_output(&stdout);
+                Ok((ExecutionOutcome::RunSuccess, print_output, program_output))
+            }
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct ExecutionOutputLine {
+    program_output: String,
+}
+
+#[derive(Deserialize)]
+struct ExecutionErrorLine {
+    #[serde(rename = "type")]
+    message_type: String,
+    message: String,
+}
+
+#[derive(Deserialize)]
+struct StatusMessage {
+    status: String,
+}
+
+fn parse_print_output(stdout: &str) -> String {
+    let mut lines: Vec<&str> = stdout.lines().collect();
+    // Drop the last line if it's an execution error or program output.
+    // This should be obtained with parsing functions defined below.
+    if lines
+        .last()
+        .map(|line| {
+            serde_json::from_str::<ExecutionOutputLine>(line).is_ok()
+                || serde_json::from_str::<ExecutionErrorLine>(line)
+                    .ok()
+                    .map(|parsed| parsed.message_type == "error")
+                    .unwrap_or_default()
+        })
+        .unwrap_or_default()
+    {
+        let _ = lines.pop();
+    }
+    lines
+        .into_iter()
+        .filter(|line| {
+            // Filter out status message marking execution start.
+            let Some(parsed) = serde_json::from_str::<StatusMessage>(line).ok() else {
+                return true;
+            };
+            parsed.status != "executing"
+        })
+        .collect_vec()
+        .join("\n")
+        .trim()
+        .to_string()
+}
+
+fn parse_program_output(stdout: &str) -> String {
+    stdout
+        .lines()
+        .next_back()
+        .and_then(|last| serde_json::from_str::<ExecutionOutputLine>(last).ok())
+        .map(|parsed| parsed.program_output)
+        .unwrap_or_default()
+}
+
+fn parse_last_error_message(stdout: &str) -> String {
+    stdout
+        .lines()
+        .next_back()
+        .and_then(|last| serde_json::from_str::<ExecutionErrorLine>(last).ok())
+        .filter(|parsed| parsed.message_type == "error")
+        .map(|parsed| parsed.message)
+        .unwrap_or_default()
+}

--- a/extensions/scarb-doc/src/doc_test/runner.rs
+++ b/extensions/scarb-doc/src/doc_test/runner.rs
@@ -169,7 +169,8 @@ impl<'a> TestRunner<'a> {
         }
         // TODO(#3097): add struct with `impl Message` to display this
         if !failed_names.is_empty() {
-            self.ui.print("\nfailures:");
+            self.ui.print(NewLine::new());
+            self.ui.print("failures:");
             for display_name in &failed_names {
                 self.ui.print(format!("    {}", display_name));
             }

--- a/extensions/scarb-doc/src/doc_test/ui.rs
+++ b/extensions/scarb-doc/src/doc_test/ui.rs
@@ -1,0 +1,62 @@
+use crate::doc_test::runner::TestSummary;
+use console::Style;
+use scarb_ui::Message;
+use serde::{Serialize, Serializer};
+use std::fmt;
+
+impl Message for TestSummary {
+    fn text(self) -> String {
+        let status = if self.is_ok() {
+            TestResultStatus::Ok
+        } else {
+            TestResultStatus::Failed
+        };
+        format!(
+            "test result: {}. {} passed; {} failed; {} ignored",
+            status.style().apply_to(status.to_string()),
+            self.passed,
+            self.failed,
+            self.ignored
+        )
+    }
+
+    fn structured<S: Serializer>(self, ser: S) -> anyhow::Result<S::Ok, S::Error> {
+        self.serialize(ser)
+    }
+}
+
+#[derive(Serialize)]
+pub enum TestResultStatus {
+    Ok,
+    Failed,
+    Ignored,
+}
+
+impl TestResultStatus {
+    pub fn style(&self) -> Style {
+        match self {
+            TestResultStatus::Ok => Style::new().green(),
+            TestResultStatus::Failed => Style::new().red(),
+            TestResultStatus::Ignored => Style::new().yellow(),
+        }
+    }
+
+    pub fn display_for(self, name: &str) -> String {
+        format!(
+            "test {} ... {}",
+            name,
+            self.style().apply_to(self.to_string())
+        )
+    }
+}
+
+impl fmt::Display for TestResultStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            TestResultStatus::Ok => "ok",
+            TestResultStatus::Failed => "FAILED",
+            TestResultStatus::Ignored => "ignored",
+        };
+        write!(f, "{s}")
+    }
+}

--- a/extensions/scarb-doc/src/doc_test/workspace.rs
+++ b/extensions/scarb-doc/src/doc_test/workspace.rs
@@ -39,7 +39,12 @@ impl DocTestWorkspace {
             has_lib_target,
         };
         workspace.write_manifest(metadata)?;
-        workspace.write_src(&code_block.content, &metadata.name, ui)?;
+        workspace.write_src(
+            &code_block.content,
+            &metadata.name,
+            metadata.edition.as_deref(),
+            ui,
+        )?;
 
         Ok(workspace)
     }
@@ -86,7 +91,13 @@ impl DocTestWorkspace {
         Ok(())
     }
 
-    fn write_src(&self, content: &str, package_name: &str, ui: &Ui) -> Result<()> {
+    fn write_src(
+        &self,
+        content: &str,
+        package_name: &str,
+        edition: Option<&str>,
+        ui: &Ui,
+    ) -> Result<()> {
         let src_dir = self.root().join("src");
         fs::create_dir_all(&src_dir).context("failed to create src directory")?;
 
@@ -101,6 +112,10 @@ impl DocTestWorkspace {
 
         let is_function_body = db.parse_virtual(&wrapped_body_candidate).is_ok();
 
+        // Global `use` items with glob are not supported in the 2023_01 and 2023_10 editions.
+        // For those editions, inject the import as a local use statement inside fn main instead.
+        let global_use_supported = !matches!(edition, Some("2023_01") | Some("2023_10"));
+
         let package_import = if is_function_body && !self.has_lib_target {
             ui.warn(formatdoc!(
                 r#"
@@ -109,8 +124,10 @@ impl DocTestWorkspace {
             "#
             ));
             String::new()
-        } else {
+        } else if global_use_supported {
             format!("use {package_name}::*;")
+        } else {
+            String::new()
         };
 
         let body = if is_function_body {

--- a/extensions/scarb-doc/src/doc_test/workspace.rs
+++ b/extensions/scarb-doc/src/doc_test/workspace.rs
@@ -1,0 +1,138 @@
+use crate::AdditionalMetadata;
+use crate::doc_test::code_blocks::CodeBlock;
+use anyhow::{Context, Result, anyhow};
+use cairo_lang_filesystem::db::Edition;
+use cairo_lang_parser::utils::SimpleParserDatabase;
+use camino::{Utf8Path, Utf8PathBuf};
+use indoc::formatdoc;
+use scarb_build_metadata::CAIRO_VERSION;
+use scarb_ui::Ui;
+use std::fmt::Write;
+use std::fs;
+use tempfile::{TempDir, tempdir};
+
+pub struct DocTestWorkspace {
+    _temp_dir: TempDir,
+    root: Utf8PathBuf,
+    package_name: String,
+    has_lib_target: bool,
+}
+
+impl DocTestWorkspace {
+    pub fn new(
+        metadata: &AdditionalMetadata,
+        index: usize,
+        code_block: &CodeBlock,
+        has_lib_target: bool,
+        ui: &Ui,
+    ) -> Result<Self> {
+        let temp_dir = tempdir().context("failed to create temporary workspace")?;
+        let root = Utf8PathBuf::from_path_buf(temp_dir.path().to_path_buf())
+            .map_err(|path| anyhow!("path `{}` is not UTF-8 encoded", path.display()))?;
+
+        let package_name = format!("{}_example_{}", metadata.name, index);
+
+        let workspace = Self {
+            _temp_dir: temp_dir,
+            root,
+            package_name,
+            has_lib_target,
+        };
+        workspace.write_manifest(metadata)?;
+        workspace.write_src(&code_block.content, &metadata.name, ui)?;
+
+        Ok(workspace)
+    }
+
+    pub fn root(&self) -> &Utf8Path {
+        &self.root
+    }
+
+    pub fn manifest_path(&self) -> Utf8PathBuf {
+        self.root.join("Scarb.toml")
+    }
+
+    fn write_manifest(&self, metadata: &AdditionalMetadata) -> Result<()> {
+        let package_dir = metadata
+            .manifest_path
+            .parent()
+            .context("package manifest path has no parent directory")?;
+
+        let dep = &metadata.name;
+        let dep_path = format!("{}", package_dir);
+        let name = &self.package_name;
+        let edition = metadata
+            .edition
+            .clone()
+            .unwrap_or_else(|| edition_variant(Edition::latest()));
+
+        let manifest = formatdoc! {r#"
+            [package]
+            name = "{name}"
+            version = "0.1.0"
+            edition = "{edition}"
+
+            [dependencies]
+            {dep} = {{ path = "{dep_path}" }}
+            cairo_execute = "{CAIRO_VERSION}"
+
+            [cairo]
+            enable-gas = false
+
+            [executable]
+        "#
+        };
+        fs::write(self.manifest_path(), manifest).context("failed to write manifest")?;
+        Ok(())
+    }
+
+    fn write_src(&self, content: &str, package_name: &str, ui: &Ui) -> Result<()> {
+        let src_dir = self.root().join("src");
+        fs::create_dir_all(&src_dir).context("failed to create src directory")?;
+
+        let db = SimpleParserDatabase::default();
+        let mut wrapped_body_candidate =
+            String::with_capacity(content.len() + content.lines().count() * 5);
+        writeln!(wrapped_body_candidate, "fn main() {{")?;
+        for line in content.lines() {
+            writeln!(wrapped_body_candidate, "    {}", line)?;
+        }
+        writeln!(wrapped_body_candidate, "}}")?;
+
+        let is_function_body = db.parse_virtual(&wrapped_body_candidate).is_ok();
+
+        let package_import = if is_function_body && !self.has_lib_target {
+            ui.warn(formatdoc!(
+                r#"
+                package `{package_name}` has no `lib` target defined
+                `{package_name}` contents cannot be imported in the doc string definition
+            "#
+            ));
+            String::new()
+        } else {
+            format!("use {package_name}::*;")
+        };
+
+        let body = if is_function_body {
+            wrapped_body_candidate
+        } else {
+            content.to_string()
+        };
+        let lib_cairo = formatdoc! {r#"
+            {package_import}
+
+            #[executable]
+            {body}
+        "#};
+        fs::write(src_dir.join("lib.cairo"), lib_cairo).context("failed to write lib.cairo")?;
+        Ok(())
+    }
+}
+
+fn edition_variant(edition: Edition) -> String {
+    let edition = serde_json::to_value(edition).unwrap();
+    let serde_json::Value::String(edition) = edition else {
+        panic!("Edition should always be a string.")
+    };
+    edition
+}

--- a/extensions/scarb-doc/src/docs_generation.rs
+++ b/extensions/scarb-doc/src/docs_generation.rs
@@ -1,3 +1,4 @@
+use crate::doc_test::code_blocks::CodeBlock;
 use crate::location_links::DocLocationLink;
 use crate::types::module_type::Module;
 use crate::types::other_types::{
@@ -83,6 +84,7 @@ pub trait DocItem {
     fn resolve_doc_link(&self, link: &CommentLinkToken) -> Option<DocumentableItemId<'_>>;
     fn markdown_formatted_path(&self) -> String;
     fn group_name(&self) -> &Option<String>;
+    fn code_blocks(&self) -> &Vec<CodeBlock>;
     fn file_path(&self) -> &String;
     fn location_in_file(&self) -> &Option<Range<usize>>;
 }
@@ -135,6 +137,10 @@ macro_rules! impl_doc_item {
 
             fn location_in_file(&self) -> &Option<Range<usize>> {
                 &self.item_data.location_in_file
+            }
+
+            fn code_blocks(&self) -> &Vec<CodeBlock> {
+                &self.item_data.code_blocks
             }
         }
     };

--- a/extensions/scarb-doc/src/docs_generation/markdown.rs
+++ b/extensions/scarb-doc/src/docs_generation/markdown.rs
@@ -3,7 +3,7 @@ use crate::docs_generation::markdown::book_toml::generate_book_toml_content;
 use crate::docs_generation::markdown::summary::generate_summary_file_content;
 use crate::errors::{IODirectoryCreationError, IOWriteError};
 use anyhow::Result;
-use camino::Utf8Path;
+use camino::{Utf8Path, Utf8PathBuf};
 use std::collections::HashMap;
 use std::fs;
 
@@ -11,6 +11,7 @@ mod book_toml;
 pub mod context;
 mod summary;
 pub mod traits;
+use crate::doc_test::runner::ExecutionResults;
 use crate::docs_generation::common::{
     GeneratedFile, OutputFilesExtension, SummaryIndexMap, SummaryListItem,
 };
@@ -27,7 +28,8 @@ pub const GROUP_CHAPTER_PREFIX: &str = "- ###";
 /// Prefixes that indicate the start of complex Markdown structures,
 /// such as tables. These should be avoided in brief documentation to maintain simple text
 /// formatting and prevent disruption of the layout.
-const SHORT_DOCUMENTATION_AVOID_PREFIXES: &[&str] = &["#", "\n\n", "```", "- ", "1.  ", "{{#"];
+const SHORT_DOCUMENTATION_AVOID_PREFIXES: &[&str] =
+    &["#", "\n\n", "```", "~~~", "- ", "1.  ", "{{#"];
 
 pub struct MarkdownContent {
     book_toml: String,
@@ -40,11 +42,13 @@ impl MarkdownContent {
     pub fn from_crate(
         package_information: &PackageInformation,
         format: OutputFilesExtension,
+        execution_results: Option<ExecutionResults>,
     ) -> Result<Self> {
         let (summary, doc_files) = generate_summary_file_content(
             &package_information.crate_,
             format,
             &package_information.remote_linking_data,
+            execution_results,
         )?;
 
         Ok(Self {
@@ -79,11 +83,11 @@ impl WorkspaceMarkdownBuilder {
         if self.book_toml.is_none() {
             self.book_toml = Some(generate_book_toml_content(&package_information.metadata));
         }
-
         let (summary, files) = generate_summary_file_content(
             &package_information.crate_,
             self.output_format,
             &package_information.remote_linking_data,
+            None,
         )?;
         let current = std::mem::replace(&mut self.summary, SummaryIndexMap::new());
         self.summary = current.add(summary);
@@ -110,6 +114,8 @@ fn package_information_placeholder() -> crate::AdditionalMetadata {
         name: "workspace".to_string(),
         authors: None,
         repository: None,
+        manifest_path: Utf8PathBuf::from("Scarb.toml"),
+        edition: None,
     }
 }
 

--- a/extensions/scarb-doc/src/docs_generation/markdown/context.rs
+++ b/extensions/scarb-doc/src/docs_generation/markdown/context.rs
@@ -1,6 +1,7 @@
+use crate::doc_test::runner::ExecutionResults;
 use crate::docs_generation::common::{OutputFilesExtension, SummaryIndexMap};
 use crate::docs_generation::markdown::SUMMARY_FILENAME;
-use crate::docs_generation::markdown::traits::WithPath;
+use crate::docs_generation::markdown::traits::WithItemDataCommon;
 use crate::linking::RemoteDocLinkingData;
 use crate::location_links::DocLocationLink;
 use crate::types::crate_type::Crate;
@@ -9,7 +10,7 @@ use cairo_lang_doc::documentable_item::DocumentableItemId;
 use itertools::Itertools;
 use std::collections::HashMap;
 
-pub type IncludedItems<'a, 'db> = HashMap<DocumentableItemId<'db>, &'a dyn WithPath>;
+pub type IncludedItems<'a, 'db> = HashMap<DocumentableItemId<'db>, &'a dyn WithItemDataCommon>;
 
 pub struct MarkdownGenerationContext<'a, 'db> {
     included_items: IncludedItems<'a, 'db>,
@@ -17,6 +18,7 @@ pub struct MarkdownGenerationContext<'a, 'db> {
     pub(crate) files_extension: &'static str,
     /// Data necessary for linking to the remote repository.
     pub remote_linking_data: RemoteDocLinkingData,
+    execution_results: Option<ExecutionResults>,
 }
 
 pub trait Formatting {
@@ -109,6 +111,7 @@ impl<'a, 'db> MarkdownGenerationContext<'a, 'db> {
         crate_: &'a Crate<'db>,
         format: OutputFilesExtension,
         remote_linking_data: RemoteDocLinkingData,
+        execution_results: Option<ExecutionResults>,
     ) -> Self
     where
         'a: 'db,
@@ -125,6 +128,7 @@ impl<'a, 'db> MarkdownGenerationContext<'a, 'db> {
             formatting,
             files_extension: format.get_string(),
             remote_linking_data,
+            execution_results,
         }
     }
 
@@ -184,6 +188,10 @@ impl<'a, 'db> MarkdownGenerationContext<'a, 'db> {
     pub fn get_header_primitive(&self, header_level: usize, name: &str, full_path: &str) -> String {
         self.formatting
             .header_primitive(header_level, name, full_path)
+    }
+
+    pub fn execution_results(&self) -> Option<&ExecutionResults> {
+        self.execution_results.as_ref()
     }
 }
 

--- a/extensions/scarb-doc/src/docs_generation/markdown/summary.rs
+++ b/extensions/scarb-doc/src/docs_generation/markdown/summary.rs
@@ -2,6 +2,7 @@ pub mod content;
 pub mod files;
 pub mod group_files;
 
+use crate::doc_test::runner::ExecutionResults;
 use crate::docs_generation::common::OutputFilesExtension;
 use crate::docs_generation::markdown::context::MarkdownGenerationContext;
 use crate::docs_generation::markdown::summary::content::{
@@ -22,10 +23,15 @@ pub fn generate_summary_file_content(
     crate_: &Crate,
     output_format: OutputFilesExtension,
     remote_linking_data: &RemoteDocLinkingData,
+    execution_results: Option<ExecutionResults>,
 ) -> Result<(SummaryIndexMap, Vec<(String, String)>)> {
     let mut summary_index_map = SummaryIndexMap::new();
-    let context =
-        MarkdownGenerationContext::from_crate(crate_, output_format, remote_linking_data.clone());
+    let context = MarkdownGenerationContext::from_crate(
+        crate_,
+        output_format,
+        remote_linking_data.clone(),
+        execution_results,
+    );
 
     generate_module_summary_content(
         &crate_.root_module,

--- a/extensions/scarb-doc/src/docs_generation/markdown/summary/files.rs
+++ b/extensions/scarb-doc/src/docs_generation/markdown/summary/files.rs
@@ -4,10 +4,8 @@ use crate::docs_generation::markdown::traits::{
     MarkdownDocItem, TopLevelMarkdownDocItem,
     generate_markdown_table_summary_for_top_level_subitems,
 };
-use crate::docs_generation::markdown::{
-    BASE_HEADER_LEVEL, BASE_MODULE_CHAPTER_PREFIX, SummaryIndexMap,
-};
-use crate::docs_generation::{DocItem, TopLevelItems};
+use crate::docs_generation::markdown::{BASE_HEADER_LEVEL, BASE_MODULE_CHAPTER_PREFIX};
+use crate::docs_generation::{DocItem, TopLevelItems, common};
 use crate::types::module_type::Module;
 use crate::types::other_types::{
     Constant, Enum, ExternFunction, ExternType, FreeFunction, Impl, ImplAlias, MacroDeclaration,
@@ -15,6 +13,7 @@ use crate::types::other_types::{
 };
 use crate::types::struct_types::Struct;
 use anyhow::Result;
+use common::SummaryIndexMap;
 use itertools::chain;
 
 macro_rules! module_summary {
@@ -148,19 +147,19 @@ pub fn generate_doc_files_for_module_items(
     summary_index_map: &SummaryIndexMap,
 ) -> Result<Vec<(String, String)>> {
     Ok(chain!(
-        generate_top_level_docs_contents(&top_level_items.modules, context, summary_index_map)?,
-        generate_top_level_docs_contents(&top_level_items.constants, context, summary_index_map)?,
+        generate_top_level_docs_contents(&top_level_items.modules, context, summary_index_map,)?,
+        generate_top_level_docs_contents(&top_level_items.constants, context, summary_index_map,)?,
         generate_top_level_docs_contents(
             &top_level_items.free_functions,
             context,
-            summary_index_map
+            summary_index_map,
         )?,
-        generate_top_level_docs_contents(&top_level_items.structs, context, summary_index_map)?,
-        generate_top_level_docs_contents(&top_level_items.enums, context, summary_index_map)?,
+        generate_top_level_docs_contents(&top_level_items.structs, context, summary_index_map,)?,
+        generate_top_level_docs_contents(&top_level_items.enums, context, summary_index_map,)?,
         generate_top_level_docs_contents(
             &top_level_items.type_aliases,
             context,
-            summary_index_map
+            summary_index_map,
         )?,
         generate_top_level_docs_contents(
             &top_level_items.impl_aliases,

--- a/extensions/scarb-doc/src/docs_generation/markdown/summary/group_files.rs
+++ b/extensions/scarb-doc/src/docs_generation/markdown/summary/group_files.rs
@@ -1,11 +1,13 @@
 use crate::docs_generation::TopLevelItems;
+use crate::docs_generation::markdown::GROUP_CHAPTER_PREFIX;
 use crate::docs_generation::markdown::context::MarkdownGenerationContext;
 use crate::docs_generation::markdown::summary::files::{
     generate_doc_files_for_module_items, generate_modules_summary_files,
     generate_summary_files_for_module_items,
 };
 use crate::docs_generation::markdown::traits::generate_markdown_table_summary_for_top_level_subitems;
-use crate::docs_generation::markdown::{GROUP_CHAPTER_PREFIX, SummaryIndexMap};
+
+use crate::docs_generation::common::SummaryIndexMap;
 use crate::types::groups::Group;
 use itertools::Itertools;
 

--- a/extensions/scarb-doc/src/docs_generation/markdown/traits.rs
+++ b/extensions/scarb-doc/src/docs_generation/markdown/traits.rs
@@ -1,9 +1,10 @@
 use super::context::MarkdownGenerationContext;
+use crate::doc_test::code_blocks::CodeBlock;
 use crate::docs_generation::markdown::{
     BASE_MODULE_CHAPTER_PREFIX, GROUP_CHAPTER_PREFIX, SHORT_DOCUMENTATION_AVOID_PREFIXES,
-    SHORT_DOCUMENTATION_LEN, SummaryIndexMap,
+    SHORT_DOCUMENTATION_LEN,
 };
-use crate::docs_generation::{DocItem, PrimitiveDocItem, SubPathDocItem, TopLevelDocItem};
+use crate::docs_generation::{DocItem, PrimitiveDocItem, SubPathDocItem, TopLevelDocItem, common};
 use crate::types::groups::Group;
 use crate::types::item_data::{ItemData, SubItemData};
 use crate::types::module_type::{Module, ModulePubUses};
@@ -15,6 +16,7 @@ use crate::types::other_types::{
 use crate::types::struct_types::{Member, Struct};
 use anyhow::Result;
 use cairo_lang_doc::parser::{CommentLinkToken, DocumentationCommentToken};
+use common::SummaryIndexMap;
 use itertools::Itertools;
 use std::collections::HashMap;
 use std::fmt::Write;
@@ -182,11 +184,30 @@ pub trait MarkdownDocItem: DocItem {
     }
 
     fn get_documentation(&self, context: &MarkdownGenerationContext) -> Option<String> {
+        let execution_results_map = context
+            .execution_results()
+            .map(|results| {
+                self.code_blocks()
+                    .iter()
+                    .filter_map(|block| {
+                        results
+                            .get(&block.id)
+                            .map(|res| (block.id.close_token_idx, res))
+                    })
+                    .collect::<HashMap<_, _>>()
+            })
+            .unwrap_or_default();
         self.doc().as_ref().map(|doc_tokens| {
             doc_tokens
                 .iter()
-                .map(|doc_token| match doc_token {
-                    DocumentationCommentToken::Content(content) => content.clone(),
+                .enumerate()
+                .map(|(idx, token)| match token {
+                    DocumentationCommentToken::Content(content) => {
+                        match execution_results_map.get(&idx) {
+                            Some(res) => format!("{}{}", content, res.as_markdown()),
+                            None => content.clone(),
+                        }
+                    }
                     DocumentationCommentToken::Link(link) => {
                         self.format_link_to_path(link, context)
                     }
@@ -883,17 +904,18 @@ fn get_full_subitem_path<T: MarkdownDocItem + SubPathDocItem>(
     }
 }
 
-pub trait WithPath {
+pub trait WithItemDataCommon {
     fn name(&self) -> &str;
     fn full_path(&self) -> String;
     fn parent_full_path(&self) -> Option<String>;
+    fn code_blocks(&self) -> Vec<CodeBlock>;
 }
 
 pub trait WithItemData {
     fn item_data(&self) -> &ItemData<'_>;
 }
 
-impl<T: WithItemData> WithPath for T {
+impl<T: WithItemData> WithItemDataCommon for T {
     fn name(&self) -> &str {
         self.item_data().name.as_str()
     }
@@ -905,6 +927,9 @@ impl<T: WithItemData> WithPath for T {
     fn parent_full_path(&self) -> Option<String> {
         self.item_data().parent_full_path.clone()
     }
+    fn code_blocks(&self) -> Vec<CodeBlock> {
+        self.item_data().code_blocks.clone()
+    }
 }
 
 impl<'db> WithItemData for ItemData<'db> {
@@ -913,8 +938,8 @@ impl<'db> WithItemData for ItemData<'db> {
     }
 }
 
-// Allow SubItemData to be used wherever a WithPath is expected without converting into ItemData.
-impl<'db> WithPath for SubItemData<'db> {
+/// Allow SubItemData to be used wherever a [`WithItemDataCommon`] is expected without converting into ItemData.
+impl<'db> WithItemDataCommon for SubItemData<'db> {
     fn name(&self) -> &str {
         self.name.as_str()
     }
@@ -923,5 +948,8 @@ impl<'db> WithPath for SubItemData<'db> {
     }
     fn parent_full_path(&self) -> Option<String> {
         self.parent_full_path.clone()
+    }
+    fn code_blocks(&self) -> Vec<CodeBlock> {
+        self.code_blocks.clone()
     }
 }

--- a/extensions/scarb-doc/src/lib.rs
+++ b/extensions/scarb-doc/src/lib.rs
@@ -18,6 +18,7 @@ use cairo_lang_filesystem::{
     ids::{CrateId, CrateLongId},
 };
 use cairo_lang_utils::Intern;
+use camino::Utf8PathBuf;
 use errors::DiagnosticError;
 use itertools::Itertools;
 use scarb_metadata::{
@@ -30,6 +31,7 @@ pub mod attributes;
 pub mod db;
 pub mod diagnostics;
 pub mod doc_link_resolver;
+pub mod doc_test;
 pub mod docs_generation;
 pub mod errors;
 pub mod linking;
@@ -52,6 +54,10 @@ pub struct AdditionalMetadata {
     pub authors: Option<Vec<String>>,
     #[serde(skip)]
     pub repository: Option<String>,
+    #[serde(skip)]
+    pub manifest_path: Utf8PathBuf,
+    #[serde(skip)]
+    pub edition: Option<String>,
 }
 
 pub struct PackageContext {
@@ -109,6 +115,8 @@ pub fn generate_package_context(
             name: package_metadata.name.clone(),
             authors,
             repository: package_metadata.manifest_metadata.repository.clone(),
+            manifest_path: package_metadata.manifest_path.clone(),
+            edition: package_metadata.edition.clone(),
         },
     })
 }

--- a/extensions/scarb-doc/src/main.rs
+++ b/extensions/scarb-doc/src/main.rs
@@ -4,6 +4,8 @@ use clap::Parser;
 use mimalloc::MiMalloc;
 use scarb_doc::db::ScarbDocDatabase;
 use scarb_doc::diagnostics::print_diagnostics;
+use scarb_doc::doc_test::code_blocks::collect_code_blocks;
+use scarb_doc::doc_test::runner::{ExecutionResults, TestRunner};
 use scarb_doc::docs_generation::common::OutputFilesExtension;
 use scarb_doc::docs_generation::markdown::{MarkdownContent, WorkspaceMarkdownBuilder};
 use scarb_doc::errors::{MetadataCommandError, PackagesSerializationError};
@@ -24,6 +26,7 @@ static GLOBAL: MiMalloc = MiMalloc;
 
 const OUTPUT_DIR: &str = "doc";
 const JSON_OUTPUT_FILENAME: &str = "output.json";
+const LIB_TARGET_KIND: &str = "lib";
 
 fn main_inner(args: Args, ui: Ui) -> Result<()> {
     ensure!(
@@ -39,6 +42,7 @@ fn main_inner(args: Args, ui: Ui) -> Result<()> {
     let metadata_for_packages = args.packages_filter.match_many(&metadata)?;
     let output_dir = get_target_dir(&metadata).join(OUTPUT_DIR);
     let workspace_root = metadata.workspace.root.clone();
+    let doc_tests_enabled = !args.no_run;
 
     let remote_base_url_flag = args.remote_base_url.clone();
 
@@ -121,11 +125,34 @@ fn main_inner(args: Args, ui: Ui) -> Result<()> {
                 },
             )?;
             print_diagnostics(&ui);
-            output.write(info)?;
+            let has_lib_target = pm
+                .targets
+                .iter()
+                .any(|target| target.kind == LIB_TARGET_KIND);
+            let execution_results = doc_tests_enabled
+                .then(|| run_doc_tests(&info, has_lib_target, &ui))
+                .transpose()?;
+            output.write(info, execution_results)?;
         }
         output.flush()?;
     }
     Ok(())
+}
+
+fn run_doc_tests(
+    package: &PackageInformation,
+    has_lib_target: bool,
+    ui: &Ui,
+) -> Result<ExecutionResults> {
+    let runnable_code_blocks = collect_code_blocks(&package.crate_);
+    if runnable_code_blocks.is_empty() {
+        Ok(Default::default())
+    } else {
+        let runner = TestRunner::new(&package.metadata, has_lib_target, ui.clone())?;
+        let (summary, execution_results) = runner.run_all(&runnable_code_blocks)?;
+        ensure!(!summary.is_fail(), "doc tests failed");
+        Ok(execution_results)
+    }
 }
 
 pub enum OutputEmit {
@@ -183,7 +210,11 @@ impl OutputEmit {
         }
     }
 
-    pub fn write(&mut self, package: PackageInformation) -> Result<()> {
+    pub fn write(
+        &mut self,
+        package: PackageInformation,
+        execution_results: Option<ExecutionResults>,
+    ) -> Result<()> {
         match self {
             OutputEmit::Markdown {
                 output_dir,
@@ -193,8 +224,8 @@ impl OutputEmit {
                 ui,
                 files_extension,
             } => {
-                let content = MarkdownContent::from_crate(&package, *files_extension)?;
-
+                let content =
+                    MarkdownContent::from_crate(&package, *files_extension, execution_results)?;
                 output_markdown(
                     content,
                     Some(package.metadata.name),

--- a/extensions/scarb-doc/src/types/module_type.rs
+++ b/extensions/scarb-doc/src/types/module_type.rs
@@ -240,6 +240,53 @@ impl<'db> ModulePubUses<'db> {
         self.use_submodules.extend(use_submodules);
         self.use_macro_declarations.extend(use_macro_declarations);
     }
+
+    pub fn get_all_item_ids<'a>(&'a self) -> IncludedItems<'a, 'db> {
+        let mut ids: IncludedItems<'a, 'db> = HashMap::default();
+
+        self.use_constants.iter().for_each(|item| {
+            ids.insert(item.item_data.id, &item.item_data);
+        });
+        self.use_free_functions.iter().for_each(|item| {
+            ids.insert(item.item_data.id, &item.item_data);
+        });
+        self.use_module_type_aliases.iter().for_each(|item| {
+            ids.insert(item.item_data.id, &item.item_data);
+        });
+        self.use_impl_aliases.iter().for_each(|item| {
+            ids.insert(item.item_data.id, &item.item_data);
+        });
+        self.use_extern_types.iter().for_each(|item| {
+            ids.insert(item.item_data.id, &item.item_data);
+        });
+        self.use_extern_functions.iter().for_each(|item| {
+            ids.insert(item.item_data.id, &item.item_data);
+        });
+        self.use_macro_declarations.iter().for_each(|item| {
+            ids.insert(item.item_data.id, &item.item_data);
+        });
+        self.use_structs.iter().for_each(|struct_| {
+            ids.insert(struct_.item_data.id, &struct_.item_data);
+            ids.extend(struct_.get_all_item_ids());
+        });
+        self.use_enums.iter().for_each(|enum_| {
+            ids.insert(enum_.item_data.id, &enum_.item_data);
+            ids.extend(enum_.get_all_item_ids());
+        });
+        self.use_traits.iter().for_each(|trait_| {
+            ids.insert(trait_.item_data.id, &trait_.item_data);
+            ids.extend(trait_.get_all_item_ids());
+        });
+        self.use_impl_defs.iter().for_each(|impl_| {
+            ids.insert(impl_.item_data.id, &impl_.item_data);
+            ids.extend(impl_.get_all_item_ids());
+        });
+        self.use_submodules.iter().for_each(|sub_module| {
+            ids.extend(sub_module.get_all_item_ids());
+        });
+
+        ids
+    }
 }
 
 macro_rules! define_insert_function {

--- a/extensions/scarb-doc/src/types/other_types.rs
+++ b/extensions/scarb-doc/src/types/other_types.rs
@@ -1,6 +1,6 @@
 use crate::db::ScarbDocDatabase;
 use crate::docs_generation::markdown::context::IncludedItems;
-use crate::docs_generation::markdown::traits::WithPath;
+use crate::docs_generation::markdown::traits::WithItemDataCommon;
 use crate::types::item_data::{ItemData, SubItemData};
 use cairo_lang_defs::ids::NamedLanguageElementId;
 use cairo_lang_defs::ids::{
@@ -128,7 +128,12 @@ impl<'db> Enum<'db> {
     pub fn get_all_item_ids<'a>(&'a self) -> IncludedItems<'a, 'db> {
         self.variants
             .iter()
-            .map(|item| (item.item_data.id, &item.item_data as &dyn WithPath))
+            .map(|item| {
+                (
+                    item.item_data.id,
+                    &item.item_data as &dyn WithItemDataCommon,
+                )
+            })
             .collect()
     }
 }

--- a/extensions/scarb-doc/src/types/struct_types.rs
+++ b/extensions/scarb-doc/src/types/struct_types.rs
@@ -1,6 +1,6 @@
 use crate::db::ScarbDocDatabase;
 use crate::docs_generation::markdown::context::IncludedItems;
-use crate::docs_generation::markdown::traits::WithPath;
+use crate::docs_generation::markdown::traits::WithItemDataCommon;
 use crate::location_links::DocLocationLink;
 use crate::types::item_data::{ItemData, SubItemData};
 use crate::types::module_type::is_doc_hidden_attr;
@@ -61,7 +61,12 @@ impl<'db> Struct<'db> {
     pub fn get_all_item_ids<'a>(&'a self) -> IncludedItems<'a, 'db> {
         self.members
             .iter()
-            .map(|item| (item.item_data.id, &item.item_data as &dyn WithPath))
+            .map(|item| {
+                (
+                    item.item_data.id,
+                    &item.item_data as &dyn WithItemDataCommon,
+                )
+            })
             .collect()
     }
 }

--- a/extensions/scarb-doc/tests/code/code_12.cairo
+++ b/extensions/scarb-doc/tests/code/code_12.cairo
@@ -1,0 +1,33 @@
+  /// Function that prints "foo" to stdout with endline.
+  /// Can invoke it like that:
+  /// ```runnable
+  /// foo();
+  /// ```
+  pub fn foo() {
+      println!("foo");
+  }
+
+  /// Function that prints "bar" to stdout with endline.
+  /// Can invoke it like that:
+  /// ```cairo
+  ///     bar();
+  /// ```
+  pub fn bar() {
+      println!("bar");
+  }
+
+  /// Function that calls both foo and bar functions.
+  /// Can invoke it like that:
+  /// ```cairo,runnable
+  /// foo_bar();
+  /// ```
+  pub fn foo_bar() {
+      foo();
+      bar();
+  }
+
+
+  /// Main function that cairo runs as a binary entrypoint.
+  fn main() {
+      println!("hello_world");
+  }

--- a/extensions/scarb-doc/tests/code/code_13.cairo
+++ b/extensions/scarb-doc/tests/code/code_13.cairo
@@ -1,0 +1,13 @@
+/// Function with a runnable example that fails at compile time.
+/// The example calls a function that doesn't exist:
+/// ```cairo,runnable
+/// undefined();
+/// ```
+pub fn foo() {
+    println!("foo");
+}
+
+fn main() {
+    println!("hello_world");
+}
+

--- a/extensions/scarb-doc/tests/code/code_14.cairo
+++ b/extensions/scarb-doc/tests/code/code_14.cairo
@@ -1,0 +1,13 @@
+/// Function with a runnable example that fails at runtime.
+/// The example panics:
+/// ```cairo,runnable
+/// foo();
+/// ```
+pub fn foo() {
+    panic!("Runtime error occurred");
+}
+
+fn main() {
+    println!("hello_world");
+}
+

--- a/extensions/scarb-doc/tests/code/code_15.cairo
+++ b/extensions/scarb-doc/tests/code/code_15.cairo
@@ -1,0 +1,21 @@
+  /// Function that returns the sum of two integers.
+  /// Example 1:
+  /// ```cairo, runnable
+  /// let x = add(2, 3);
+  /// println!("{}", x);
+  /// ```
+  /// Example 2:
+  /// ```cairo, runnable
+  /// #[executable]
+  /// fn main() -> i32 {
+  ///     add(-1, 1)
+  /// }
+  /// ```
+  pub fn add(a: i32, b: i32) -> i32 {
+      a + b
+  }
+
+  /// Main function that cairo runs as a binary entrypoint.
+  fn main() {
+      println!("hello_world");
+  }

--- a/extensions/scarb-doc/tests/code/code_16.cairo
+++ b/extensions/scarb-doc/tests/code/code_16.cairo
@@ -1,0 +1,33 @@
+/// A simple storage contract with a runnable example.
+/// ```cairo,runnable
+/// let balance = 100_u128;
+/// assert!(balance > 0);
+/// ```
+#[starknet::interface]
+pub trait IBalance<T> {
+    fn get(self: @T) -> u128;
+    fn increase(ref self: T, a: u128);
+}
+
+#[starknet::contract]
+pub mod Balance {
+    #[storage]
+    struct Storage {
+        value: u128,
+    }
+
+    #[constructor]
+    fn constructor(ref self: ContractState, value_: u128) {
+        self.value.write(value_);
+    }
+
+    #[abi(embed_v0)]
+    impl Balance of super::IBalance<ContractState> {
+        fn get(self: @ContractState) -> u128 {
+            self.value.read()
+        }
+        fn increase(ref self: ContractState, a: u128) {
+            self.value.write(self.value.read() + a);
+        }
+    }
+}

--- a/extensions/scarb-doc/tests/code/code_17.cairo
+++ b/extensions/scarb-doc/tests/code/code_17.cairo
@@ -1,0 +1,17 @@
+/// Example that fails to compile.
+/// ```cairo,runnable,compile_fail
+/// is_odd(true);
+/// ```
+/// Example that unexpectedly compiles.
+/// ```cairo,runnable,compile_fail
+/// let result = is_odd(3);
+/// println!("{}", result);
+/// ```
+pub fn is_odd(n: i32) -> bool {
+    n % 2 != 0
+}
+
+fn main() {
+    println!("hello_world");
+}
+

--- a/extensions/scarb-doc/tests/code/code_18.cairo
+++ b/extensions/scarb-doc/tests/code/code_18.cairo
@@ -1,0 +1,16 @@
+/// Example that panics.
+/// ```cairo,runnable,should_panic
+/// assert(is_odd(2), '2 is not odd');
+/// ```
+/// Example that unexpectedly compiles/passes.
+/// ```cairo,runnable,should_panic
+/// let result = is_odd(3);
+/// assert(result, '3 is odd');
+/// ```
+pub fn is_odd(n: i32) -> bool {
+    n % 2 != 0
+}
+
+fn main() {
+    println!("hello_world");
+}

--- a/extensions/scarb-doc/tests/code/code_19.cairo
+++ b/extensions/scarb-doc/tests/code/code_19.cairo
@@ -1,0 +1,9 @@
+mod inner {
+    /// A struct defined in a submodule, with a runnable example.
+    /// ```cairo, runnable
+    /// println!("hello from re-exported item");
+    /// ```
+    pub struct MyStruct {}
+}
+
+pub use inner::MyStruct;

--- a/extensions/scarb-doc/tests/data/runnable_examples/book.toml
+++ b/extensions/scarb-doc/tests/data/runnable_examples/book.toml
@@ -1,0 +1,18 @@
+[book]
+authors = ["<unknown>"]
+language = "en"
+src = "src"
+title = "hello_world - Cairo"
+
+[output.html]
+no-section-label = true
+
+[output.html.playground]
+runnable = false
+
+[output.html.fold]
+enable = true
+level = 0
+
+[output.html.code.hidelines]
+cairo = "#"

--- a/extensions/scarb-doc/tests/data/runnable_examples/src/SUMMARY.md
+++ b/extensions/scarb-doc/tests/data/runnable_examples/src/SUMMARY.md
@@ -1,0 +1,5 @@
+- [hello_world](./hello_world.md)
+  - [Free functions](./hello_world-free_functions.md)
+    - [foo](./hello_world-foo.md)
+    - [bar](./hello_world-bar.md)
+    - [foo_bar](./hello_world-foo_bar.md)

--- a/extensions/scarb-doc/tests/data/runnable_examples/src/hello_world-bar.md
+++ b/extensions/scarb-doc/tests/data/runnable_examples/src/hello_world-bar.md
@@ -1,0 +1,12 @@
+# bar
+
+Function that prints "bar" to stdout with endline.
+Can invoke it like that:
+```cairo
+    bar();
+```
+
+Fully qualified path: [hello_world](./hello_world.md)::[bar](./hello_world-bar.md)
+
+<pre><code class="language-cairo">pub fn bar()</code></pre>
+

--- a/extensions/scarb-doc/tests/data/runnable_examples/src/hello_world-foo.md
+++ b/extensions/scarb-doc/tests/data/runnable_examples/src/hello_world-foo.md
@@ -1,0 +1,12 @@
+# foo
+
+Function that prints "foo" to stdout with endline.
+Can invoke it like that:
+```runnable
+foo();
+```
+
+Fully qualified path: [hello_world](./hello_world.md)::[foo](./hello_world-foo.md)
+
+<pre><code class="language-cairo">pub fn foo()</code></pre>
+

--- a/extensions/scarb-doc/tests/data/runnable_examples/src/hello_world-foo_bar.md
+++ b/extensions/scarb-doc/tests/data/runnable_examples/src/hello_world-foo_bar.md
@@ -1,0 +1,18 @@
+# foo_bar
+
+Function that calls both foo and bar functions.
+Can invoke it like that:
+```cairo,runnable
+foo_bar();
+```
+Output:
+```
+foo
+bar
+```
+
+
+Fully qualified path: [hello_world](./hello_world.md)::[foo_bar](./hello_world-foo_bar.md)
+
+<pre><code class="language-cairo">pub fn foo_bar()</code></pre>
+

--- a/extensions/scarb-doc/tests/data/runnable_examples/src/hello_world-free_functions.md
+++ b/extensions/scarb-doc/tests/data/runnable_examples/src/hello_world-free_functions.md
@@ -1,0 +1,8 @@
+
+## [Free functions](./hello_world-free_functions.md)
+
+| | |
+|:---|:---|
+| [foo](./hello_world-foo.md) | Function that prints "foo" to stdout with endline. Can invoke it like that:... |
+| [bar](./hello_world-bar.md) | Function that prints "bar" to stdout with endline. Can invoke it like that:... |
+| [foo_bar](./hello_world-foo_bar.md) | Function that calls both foo and bar functions. Can invoke it like that:... |

--- a/extensions/scarb-doc/tests/data/runnable_examples/src/hello_world.md
+++ b/extensions/scarb-doc/tests/data/runnable_examples/src/hello_world.md
@@ -1,0 +1,12 @@
+# hello_world
+
+Fully qualified path: [hello_world](./hello_world.md)
+
+
+## [Free functions](./hello_world-free_functions.md)
+
+| | |
+|:---|:---|
+| [foo](./hello_world-foo.md) | Function that prints "foo" to stdout with endline. Can invoke it like that:... |
+| [bar](./hello_world-bar.md) | Function that prints "bar" to stdout with endline. Can invoke it like that:... |
+| [foo_bar](./hello_world-foo_bar.md) | Function that calls both foo and bar functions. Can invoke it like that:... |

--- a/extensions/scarb-doc/tests/data/runnable_examples_json.json
+++ b/extensions/scarb-doc/tests/data/runnable_examples_json.json
@@ -1,0 +1,77 @@
+{
+  "format_version": 1,
+  "packages_information": [
+    {
+      "crate_": {
+        "groups": [],
+        "root_module": {
+          "constants": [],
+          "enums": [],
+          "extern_functions": [],
+          "extern_types": [],
+          "free_functions": [
+            {
+              "item_data": {
+                "doc": "Function that prints \"foo\" to stdout with endline.\nCan invoke it like that:\n```runnable\nfoo();\n```",
+                "full_path": "hello_world::foo",
+                "group": null,
+                "name": "foo",
+                "signature": "pub fn foo()"
+              }
+            },
+            {
+              "item_data": {
+                "doc": "Function that prints \"bar\" to stdout with endline.\nCan invoke it like that:\n```cairo\n    bar();\n```",
+                "full_path": "hello_world::bar",
+                "group": null,
+                "name": "bar",
+                "signature": "pub fn bar()"
+              }
+            },
+            {
+              "item_data": {
+                "doc": "Function that calls both foo and bar functions.\nCan invoke it like that:\n```cairo,runnable\nfoo_bar();\n```",
+                "full_path": "hello_world::foo_bar",
+                "group": null,
+                "name": "foo_bar",
+                "signature": "pub fn foo_bar()"
+              }
+            }
+          ],
+          "impl_aliases": [],
+          "impls": [],
+          "item_data": {
+            "doc": null,
+            "full_path": "hello_world",
+            "group": null,
+            "name": "hello_world",
+            "signature": null
+          },
+          "macro_declarations": [],
+          "pub_uses": {
+            "use_constants": [],
+            "use_enums": [],
+            "use_extern_functions": [],
+            "use_extern_types": [],
+            "use_free_functions": [],
+            "use_impl_aliases": [],
+            "use_impl_defs": [],
+            "use_macro_declarations": [],
+            "use_module_type_aliases": [],
+            "use_structs": [],
+            "use_submodules": [],
+            "use_traits": []
+          },
+          "structs": [],
+          "submodules": [],
+          "traits": [],
+          "type_aliases": []
+        }
+      },
+      "metadata": {
+        "authors": null,
+        "name": "hello_world"
+      }
+    }
+  ]
+}

--- a/extensions/scarb-doc/tests/data/runnable_examples_mdx/src/SUMMARY.mdx
+++ b/extensions/scarb-doc/tests/data/runnable_examples_mdx/src/SUMMARY.mdx
@@ -1,0 +1,5 @@
+- [hello_world](./hello_world.mdx)
+  - [Free functions](./hello_world-free_functions.mdx)
+    - [foo](./hello_world-foo.mdx)
+    - [bar](./hello_world-bar.mdx)
+    - [foo_bar](./hello_world-foo_bar.mdx)

--- a/extensions/scarb-doc/tests/data/runnable_examples_mdx/src/hello_world-bar.mdx
+++ b/extensions/scarb-doc/tests/data/runnable_examples_mdx/src/hello_world-bar.mdx
@@ -1,0 +1,16 @@
+---
+ title: "hello_world::bar"
+---
+
+Function that prints "bar" to stdout with endline.
+Can invoke it like that:
+```cairo
+    bar();
+```
+
+## Signature
+
+```rust
+pub fn bar()
+```
+

--- a/extensions/scarb-doc/tests/data/runnable_examples_mdx/src/hello_world-foo.mdx
+++ b/extensions/scarb-doc/tests/data/runnable_examples_mdx/src/hello_world-foo.mdx
@@ -1,0 +1,16 @@
+---
+ title: "hello_world::foo"
+---
+
+Function that prints "foo" to stdout with endline.
+Can invoke it like that:
+```runnable
+foo();
+```
+
+## Signature
+
+```rust
+pub fn foo()
+```
+

--- a/extensions/scarb-doc/tests/data/runnable_examples_mdx/src/hello_world-foo_bar.mdx
+++ b/extensions/scarb-doc/tests/data/runnable_examples_mdx/src/hello_world-foo_bar.mdx
@@ -1,0 +1,22 @@
+---
+ title: "hello_world::foo_bar"
+---
+
+Function that calls both foo and bar functions.
+Can invoke it like that:
+```cairo,runnable
+foo_bar();
+```
+Output:
+```
+foo
+bar
+```
+
+
+## Signature
+
+```rust
+pub fn foo_bar()
+```
+

--- a/extensions/scarb-doc/tests/data/runnable_examples_mdx/src/hello_world-free_functions.mdx
+++ b/extensions/scarb-doc/tests/data/runnable_examples_mdx/src/hello_world-free_functions.mdx
@@ -1,0 +1,8 @@
+
+## [Free functions](./hello_world-free_functions.mdx)
+
+| | |
+|:---|:---|
+| [foo](./hello_world-foo.mdx) | Function that prints "foo" to stdout with endline. Can invoke it like that:... |
+| [bar](./hello_world-bar.mdx) | Function that prints "bar" to stdout with endline. Can invoke it like that:... |
+| [foo_bar](./hello_world-foo_bar.mdx) | Function that calls both foo and bar functions. Can invoke it like that:... |

--- a/extensions/scarb-doc/tests/data/runnable_examples_mdx/src/hello_world.mdx
+++ b/extensions/scarb-doc/tests/data/runnable_examples_mdx/src/hello_world.mdx
@@ -1,0 +1,12 @@
+---
+ title: "hello_world"
+---
+
+
+## [Free functions](./hello_world-free_functions.mdx)
+
+| | |
+|:---|:---|
+| [foo](./hello_world-foo.mdx) | Function that prints "foo" to stdout with endline. Can invoke it like that:... |
+| [bar](./hello_world-bar.mdx) | Function that prints "bar" to stdout with endline. Can invoke it like that:... |
+| [foo_bar](./hello_world-foo_bar.mdx) | Function that calls both foo and bar functions. Can invoke it like that:... |

--- a/extensions/scarb-doc/tests/data/runnable_examples_multiple_per_item/book.toml
+++ b/extensions/scarb-doc/tests/data/runnable_examples_multiple_per_item/book.toml
@@ -1,0 +1,18 @@
+[book]
+authors = ["<unknown>"]
+language = "en"
+src = "src"
+title = "hello_world - Cairo"
+
+[output.html]
+no-section-label = true
+
+[output.html.playground]
+runnable = false
+
+[output.html.fold]
+enable = true
+level = 0
+
+[output.html.code.hidelines]
+cairo = "#"

--- a/extensions/scarb-doc/tests/data/runnable_examples_multiple_per_item/src/SUMMARY.md
+++ b/extensions/scarb-doc/tests/data/runnable_examples_multiple_per_item/src/SUMMARY.md
@@ -1,0 +1,3 @@
+- [hello_world](./hello_world.md)
+  - [Free functions](./hello_world-free_functions.md)
+    - [add](./hello_world-add.md)

--- a/extensions/scarb-doc/tests/data/runnable_examples_multiple_per_item/src/hello_world-add.md
+++ b/extensions/scarb-doc/tests/data/runnable_examples_multiple_per_item/src/hello_world-add.md
@@ -1,0 +1,31 @@
+# add
+
+Function that returns the sum of two integers.
+Example 1:
+```cairo, runnable
+let x = add(2, 3);
+println!("{}", x);
+```
+
+Output:
+```
+5
+```
+
+Example 2:
+```cairo, runnable
+#[executable]
+fn main() -> i32 {
+    add(-1, 1)
+}
+```
+Result:
+```
+0
+```
+
+
+Fully qualified path: [hello_world](./hello_world.md)::[add](./hello_world-add.md)
+
+<pre><code class="language-cairo">pub fn add(a: i32, b: i32) -&gt; i32</code></pre>
+

--- a/extensions/scarb-doc/tests/data/runnable_examples_multiple_per_item/src/hello_world-free_functions.md
+++ b/extensions/scarb-doc/tests/data/runnable_examples_multiple_per_item/src/hello_world-free_functions.md
@@ -1,0 +1,6 @@
+
+## [Free functions](./hello_world-free_functions.md)
+
+| | |
+|:---|:---|
+| [add](./hello_world-add.md) | Function that returns the sum of two integers. Example 1:... |

--- a/extensions/scarb-doc/tests/data/runnable_examples_multiple_per_item/src/hello_world.md
+++ b/extensions/scarb-doc/tests/data/runnable_examples_multiple_per_item/src/hello_world.md
@@ -1,0 +1,10 @@
+# hello_world
+
+Fully qualified path: [hello_world](./hello_world.md)
+
+
+## [Free functions](./hello_world-free_functions.md)
+
+| | |
+|:---|:---|
+| [add](./hello_world-add.md) | Function that returns the sum of two integers. Example 1:... |

--- a/extensions/scarb-doc/tests/runnable_examples.rs
+++ b/extensions/scarb-doc/tests/runnable_examples.rs
@@ -1,0 +1,483 @@
+use assert_fs::TempDir;
+use assert_fs::prelude::PathChild;
+use indoc::{formatdoc, indoc};
+use scarb_test_support::command::Scarb;
+use scarb_test_support::project_builder::ProjectBuilder;
+use scarb_test_support::workspace_builder::WorkspaceBuilder;
+mod markdown_target;
+use markdown_target::MarkdownTargetChecker;
+
+mod json_target;
+use json_target::JsonTargetChecker;
+
+const CODE_WITH_RUNNABLE_CODE_BLOCKS: &str = include_str!("code/code_12.cairo");
+const CODE_WITH_COMPILE_ERROR: &str = include_str!("code/code_13.cairo");
+const CODE_WITH_RUNTIME_ERROR: &str = include_str!("code/code_14.cairo");
+const CODE_WITH_MULTIPLE_CODE_BLOCKS_PER_ITEM: &str = include_str!("code/code_15.cairo");
+const CODE_WITH_STARKNET_CONTRACT: &str = include_str!("code/code_16.cairo");
+const CODE_WITH_COMPILE_FAIL: &str = include_str!("code/code_17.cairo");
+const CODE_WITH_SHOULD_PANIC: &str = include_str!("code/code_18.cairo");
+const CODE_WITH_REEXPORTED_ITEM: &str = include_str!("code/code_19.cairo");
+const EXPECTED_WITH_EMBEDDINGS_PATH: &str = "tests/data/runnable_examples";
+const EXPECTED_WITH_EMBEDDINGS_MDX_PATH: &str = "tests/data/runnable_examples_mdx";
+const EXPECTED_MULTIPLE_PER_ITEM_PATH: &str = "tests/data/runnable_examples_multiple_per_item";
+
+#[test]
+fn supports_runnable_examples() {
+    let t = TempDir::new().unwrap();
+    ProjectBuilder::start()
+        .name("hello_world")
+        .lib_cairo(CODE_WITH_RUNNABLE_CODE_BLOCKS)
+        .build(&t);
+
+    Scarb::quick_command()
+        .arg("doc")
+        .args(["--output-format", "markdown"])
+        .arg("--disable-remote-linking")
+        .arg("--build")
+        .current_dir(&t)
+        .assert()
+        .success()
+        .stdout_eq(formatdoc! {r#"
+            [..] Running 3 doc examples for `hello_world`
+            test hello_world::bar ... ignored
+            test hello_world::foo ... ignored
+            [..] Compiling hello_world_example_1 v0.1.0 ([..])
+            [..]  Finished `dev` profile target(s) in [..]
+            test hello_world::foo_bar ... ok
+
+            test result: ok. 1 passed; 0 failed; 2 ignored
+            Saving output to: target/doc/hello_world
+            Saving build output to: target/doc/hello_world/book
+
+            Run the following to see the results:[..]
+            `mdbook serve target/doc/hello_world`
+
+            Or open the following in your browser:[..]
+            `[..]/target/doc/hello_world/book/index.html`
+        "#});
+
+    MarkdownTargetChecker::lenient()
+        .actual(t.path().join("target/doc/hello_world").to_str().unwrap())
+        .expected(EXPECTED_WITH_EMBEDDINGS_PATH)
+        .assert_all_files_match();
+}
+
+#[test]
+fn supports_runnable_examples_mdx() {
+    let t = TempDir::new().unwrap();
+    ProjectBuilder::start()
+        .name("hello_world")
+        .lib_cairo(CODE_WITH_RUNNABLE_CODE_BLOCKS)
+        .build(&t);
+
+    Scarb::quick_command()
+        .arg("doc")
+        .args(["--output-format", "mdx"])
+        .arg("--disable-remote-linking")
+        .current_dir(&t)
+        .assert()
+        .success()
+        .stdout_eq(formatdoc! {r#"
+            [..] Running 3 doc examples for `hello_world`
+            test hello_world::bar ... ignored
+            test hello_world::foo ... ignored
+            [..] Compiling hello_world_example_1 v0.1.0 ([..])
+            [..]  Finished `dev` profile target(s) in [..]
+            test hello_world::foo_bar ... ok
+
+            test result: ok. 1 passed; 0 failed; 2 ignored
+            Saving output to: target/doc/hello_world
+        "#});
+
+    MarkdownTargetChecker::lenient()
+        .actual(t.path().join("target/doc/hello_world").to_str().unwrap())
+        .expected(EXPECTED_WITH_EMBEDDINGS_MDX_PATH)
+        .assert_all_files_match();
+}
+
+#[test]
+fn supports_runnable_examples_json() {
+    let t = TempDir::new().unwrap();
+    ProjectBuilder::start()
+        .name("hello_world")
+        .lib_cairo(CODE_WITH_RUNNABLE_CODE_BLOCKS)
+        .build(&t);
+
+    Scarb::quick_command()
+        .arg("doc")
+        .args(["--output-format", "json"])
+        .current_dir(&t)
+        .assert()
+        .success()
+        .stdout_eq(formatdoc! {r#"
+            [..] Running 3 doc examples for `hello_world`
+            test hello_world::bar ... ignored
+            test hello_world::foo ... ignored
+            [..] Compiling hello_world_example_1 v0.1.0 ([..])
+            [..]  Finished `dev` profile target(s) in [..]
+            test hello_world::foo_bar ... ok
+
+            test result: ok. 1 passed; 0 failed; 2 ignored
+            Saving output to: target/doc/output.json
+        "#});
+
+    JsonTargetChecker::default()
+        .actual(&t.path().join("target/doc/output.json"))
+        .expected("./data/runnable_examples_json.json")
+        .assert_files_match();
+}
+
+#[test]
+fn supports_runnable_examples_multiple_per_item() {
+    let t = TempDir::new().unwrap();
+    ProjectBuilder::start()
+        .name("hello_world")
+        .lib_cairo(CODE_WITH_MULTIPLE_CODE_BLOCKS_PER_ITEM)
+        .build(&t);
+
+    Scarb::quick_command()
+        .arg("doc")
+        .args(["--output-format", "markdown"])
+        .arg("--disable-remote-linking")
+        .arg("--build")
+        .current_dir(&t)
+        .assert()
+        .success()
+        .stdout_eq(formatdoc! {r#"
+            [..] Running 2 doc examples for `hello_world`
+            [..] Compiling hello_world_example_1 v0.1.0 ([..])
+            [..]  Finished `dev` profile target(s) in [..]
+            test hello_world::add (example 1) ... ok
+            [..] Compiling hello_world_example_2 v0.1.0 ([..])
+            [..]  Finished `dev` profile target(s) in [..]
+            test hello_world::add (example 2) ... ok
+
+            test result: ok. 2 passed; 0 failed; 0 ignored
+            Saving output to: target/doc/hello_world
+            Saving build output to: target/doc/hello_world/book
+
+            Run the following to see the results:[..]
+            `mdbook serve target/doc/hello_world`
+
+            Or open the following in your browser:[..]
+            `[..]/target/doc/hello_world/book/index.html`
+        "#});
+
+    MarkdownTargetChecker::lenient()
+        .actual(t.path().join("target/doc/hello_world").to_str().unwrap())
+        .expected(EXPECTED_MULTIPLE_PER_ITEM_PATH)
+        .assert_all_files_match();
+}
+
+#[test]
+fn runnable_example_fails_at_compile_time() {
+    let t = TempDir::new().unwrap();
+    ProjectBuilder::start()
+        .name("hello_world")
+        .lib_cairo(CODE_WITH_COMPILE_ERROR)
+        .build(&t);
+
+    Scarb::quick_command()
+        .arg("doc")
+        .args(["--output-format", "markdown"])
+        .arg("--disable-remote-linking")
+        .arg("--build")
+        .current_dir(&t)
+        .assert()
+        .failure()
+        .stdout_eq(indoc! {r#"
+            [..] Running 1 doc examples for `hello_world`
+            [..] Compiling hello_world_example_1 v0.1.0 ([..])
+            error[E0006]: Function not found.
+             --> [..]lib.cairo[..]
+                undefined();
+                ^^^^^^^^^
+
+            error: could not compile `hello_world_example_1` due to 1 previous error
+            test hello_world::foo ... FAILED
+
+            failures:
+                hello_world::foo
+
+            test result: FAILED. 0 passed; 1 failed; 0 ignored
+            error: doc tests failed
+        "#});
+}
+
+#[test]
+fn runnable_example_fails_at_runtime() {
+    let t = TempDir::new().unwrap();
+    ProjectBuilder::start()
+        .name("hello_world")
+        .lib_cairo(CODE_WITH_RUNTIME_ERROR)
+        .build(&t);
+
+    Scarb::quick_command()
+        .arg("doc")
+        .args(["--output-format", "markdown"])
+        .arg("--disable-remote-linking")
+        .arg("--build")
+        .current_dir(&t)
+        .assert()
+        .failure()
+        .stdout_eq(indoc! {r#"
+            [..] Running 1 doc examples for `hello_world`
+            [..] Compiling hello_world_example_1 v0.1.0 ([..])
+            [..]  Finished `dev` profile target(s) in [..]
+            Panicked with "Runtime error occurred".
+            test hello_world::foo ... FAILED
+
+            failures:
+                hello_world::foo
+
+            test result: FAILED. 0 passed; 1 failed; 0 ignored
+            error: doc tests failed
+        "#});
+}
+
+#[test]
+fn supports_runnable_examples_with_starknet_contract() {
+    let t = TempDir::new().unwrap();
+    ProjectBuilder::start()
+        .name("hello_world")
+        .edition("2023_01")
+        .manifest_extra(indoc! {r#"
+            [lib]
+            [[target.starknet-contract]]
+        "#})
+        .dep_starknet()
+        .lib_cairo(CODE_WITH_STARKNET_CONTRACT)
+        .build(&t);
+
+    Scarb::quick_command()
+        .arg("doc")
+        .args(["--output-format", "markdown"])
+        .arg("--disable-remote-linking")
+        .arg("--build")
+        .current_dir(&t)
+        .assert()
+        .success()
+        .stdout_eq(formatdoc! {r#"
+            [..] Running 1 doc examples for `hello_world`
+            [..] Compiling hello_world_example_1 v0.1.0 ([..])
+            [..]  Finished `dev` profile target(s) in [..]
+            test hello_world::IBalance ... ok
+
+            test result: ok. 1 passed; 0 failed; 0 ignored
+            Saving output to: target/doc/hello_world
+            Saving build output to: target/doc/hello_world/book
+
+            Run the following to see the results:[..]
+            `mdbook serve target/doc/hello_world`
+
+            Or open the following in your browser:[..]
+            `[..]/target/doc/hello_world/book/index.html`
+        "#});
+}
+
+#[test]
+fn supports_runnable_examples_with_only_starknet_contract_target() {
+    let t = TempDir::new().unwrap();
+    ProjectBuilder::start()
+        .name("hello_world")
+        .edition("2023_01")
+        .manifest_extra("[[target.starknet-contract]]")
+        .dep_starknet()
+        .lib_cairo(CODE_WITH_STARKNET_CONTRACT)
+        .build(&t);
+
+    Scarb::quick_command()
+        .arg("doc")
+        .args(["--output-format", "markdown"])
+        .arg("--disable-remote-linking")
+        .arg("--build")
+        .current_dir(&t)
+        .assert()
+        .success()
+        .stdout_eq(indoc! {r#"
+            [..] Running 1 doc examples for `hello_world`
+            warn: package `hello_world` has no `lib` target defined
+            `hello_world` contents cannot be imported in the doc string definition
+            
+            warn: hello_world_example_1 v0.1.0 ([..]Scarb.toml) ignoring invalid dependency `hello_world` which is missing a lib or cairo-plugin target
+            [..] Compiling hello_world_example_1 v0.1.0 ([..])
+            [..]  Finished `dev` profile target(s) in [..]
+            test hello_world::IBalance ... ok
+
+            test result: ok. 1 passed; 0 failed; 0 ignored
+            Saving output to: target/doc/hello_world
+            Saving build output to: target/doc/hello_world/book
+
+            Run the following to see the results:[..]
+            `mdbook serve target/doc/hello_world`
+
+            Or open the following in your browser:[..]
+            `[..]/target/doc/hello_world/book/index.html`
+        "#});
+}
+
+#[test]
+fn should_panic() {
+    let t = TempDir::new().unwrap();
+    ProjectBuilder::start()
+        .name("hello_world")
+        .lib_cairo(CODE_WITH_SHOULD_PANIC)
+        .build(&t);
+
+    Scarb::quick_command()
+        .arg("doc")
+        .args(["--output-format", "markdown"])
+        .arg("--disable-remote-linking")
+        .arg("--build")
+        .current_dir(&t)
+        .assert()
+        .failure()
+        .stdout_eq(indoc! {r#"
+            [..] Running 2 doc examples for `hello_world`
+            [..] Compiling hello_world_example_1 v0.1.0 ([..])
+            [..]  Finished `dev` profile target(s) in [..]
+            test hello_world::is_odd (example 1) ... ok
+            [..] Compiling hello_world_example_2 v0.1.0 ([..])
+            [..]  Finished `dev` profile target(s) in [..]
+            error: Test executable succeeded, but it's marked `should_panic`.
+            test hello_world::is_odd (example 2) ... FAILED
+
+            failures:
+                hello_world::is_odd (example 2)
+
+            test result: FAILED. 1 passed; 1 failed; 0 ignored
+            error: doc tests failed
+        "#});
+}
+
+#[test]
+fn compile_fail() {
+    let t = TempDir::new().unwrap();
+    ProjectBuilder::start()
+        .name("hello_world")
+        .lib_cairo(CODE_WITH_COMPILE_FAIL)
+        .build(&t);
+
+    Scarb::quick_command()
+        .arg("doc")
+        .args(["--output-format", "markdown"])
+        .arg("--disable-remote-linking")
+        .arg("--build")
+        .current_dir(&t)
+        .assert()
+        .failure()
+        .stdout_eq(indoc! {r#"
+            [..] Running 2 doc examples for `hello_world`
+            [..] Compiling hello_world_example_1 v0.1.0 ([..])
+            error[E2041]: Unexpected argument type. Expected: "core::integer::i32", found: "core::bool".
+             --> [..]lib.cairo[..]
+                is_odd(true);
+                       ^^^^
+
+            error: could not compile `hello_world_example_1` due to 1 previous error
+            test hello_world::is_odd (example 1) ... ok
+            [..] Compiling hello_world_example_2 v0.1.0 ([..])
+            [..]  Finished `dev` profile target(s) in [..]
+            error: Test compiled successfully, but it's marked `compile_fail`.
+            test hello_world::is_odd (example 2) ... FAILED
+
+            failures:
+                hello_world::is_odd (example 2)
+
+            test result: FAILED. 1 passed; 1 failed; 0 ignored
+            error: doc tests failed
+        "#});
+}
+
+#[test]
+fn runnable_examples_not_duplicated_for_reexported_items() {
+    let t = TempDir::new().unwrap();
+    ProjectBuilder::start()
+        .name("hello_world")
+        .lib_cairo(CODE_WITH_REEXPORTED_ITEM)
+        .build(&t);
+
+    Scarb::quick_command()
+        .arg("doc")
+        .args(["--output-format", "markdown"])
+        .arg("--disable-remote-linking")
+        .current_dir(&t)
+        .assert()
+        .success()
+        .stdout_eq(formatdoc! {r#"
+            [..] Running 1 doc examples for `hello_world`
+            [..] Compiling hello_world_example_1 v0.1.0 ([..])
+            [..]  Finished `dev` profile target(s) in [..]
+            test hello_world::inner::MyStruct ... ok
+
+            test result: ok. 1 passed; 0 failed; 0 ignored
+            Saving output to: target/doc/hello_world
+
+            Run the following to see the results:[..]
+            `mdbook serve target/doc/hello_world`
+            (you will need to have mdbook installed)
+
+            Or build html docs by running `scarb doc --build`
+        "#});
+}
+
+#[test]
+fn workspace_with_multiple_packages_each_has_doc_tests() {
+    let root_dir = TempDir::new().unwrap();
+    let pkg_a_dir = root_dir.child("pkg_a");
+    let pkg_b_dir = root_dir.child("pkg_b");
+
+    ProjectBuilder::start()
+        .name("pkg_a")
+        .lib_cairo(indoc! {r#"
+            /// Adds two numbers.
+            /// ```cairo,runnable
+            /// add(1_u32, 2_u32);
+            /// ```
+            pub fn add(a: u32, b: u32) -> u32 {
+                a + b
+            }
+        "#})
+        .build(&pkg_a_dir);
+
+    ProjectBuilder::start()
+        .name("pkg_b")
+        .lib_cairo(indoc! {r#"
+            /// Doubles a number.
+            /// ```cairo,runnable
+            /// double(5_u32);
+            /// ```
+            pub fn double(a: u32) -> u32 {
+                a * 2
+            }
+        "#})
+        .build(&pkg_b_dir);
+
+    WorkspaceBuilder::start()
+        .add_member("pkg_a")
+        .add_member("pkg_b")
+        .build(&root_dir);
+
+    Scarb::quick_command()
+        .arg("doc")
+        .args(["--workspace", "--output-format", "json"])
+        .current_dir(&root_dir)
+        .assert()
+        .success()
+        .stdout_eq(formatdoc! {r#"
+            [..] Running 1 doc examples for `pkg_a`
+            [..] Compiling pkg_a_example_1 v0.1.0 ([..])
+            [..]  Finished `dev` profile target(s) in [..]
+            test pkg_a::add ... ok
+
+            test result: ok. 1 passed; 0 failed; 0 ignored
+            [..] Running 1 doc examples for `pkg_b`
+            [..] Compiling pkg_b_example_1 v0.1.0 ([..])
+            [..]  Finished `dev` profile target(s) in [..]
+            test pkg_b::double ... ok
+
+            test result: ok. 1 passed; 0 failed; 0 ignored
+            Saving output to: target/doc/output.json
+        "#});
+}

--- a/extensions/scarb-doc/tests/runnable_examples.rs
+++ b/extensions/scarb-doc/tests/runnable_examples.rs
@@ -241,7 +241,7 @@ fn supports_runnable_examples_with_starknet_contract() {
     let t = TempDir::new().unwrap();
     ProjectBuilder::start()
         .name("hello_world")
-        .edition("2023_01")
+        .edition("2023_11")
         .manifest_extra(indoc! {r#"
             [lib]
             [[target.starknet-contract]]
@@ -299,7 +299,7 @@ fn supports_runnable_examples_with_only_starknet_contract_target() {
             [..] Running 1 doc examples for `hello_world`
             warn: package `hello_world` has no `lib` target defined
             `hello_world` contents cannot be imported in the doc string definition
-            
+
             warn: hello_world_example_1 v0.1.0 ([..]Scarb.toml) ignoring invalid dependency `hello_world` which is missing a lib or cairo-plugin target
             [..] Compiling hello_world_example_1 v0.1.0 ([..])
             [..]  Finished `dev` profile target(s) in [..]

--- a/utils/scarb-extensions-cli/src/doc.rs
+++ b/utils/scarb-extensions-cli/src/doc.rs
@@ -45,6 +45,10 @@ pub struct Args {
     #[arg(long, default_value_t = false)]
     pub build: bool,
 
+    /// Do not run doc tests.
+    #[arg(long, default_value_t = false)]
+    pub no_run: bool,
+
     /// Open the generated documentation in a browser.
     ///
     /// Implies `--build`.

--- a/website/docs/extensions/documentation-generation.md
+++ b/website/docs/extensions/documentation-generation.md
@@ -82,6 +82,149 @@ Scarb does not automatically detect your repository host. Instead, it assumes a 
 
 While other VCS hosts are not officially supported, they may still work if they follow the same URL formatting for file browsing and line anchors (e.g., using `/blob/` for file paths and `#L` for line ranges). We may add official support or configuration options for other providers in the future based on community demand.
 
+## Doc tests
+
+`scarb doc` can extract and run code examples embedded in documentation comments, verifying that they compile and execute correctly. This helps ensure that code examples in your documentation stay up to date.
+
+### Writing runnable examples
+
+To make a code block runnable, add the `cairo` and `runnable` attributes to the code fence:
+
+````cairo
+/// Adds two numbers together.
+/// ```cairo,runnable
+/// let result = add(2, 3);
+/// assert(result == 5, 'should be 5');
+/// ```
+pub fn add(a: u32, b: u32) -> u32 {
+    a + b
+}
+````
+
+Code blocks marked only with `cairo` (without `runnable`) are not executed and will be ignored during testing.
+
+### Function body vs full Cairo snippet
+
+Scarb detects whether a code block contains a **function body** (expressions and statements) or a **full Cairo snippet** (with top-level items like functions) and handles each differently.
+
+#### Function body
+
+If the code block contains only expressions and statements, Scarb automatically wraps it in a `fn main() { ... }` and adds `use package_name::*;` so you can call items from the documented package directly:
+
+````cairo
+/// ```cairo,runnable
+/// let result = add(2, 3);
+/// println!("{}", result);
+/// ```
+pub fn add(a: u32, b: u32) -> u32 {
+    a + b
+}
+````
+
+Under the hood this becomes:
+
+```cairo
+use hello_world::*;
+
+#[executable]
+fn main() {
+    let result = add(2, 3);
+    println!("{}", result);
+}
+```
+
+#### Full Cairo snippet
+
+If the code block contains top-level items (e.g. its own `fn main()`), Scarb uses it as-is without wrapping. You must define the entry point yourself:
+
+````cairo
+/// ```cairo,runnable
+/// #[executable]
+/// fn main() -> i32 {
+///     add(-1, 1)
+/// }
+/// ```
+pub fn add(a: i32, b: i32) -> i32 {
+    a + b
+}
+````
+
+This form is useful when you need to return a value from `main`, define helper functions, or have full control over the example structure. The documented package is still imported with `use package_name::*;`.
+
+### Code block attributes
+
+Attributes are specified as a comma-separated list after the opening code fence:
+
+| Attribute      | Description                                                                       |
+| -------------- | --------------------------------------------------------------------------------- |
+| `cairo`        | Marks the block as Cairo code.                                                    |
+| `runnable`     | Marks the block for execution. Must be combined with `cairo`.                     |
+| `ignore`       | Skips the block entirely (not compiled, not run).                                 |
+| `no_run`       | Compiles the block but does not execute it.                                       |
+| `compile_fail` | Asserts that the block **fails to compile**. The test passes on a compile error.  |
+| `should_panic` | Asserts that the block **panics at runtime**. The test passes on a runtime error. |
+
+Example using `should_panic`:
+
+````cairo
+/// ```cairo,runnable,should_panic
+/// assert(is_odd(2), '2 is not odd');
+/// ```
+pub fn is_odd(n: i32) -> bool {
+    n % 2 != 0
+}
+````
+
+Example using `compile_fail`:
+
+````cairo
+/// ```cairo,runnable,compile_fail
+/// is_odd(true);
+/// ```
+pub fn is_odd(n: i32) -> bool {
+    n % 2 != 0
+}
+````
+
+### Package import
+
+The package import will only be added if the package declares a `[lib]` target.
+Otherwise, it's not possible to import the package's code.
+In such case, a warning will be shown and you need to provide all imports for your code manually.
+
+### Dependencies
+
+Doc test examples are executed in an isolated temporary workspace that includes only the documented package and the Cairo standard library. **Examples cannot import or depend on any other external packages.** If your example requires types or functions from third-party dependencies, you will need to redefine or stub them within the code block itself.
+
+### Running doc tests
+
+Doc tests run automatically as part of `scarb doc`. When code blocks are found, each runnable block is compiled and executed in an isolated temporary workspace that depends on the documented package.
+
+To skip running doc tests, use the `--no-run` flag:
+
+```shell
+scarb doc --no-run
+```
+
+The output shows the result for each code block:
+
+```
+   Running 3 doc examples for `hello_world`
+test hello_world::bar ... ignored
+test hello_world::foo ... ok
+test hello_world::foo_bar ... ok
+
+test result: ok. 2 passed; 0 failed; 1 ignored
+```
+
+When a code block has multiple examples, they are distinguished by index (e.g., `hello_world::add (example 0)`, `hello_world::add (example 1)`).
+
+If any runnable example fails unexpectedly, `scarb doc` exits with a non-zero status.
+
+### Embedding execution results
+
+For Markdown output format, execution results of runnable examples are embedded directly into the generated documentation pages. Each successfully executed code block includes the captured output and return value below it.
+
 ## mdBook
 
 Generated Markdown can be used to build a [mdBook](https://rust-lang.github.io/mdBook) documentation.


### PR DESCRIPTION
Support runnable code blocks in docs

Add test case with starknet-contract target

Add test cases for mdx and json outputs

Add support for should_panic and compile_fail doc-test attributes