### PR TITLE
Fix Windows CI: normalize workspace dep paths in doc test manifest

### DIFF
--- a/extensions/scarb-doc/src/doc_test/workspace.rs
+++ b/extensions/scarb-doc/src/doc_test/workspace.rs
@@ -98,7 +98,8 @@ impl DocTestWorkspace {
             writeln!(
                 workspace_dep_lines,
                 r#"{} = {{ path = "{}" }}"#,
-                dep.name, dep.package_dir
+                dep.name,
+                dep.package_dir.as_str().replace('\\', "/")
             )?;
         }
 


### PR DESCRIPTION
## Summary
- Commit 760498cf normalized `\` → `/` for the primary dep path embedded in the generated doc-test `Scarb.toml`, but the `workspace_deps` loop in `extensions/scarb-doc/src/doc_test/workspace.rs` still embedded `dep.package_dir` raw.
- On Windows, the native backslash separators are interpreted as TOML escape sequences, causing `scarb-doc::runnable_examples::workspace_with_root_package_includes_it_as_doc_test_dep` to fail with `failed to parse manifest at: ...\Scarb.toml` — the only test that exercises this loop with a real workspace dep.
- Apply the same `\\` → `/` replacement when writing each workspace dep line.

## Test plan
- [x] `cargo test -p scarb-doc --test runnable_examples workspace_with_root_package_includes_it_as_doc_test_dep` passes locally on Linux.
- [ ] Windows CI green on this branch (the `test-windows` label triggers the matrix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)