### PR TITLE
update docstrings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7047,9 +7047,11 @@ name = "scarb-manifest-schema"
 version = "1.0.0"
 dependencies = [
  "anyhow",
+ "indoc",
  "scarb",
  "schemars",
  "serde_json",
+ "test-case",
 ]
 
 [[package]]

--- a/scarb/src/core/manifest/maybe_workspace.rs
+++ b/scarb/src/core/manifest/maybe_workspace.rs
@@ -21,7 +21,7 @@ pub trait WorkspaceInherit {
     fn workspace(&self) -> bool;
 }
 
-/// An enum that allows for inheriting keys from a workspace in a Scarb.toml.
+/// Allows inheriting keys from a workspace.
 #[derive(Clone, Debug, Serialize, JsonSchema)]
 #[serde(untagged)]
 pub enum MaybeWorkspace<T, W: WorkspaceInherit> {

--- a/utils/scarb-manifest-schema/Cargo.toml
+++ b/utils/scarb-manifest-schema/Cargo.toml
@@ -14,3 +14,7 @@ anyhow.workspace = true
 scarb = { path = "../../scarb" }
 schemars.workspace = true
 serde_json.workspace = true
+
+[dev-dependencies]
+test-case.workspace = true
+indoc.workspace = true

--- a/utils/scarb-manifest-schema/tests/traverse.rs
+++ b/utils/scarb-manifest-schema/tests/traverse.rs
@@ -1,21 +1,41 @@
-use scarb_manifest_schema::{SchemaTraverser, get_manifest_schema};
+use indoc::indoc;
+use scarb_manifest_schema::get_shared_traverser;
 use serde_json::json;
+use test_case::test_case;
 
-fn setup_schema() -> SchemaTraverser {
-    let schema = get_manifest_schema();
-    SchemaTraverser::new(schema)
-}
+#[test_case(vec!["cairo",], indoc!{r#"
+        Global Cairo compiler configuration for this package or workspace profile.
+        - See official documentation at: <https://docs.swmansion.com/scarb/docs/reference/manifest.html#cairo>"#} ; "simple_traversal")]
+#[test_case(vec!["package", "version"], indoc!{r#"
+        Package version obeying Semantic Versioning (semver), e.g. `"0.1.0"`.
+        Can be inherited from the workspace via `{ workspace = true }`.
+        - See official documentation at: <https://docs.swmansion.com/scarb/docs/reference/manifest.html#version>"#} ; "nested_traversal1")]
+#[test_case(vec!["workspace", "require-audits"], indoc!{r#"
+        Setting this field to true will cause Scarb to ignore any versions of dependencies, including transitive ones, that are not marked as audited in the registry.
+        If unable to resolve the dependency tree due to this, Scarb will exit with an error.
+        By default, this field is set to false. This policy applies to the entire workspace.
+        This field is ignored in member packages manifest files, and only the one defined in the workspace root manifest is applied when compiling member packages.
 
-#[test]
-fn test_simple_traversal() {
-    let traverser = setup_schema();
-    let result = traverser.traverse(vec!["cairo"]).unwrap();
-    assert!(result["description"].is_null());
+        You may whitelist specific packages to ignore the require-audits setting by specifying them in the allow-no-audits key:
+        ```toml
+        [workspace]
+        allow-no-audits = ["alexandria_math"]
+        ```
+        - See official documentation at: <https://docs.swmansion.com/scarb/docs/reference/workspaces.html#security-and-audits>"#} ; "nested_traversal2")]
+#[test_case(vec!["package", "edition", "workspace"], indoc!{r#"
+        Allows inheriting keys from a workspace."#} ; "nested_traversal_with_workspace_inheritable")]
+fn test_traverse(path: Vec<&str>, expected_description: &str) {
+    let traverser = get_shared_traverser();
+    let result = traverser.traverse(path.to_vec()).unwrap();
+    assert_eq!(
+        result["description"].as_str().unwrap(),
+        expected_description
+    );
 }
 
 #[test]
 fn test_nested_traversal_with_ref() {
-    let traverser = setup_schema();
+    let traverser = get_shared_traverser();
     let result = traverser.traverse(vec!["package", "no-core"]).unwrap();
     let expected = json!({
           "description": "**UNSTABLE** This package does not depend on Cairo's `core`.",
@@ -28,24 +48,8 @@ fn test_nested_traversal_with_ref() {
 }
 
 #[test]
-fn test_nested_traversal_with_ref2() {
-    let traverser = setup_schema();
-    let result = traverser
-        .traverse(vec!["workspace", "require-audits"])
-        .unwrap();
-    assert!(result["description"].is_null());
-}
-
-#[test]
-fn test_double_ref_resolution() {
-    let traverser = setup_schema();
-    let result = traverser.traverse(vec!["package", "version"]).unwrap();
-    assert!(result["description"].is_null());
-}
-
-#[test]
 fn test_error_missing_key() {
-    let traverser = setup_schema();
+    let traverser = get_shared_traverser();
     let result = traverser.traverse(vec!["non_existent_field"]);
     assert!(result.is_err());
     assert!(
@@ -58,7 +62,7 @@ fn test_error_missing_key() {
 
 #[test]
 fn test_error_traversing_into_leaf() {
-    let traverser = setup_schema();
+    let traverser = get_shared_traverser();
     let result = traverser.traverse(vec!["cairo", "something_else"]);
     assert!(result.is_err());
 


### PR DESCRIPTION
- I will update `utils/scarb-manifest-schema/CHANGELOG.md` and `utils/scarb-manifest-schema/README.md` in following PR, just this is shippable pice so I wanted to publish it already as I assume (and hope) that the docstrings review will cause a lot of noise.
- The docstring were partially AI generated, I did read and edit all of them but still consider it  might be relevant to let you know 🫡 
- Also, originally we discussed having the dosctrings one-to-one copy of what's on the [offcicial doc web](https://docs.swmansion.com/scarb/docs/reference/manifest.html) but I did shift from that idea as they are tailored for the web - let me know if you do not agree and would rather see them as a copy of what's on the web 🙏 

closes https://github.com/software-mansion/scarb/issues/2991