### PR TITLE
Fully cache warnings in incremental 

### DIFF
--- a/scarb/src/compiler/helpers.rs
+++ b/scarb/src/compiler/helpers.rs
@@ -1,6 +1,6 @@
 //! Various utility functions helpful for interacting with Cairo compiler.
 
-use crate::compiler::incremental::IncrementalContext;
+use crate::compiler::incremental::{CachedWarnings, IncrementalContext};
 use crate::compiler::{CairoCompilationUnit, CompilationUnitAttributes};
 use crate::core::{InliningStrategy, Workspace};
 use crate::flock::Filesystem;
@@ -13,7 +13,6 @@ use cairo_lang_filesystem::ids::CrateId;
 use itertools::Itertools;
 use salsa::Database;
 use serde::Serialize;
-use std::collections::HashSet;
 use std::io::{BufWriter, Write};
 
 pub struct CountingWriter<W> {
@@ -64,35 +63,19 @@ where
     // we should not use it in the first place.
     // We also skip showing warnings produced for dependency crates.
     let crates_to_check = db.crates().iter().filter(|crate_id| {
-        !ctx.cached_crates()
-            .contains(&crate_id.long(db).clone().into_crate_input(db))
-    });
-    // Note we may need to add the main crates to display warnings generated from them.
-    // This is because warnings do not fail compilation, so we can produce caches for crates with them.
-    //
-    // We only need them in one case: if ui is set to print warnings (verbosity higher than no warnings)
-    // and the compiler is configured to succeed on warnings.
-    //
-    // Note that the compiler may be configured to fail on warnings, so it seems we should check for
-    // them in this case as well. However, if the compiler is set to fail on warnings, we are unable
-    // to produce caches for crates with warnings. If this config changes in between runs, we will
-    // invalidate the cache anyway.
-    let crates_to_check: HashSet<CrateId<'db>> =
-        if ws.config().ui().verbosity().should_print_warnings()
-            && unit.compiler_config.allow_warnings
-        {
-            crates_to_check
-                .chain(main_crate_ids.iter().filter(|c| {
-                    // If we saved information about crate warnings, we can use it here to decide
-                    // whether we should calculate diagnostics for it.
-                    ctx.cached_crates_with_warnings()
-                        .contains(&c.long(db).clone().into_crate_input(db))
-                }))
-                .copied()
-                .collect()
+        let crate_input = crate_id.long(db).clone().into_crate_input(db);
+        if ctx.cached_crates().contains(&crate_input) {
+            // Even if cached, include the main crate in diagnostics checking when its
+            // warnings are unknown (i.e., it was previously compiled only as a dependency).
+            main_crate_ids.contains(crate_id)
+                && matches!(
+                    ctx.cached_crate_warnings_for(&crate_input),
+                    CachedWarnings::Unresolved
+                )
         } else {
-            crates_to_check.copied().collect()
-        };
+            true
+        }
+    });
     let diagnostics_reporter = DiagnosticsReporter::callback({
         let config = ws.config();
 
@@ -110,9 +93,10 @@ where
                     }
                 }
                 Severity::Warning => {
-                    ctx.report_warnings();
-                    if let Some(code) = entry.error_code() {
-                        config.ui().warn_with_code(code.as_str(), msg)
+                    let code = entry.error_code().map(|c| c.as_str().to_string());
+                    ctx.add_warning(code.clone(), msg.to_string());
+                    if let Some(code) = code {
+                        config.ui().warn_with_code(&code, msg)
                     } else {
                         config.ui().warn(msg)
                     }

--- a/scarb/src/compiler/incremental/compilation.rs
+++ b/scarb/src/compiler/incremental/compilation.rs
@@ -19,21 +19,43 @@ use rayon::prelude::*;
 use salsa::Database;
 use scarb_fs_utils as fsx;
 use scarb_stable_hash::u64_hash;
+use std::collections::HashMap;
 use std::io::{BufReader, Write};
 use std::mem;
 use std::ops::Deref;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use tokio::task::spawn_blocking;
 use tracing::{debug, error, trace_span};
 
 const SCARB_INCREMENTAL: &str = "SCARB_INCREMENTAL";
 
+/// A single warning captured during compilation, stored in the incremental cache for replay.
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
+pub struct CachedWarning {
+    /// The diagnostic error code (e.g. `"E2066"`), if any.
+    pub code: Option<String>,
+    /// The formatted warning message (without trailing newline).
+    pub message: String,
+}
+
+/// The warning state of a cached crate.
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
+pub enum CachedWarnings {
+    /// The crate was only compiled as a dependency — warnings are unknown.
+    Unresolved,
+    /// The crate was compiled as the main unit; holds emitted warnings (empty = clean).
+    Resolved(Vec<CachedWarning>),
+}
+
 pub struct EnabledIncrementalContext {
     fingerprints: UnitComponentsFingerprint,
     cached_crates: Vec<CrateInput>,
-    cached_crates_with_warnings: Vec<CrateInput>,
-    warnings_found: AtomicBool,
+    /// Known warnings per cached crate, keyed by `CrateInput`.
+    /// Present only for crates previously compiled as a main unit.
+    /// An empty `Vec` means the crate compiled with no warnings.
+    cached_crate_warnings: HashMap<CrateInput, Vec<CachedWarning>>,
+    /// Warnings collected during the current compilation pass (main component only).
+    collected_warnings: Mutex<Vec<CachedWarning>>,
     artifacts: Mutex<Vec<LocalFingerprint>>,
 }
 
@@ -63,24 +85,41 @@ impl IncrementalContext {
         };
         &enabled.cached_crates
     }
-    pub fn cached_crates_with_warnings(&self) -> &[CrateInput] {
-        let IncrementalContext::Enabled(enabled) = self else {
-            return &[];
-        };
-        &enabled.cached_crates_with_warnings
-    }
 
-    pub fn report_warnings(&self) {
-        if let IncrementalContext::Enabled(enabled) = self {
-            enabled.warnings_found.store(true, Ordering::Release)
+    /// Returns the warning state for a cached crate.
+    /// Returns `Unresolved` if incremental is disabled or the crate was only ever compiled as a
+    /// dependency (never as a main unit).
+    pub fn cached_crate_warnings_for(&self, crate_input: &CrateInput) -> CachedWarnings {
+        let IncrementalContext::Enabled(enabled) = self else {
+            return CachedWarnings::Unresolved;
+        };
+        match enabled.cached_crate_warnings.get(crate_input) {
+            Some(v) => CachedWarnings::Resolved(v.clone()),
+            None => CachedWarnings::Unresolved,
         }
     }
 
-    pub fn warnings_found(&self) -> bool {
+    /// Records a warning emitted during the current compilation pass.
+    pub fn add_warning(&self, code: Option<String>, message: String) {
         if let IncrementalContext::Enabled(enabled) = self {
-            enabled.warnings_found.load(Ordering::Acquire)
+            enabled
+                .collected_warnings
+                .lock()
+                .expect("failed to acquire collected_warnings mutex")
+                .push(CachedWarning { code, message });
+        }
+    }
+
+    /// Returns all warnings collected during the current compilation pass.
+    pub fn collected_warnings(&self) -> Vec<CachedWarning> {
+        if let IncrementalContext::Enabled(enabled) = self {
+            enabled
+                .collected_warnings
+                .lock()
+                .expect("failed to acquire collected_warnings mutex")
+                .clone()
         } else {
-            false
+            Vec::new()
         }
     }
 
@@ -114,7 +153,8 @@ impl IncrementalContext {
 
 #[derive(serde::Serialize, serde::Deserialize)]
 pub struct ScarbComponentCache {
-    pub has_warnings: bool,
+    /// Warning state recorded when this component was last compiled.
+    pub warnings: CachedWarnings,
     pub blob: Vec<u8>,
 }
 
@@ -164,7 +204,7 @@ pub fn load_incremental_artifacts(
     })?;
 
     let span = trace_span!("set_crate_configs");
-    let mut cached_crates_with_warnings = Vec::new();
+    let mut cached_crate_warnings: HashMap<CrateInput, Vec<CachedWarning>> = HashMap::new();
     let cached_crates = {
         let _guard = span.enter();
 
@@ -175,7 +215,7 @@ pub fn load_incremental_artifacts(
                 CrateCache::Loaded {
                     component,
                     blob_content,
-                    has_warnings,
+                    warnings,
                 } => {
                     let crate_id = component.crate_id(db);
                     if let Some(core_conf) = db.crate_config(crate_id) {
@@ -189,10 +229,11 @@ pub fn load_incremental_artifacts(
                             })
                         );
                     }
-                    if has_warnings {
-                        cached_crates_with_warnings.push(component.crate_input(db));
+                    let crate_input = component.crate_input(db);
+                    if let CachedWarnings::Resolved(known_warnings) = warnings {
+                        cached_crate_warnings.insert(crate_input.clone(), known_warnings);
                     }
-                    Some(component.crate_input(db))
+                    Some(crate_input)
                 }
             })
             .collect_vec()
@@ -202,8 +243,8 @@ pub fn load_incremental_artifacts(
         EnabledIncrementalContext {
             fingerprints,
             cached_crates,
-            cached_crates_with_warnings,
-            warnings_found: AtomicBool::new(false),
+            cached_crate_warnings,
+            collected_warnings: Default::default(),
             artifacts: Default::default(),
         },
     )))
@@ -255,10 +296,13 @@ fn load_component_cache(
         let mut reader = BufReader::new(file.deref());
         let mut bytes = Vec::new();
         std::io::Read::read_to_end(&mut reader, &mut bytes)?;
-        let decoded: ScarbComponentCache = postcard::from_bytes(&bytes)?;
+        let decoded: ScarbComponentCache = postcard::from_bytes(&bytes).context(format!(
+            "failed to deserialize incremental cache for component {}",
+            component.target_name()
+        ))?;
         Ok(CrateCache::Loaded {
             component,
-            has_warnings: decoded.has_warnings,
+            warnings: decoded.warnings,
             blob_content: decoded.blob,
         })
     } else {
@@ -270,7 +314,7 @@ enum CrateCache {
     None,
     Loaded {
         component: CompilationUnitComponent,
-        has_warnings: bool,
+        warnings: CachedWarnings,
         blob_content: Vec<u8>,
     },
 }
@@ -282,12 +326,13 @@ pub fn save_incremental_artifacts(
     ctx: Arc<IncrementalContext>,
     ws: &Workspace<'_>,
 ) -> Result<()> {
-    let warnings_found = ctx.warnings_found();
+    let collected_warnings = ctx.collected_warnings();
     let Some(fingerprints) = ctx.fingerprints() else {
         return Ok(());
     };
 
     let main_component_id = &unit.main_component().id;
+
     let components = unit
         .components
         .iter()
@@ -295,37 +340,34 @@ pub fn save_incremental_artifacts(
             let fingerprint = fingerprints
                 .get(&component.id)
                 .expect("component fingerprint must exist in unit fingerprints");
-            let crate_input = component.crate_input(db);
-            let cached_has_warnings = if ctx.cached_crates().contains(&crate_input) {
-                Some(ctx.cached_crates_with_warnings().contains(&crate_input))
+            // For the main component, record the warnings we just collected.
+            // For dependency components, preserve any previously known warnings so we don't
+            // lose information. If a dep was never compiled as main (no entry in
+            // cached_crate_warnings), keep it as Unresolved so warnings are checked the next
+            // time it is compiled as the main unit.
+            let is_main = &component.id == main_component_id;
+            let component_warnings: CachedWarnings = if is_main {
+                CachedWarnings::Resolved(collected_warnings.clone())
             } else {
-                None
+                let crate_input = component.crate_input(db);
+                if ctx.cached_crates().contains(&crate_input) {
+                    // Preserve previously known warning status (may be Unresolved if dep-only).
+                    ctx.cached_crate_warnings_for(&crate_input)
+                } else {
+                    // Compiled fresh as a dep this round; warnings unknown.
+                    CachedWarnings::Unresolved
+                }
             };
-            // For the main component, use the actual warnings_found flag.
-            // For dependency components, warnings are suppressed during compilation so
-            // warnings_found is not reliable. Instead, preserve the previously cached
-            // has_warnings value to avoid incorrectly marking a component as warning-free.
-            // If the component has no prior cache entry, default to true (conservative) so
-            // that warnings will be re-checked when the component is next compiled as main.
-            let component_has_warnings = if &component.id == main_component_id {
-                warnings_found
-            } else {
-                cached_has_warnings.unwrap_or(true)
-            };
-            (
-                component,
-                fingerprint,
-                component_has_warnings,
-                cached_has_warnings,
-            )
+            (component, fingerprint, component_warnings)
         })
         .collect_vec();
 
+    let ctx = ctx.as_ref();
     let results: Vec<Result<()>> = components
         .par_iter()
         .map_with(
             db.dyn_clone(),
-            move |group, (component, fingerprint, component_has_warnings, cached_has_warnings)| {
+            move |group, (component, fingerprint, component_warnings)| {
                 let fingerprint = match fingerprint.deref() {
                     ComponentFingerprint::Library(lib) => lib,
                     ComponentFingerprint::Plugin(_plugin) => {
@@ -337,8 +379,8 @@ pub fn save_incremental_artifacts(
                     group.as_ref(),
                     unit,
                     component,
-                    *component_has_warnings,
-                    *cached_has_warnings,
+                    component_warnings.clone(),
+                    ctx,
                     ws,
                 )
                 .with_context(|| {
@@ -361,8 +403,8 @@ fn save_component_cache(
     db: &dyn CloneableDatabase,
     unit: &CairoCompilationUnit,
     component: &CompilationUnitComponent,
-    warnings_found: bool,
-    cached_has_warnings: Option<bool>,
+    warnings: CachedWarnings,
+    ctx: &IncrementalContext,
     ws: &Workspace<'_>,
 ) -> Result<()> {
     let fingerprint_digest = fingerprint.digest();
@@ -379,14 +421,16 @@ fn save_component_cache(
     )?;
     // We drop the fingerprint lock, so it can be locked for writing.
     drop(file_guard);
-    // Write the cache when the component is not fresh (artifacts changed), when there is no
-    // prior cache entry (first time caching this component), or when the main component's
-    // cached `has_warnings` flag disagrees with the actual compilation result (e.g.,
-    // conservatively cached with `has_warnings=true` but this compilation found no warnings).
-    // Note: for dependency components, `cached_has_warnings` is set to the cached value, so
-    // `warnings_changed` can only be true here when there is no prior cache entry.
-    let warnings_changed = cached_has_warnings != Some(warnings_found);
-    if !is_fresh || warnings_changed {
+    // Force-save when the blob is fresh but the main component's warnings just became resolved
+    // for the first time (previously compiled only as a dependency, warnings were unknown).
+    let is_main = component.id == unit.main_component().id;
+    let force_save = is_main
+        && is_fresh
+        && matches!(
+            ctx.cached_crate_warnings_for(&component.crate_input(db)),
+            CachedWarnings::Unresolved
+        );
+    if !is_fresh || force_save {
         debug!(
             "component `{}` is not fresh, saving new cache artifacts",
             component.target_name()
@@ -404,7 +448,7 @@ fn save_component_cache(
             }
         };
         let component_cache = ScarbComponentCache {
-            has_warnings: warnings_found,
+            warnings,
             blob: cache_blob,
         };
         let cache_blob = postcard::to_allocvec(&component_cache)?;

--- a/scarb/src/compiler/incremental/mod.rs
+++ b/scarb/src/compiler/incremental/mod.rs
@@ -4,7 +4,7 @@ mod fingerprint;
 mod source;
 
 pub use compilation::{
-    IncrementalContext, load_incremental_artifacts, save_incremental_artifacts,
+    CachedWarnings, IncrementalContext, load_incremental_artifacts, save_incremental_artifacts,
     warmup_incremental_cache,
 };
 

--- a/scarb/src/ops/compile.rs
+++ b/scarb/src/ops/compile.rs
@@ -7,7 +7,7 @@ use crate::compiler::incremental::artifacts_fingerprint::{
     save_unit_artifacts_fingerprint, unit_artifacts_fingerprint_is_fresh,
 };
 use crate::compiler::incremental::{
-    IncrementalContext, load_incremental_artifacts, save_incremental_artifacts,
+    CachedWarnings, IncrementalContext, load_incremental_artifacts, save_incremental_artifacts,
 };
 use crate::compiler::plugin::proc_macro;
 use crate::compiler::{CairoCompilationUnit, CompilationUnit, CompilationUnitAttributes};
@@ -287,12 +287,11 @@ fn compile_cairo_unit_inner(unit: CairoCompilationUnit, ws: &Workspace<'_>) -> R
 
         let ctx = load_incremental_artifacts(&unit, &mut db, ws)?;
 
-        let warnings_to_print = ws.config().ui().verbosity().should_print_warnings()
-            && !ctx.cached_crates_with_warnings().is_empty();
+        // Check whether we already have the main crate's warnings stored in cache.
+        let main_crate_input = unit.main_component().crate_input(&db);
+        let main_crate_known_warnings = ctx.cached_crate_warnings_for(&main_crate_input);
 
-        let is_fresh_unit_artifacts = !warnings_to_print
-            && artifacts_fingerprint_allowed()
-            && ctx.cached_crates_with_warnings().is_empty()
+        let is_fresh_unit_artifacts = artifacts_fingerprint_allowed()
             && ctx
                 .fingerprints()
                 .and_then(|unit_fingerprint| {
@@ -319,7 +318,24 @@ fn compile_cairo_unit_inner(unit: CairoCompilationUnit, ws: &Workspace<'_>) -> R
                     .post_process(&db)
                     .context("procedural macro post processing callback failed")?;
             }
-        };
+        }
+
+        let main_crate_is_cached = ctx.cached_crates().contains(&main_crate_input);
+        // Replay cached warnings for the main crate when:
+        // - compilation was skipped entirely, or
+        // - compilation ran, but the main crate came from incremental cache and was not
+        //   included in diagnostics crates_to_check.
+        let should_replay_main_cached_warnings = is_fresh_unit_artifacts || main_crate_is_cached;
+        if should_replay_main_cached_warnings
+            && ws.config().ui().verbosity().should_print_warnings()
+            && let CachedWarnings::Resolved(warnings) = &main_crate_known_warnings
+        {
+            for warning in warnings {
+                ws.config()
+                    .ui()
+                    .warn_maybe_with_code(&warning.message, &warning.code);
+            }
+        }
 
         let span = trace_span!("drop_db");
         {

--- a/utils/scarb-ui/src/lib.rs
+++ b/utils/scarb-ui/src/lib.rs
@@ -157,6 +157,16 @@ impl Ui {
         }
     }
 
+    /// Print a warning to the user.
+    /// Include error code if defined.
+    pub fn warn_maybe_with_code(&self, message: impl AsRef<str>, code: &Option<impl AsRef<str>>) {
+        if let Some(code) = code {
+            self.warn_with_code(code, message.as_ref());
+        } else {
+            self.warn(message.as_ref());
+        }
+    }
+
     /// Print an error to the user.
     pub fn error(&self, message: impl AsRef<str>) {
         self.counter.error();


### PR DESCRIPTION
Quick benchmark - perpetual with warnings in 3 packages. 

Before: 
```
➜  starknet-perpetual git:(RoeeGross/bump-versions) ✗ hyperfine --warmup 1 --runs 5 -- 'SCARB_INCREMENTAL=1 SCARB_ARTIFACTS_FINGERPRINT=1 /Users/maciektr/Projects/scarb/target/release/scarb build -w'
Benchmark 1: SCARB_INCREMENTAL=1 SCARB_ARTIFACTS_FINGERPRINT=1 /Users/maciektr/Projects/scarb/target/release/scarb build -w
  Time (mean ± σ):     14.497 s ±  0.233 s    [User: 32.518 s, System: 3.562 s]
  Range (min … max):   14.313 s … 14.866 s    5 runs

➜  starknet-perpetual git:(RoeeGross/bump-versions) ✗ hyperfine --warmup 1 --runs 5 -- 'SCARB_INCREMENTAL=1 SCARB_ARTIFACTS_FINGERPRINT=0 /Users/maciektr/Projects/scarb/target/release/scarb build -w'
Benchmark 1: SCARB_INCREMENTAL=1 SCARB_ARTIFACTS_FINGERPRINT=0 /Users/maciektr/Projects/scarb/target/release/scarb build -w
  Time (mean ± σ):     14.733 s ±  0.134 s    [User: 32.932 s, System: 3.566 s]
  Range (min … max):   14.541 s … 14.889 s    5 runs
  ```

After: 
```
➜  starknet-perpetual git:(RoeeGross/bump-versions) ✗ hyperfine --warmup 1 --runs 5 -- 'SCARB_INCREMENTAL=1 SCARB_ARTIFACTS_FINGERPRINT=1 /Users/maciektr/Projects/scarb/target/release/scarb build -w'
Benchmark 1: SCARB_INCREMENTAL=1 SCARB_ARTIFACTS_FINGERPRINT=1 /Users/maciektr/Projects/scarb/target/release/scarb build -w
  Time (mean ± σ):     530.9 ms ±  25.8 ms    [User: 548.2 ms, System: 698.4 ms]
  Range (min … max):   500.6 ms … 564.6 ms    5 runs

➜  starknet-perpetual git:(RoeeGross/bump-versions) ✗ hyperfine --warmup 1 --runs 5 -- 'SCARB_INCREMENTAL=1 SCARB_ARTIFACTS_FINGERPRINT=0 /Users/maciektr/Projects/scarb/target/release/scarb build -w'
Benchmark 1: SCARB_INCREMENTAL=1 SCARB_ARTIFACTS_FINGERPRINT=0 /Users/maciektr/Projects/scarb/target/release/scarb build -w
  Time (mean ± σ):     13.988 s ±  0.471 s    [User: 28.258 s, System: 3.231 s]
  Range (min … max):   13.462 s … 14.617 s    5 runs
```