### PR TITLE
Fix Windows CI: normalize path separators in doc test TOML manifest

### DIFF
--- a/extensions/scarb-doc/src/doc_test/workspace.rs
+++ b/extensions/scarb-doc/src/doc_test/workspace.rs
@@ -64,7 +64,9 @@ impl DocTestWorkspace {
             .context("package manifest path has no parent directory")?;
 
         let dep = &metadata.name;
-        let dep_path = format!("{}", package_dir);
+        // Use forward slashes so the path is valid in a TOML basic string on Windows,
+        // where native separators are backslashes which TOML treats as escape characters.
+        let dep_path = package_dir.as_str().replace('\\', "/");
         let name = &self.package_name;
         let edition = metadata
             .edition


### PR DESCRIPTION
On Windows, the dependency path embedded in the generated Scarb.toml used
native backslash separators (e.g. C:\path\to\pkg), which TOML treats as
escape sequences in basic strings, causing a parse error. Replace backslashes
with forward slashes before writing the manifest; Windows accepts forward
slashes in paths and TOML handles them as plain characters.

https://claude.ai/code/session_01BVLPMyWHrMahHKTBzU5CvW