### PR TITLE
feat(scarb-prove): expose --proof-format flag for cairo_serde output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7432,7 +7432,6 @@ version = "2.18.0"
 dependencies = [
  "anyhow",
  "assert_fs",
- "cairo-air",
  "camino",
  "clap",
  "create-output-dir 1.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7295,6 +7295,7 @@ name = "scarb-extensions-cli"
 version = "2.18.0"
 dependencies = [
  "anyhow",
+ "cairo-air",
  "cairo-vm",
  "camino",
  "clap",

--- a/extensions/scarb-prove/Cargo.toml
+++ b/extensions/scarb-prove/Cargo.toml
@@ -16,7 +16,6 @@ heavy-tests = []
 
 [dependencies]
 anyhow.workspace = true
-cairo-air.workspace = true
 camino.workspace = true
 clap.workspace = true
 create-output-dir = { path = "../../utils/create-output-dir" }

--- a/extensions/scarb-prove/src/main.rs
+++ b/extensions/scarb-prove/src/main.rs
@@ -2,7 +2,6 @@
 #![deny(clippy::disallowed_methods)]
 
 use anyhow::{Context, Result, bail, ensure};
-use cairo_air::utils::ProofFormat;
 use camino::{Utf8Path, Utf8PathBuf};
 use clap::Parser;
 use create_output_dir::create_output_dir;
@@ -105,7 +104,7 @@ fn main_inner(args: Args, ui: Ui) -> Result<()> {
         prover_input,
         false,
         proof_path.as_std_path().to_path_buf(),
-        ProofFormat::Json,
+        args.proof_format,
         None,
     )?;
 

--- a/utils/scarb-extensions-cli/Cargo.toml
+++ b/utils/scarb-extensions-cli/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 anyhow = { workspace = true, optional = true }
 clap.workspace = true
 camino = { workspace = true, optional = true }
+cairo-air = { workspace = true, optional = true }
 cairo-vm = { workspace = true, optional = true }
 scarb-ui = { path = "../scarb-ui", optional = true }
 
@@ -24,7 +25,7 @@ execute = [
     "cairo-vm/clap"
 ]
 mdbook = ["dep:camino", "dep:scarb-ui"]
-prove = ["execute", "dep:scarb-ui"]
+prove = ["execute", "dep:cairo-air", "dep:scarb-ui"]
 verify = ["dep:camino", "dep:scarb-ui"]
 default = [
     "cairo-language-server",

--- a/utils/scarb-extensions-cli/src/prove.rs
+++ b/utils/scarb-extensions-cli/src/prove.rs
@@ -3,6 +3,7 @@
 //! Extension CLI arguments datastructures.
 
 use crate::execute::ExecutionArgs;
+use cairo_air::utils::ProofFormat;
 use clap::Parser;
 use scarb_ui::args::{PackagesFilter, VerbositySpec};
 
@@ -50,6 +51,10 @@ pub struct Args {
     /// Print machine-readable output in NDJSON format.
     #[arg(long, env = "SCARB_OUTPUT_JSON")]
     pub json: bool,
+
+    /// Format used to serialize the generated proof.
+    #[arg(long, value_enum, default_value_t = ProofFormat::Json)]
+    pub proof_format: ProofFormat,
 
     /// Logging verbosity.
     #[command(flatten)]


### PR DESCRIPTION
## Summary

Expose `ProofFormat::CairoSerde` on `scarb prove` via a new `--proof-format` flag, mirroring the upstream `stwo-cairo-prover` `prove` binary. Enables proof-composition pipelines (e.g. recursive aggregation in `vauban-zkpay`) where one Cairo program takes an `Array<CairoProof>` as input — currently impossible because `scarb prove` only writes `CairoProofForRustVerifier`-shaped JSON which loses the `ExtendedStarkProof` auxiliary data the in-Cairo verifier needs.

## Motivation

`stwo-cairo-prover` already supports `ProofFormat::CairoSerde` through `create_and_serialize_proof`. `scarb prove` hardcodes `ProofFormat::Json` at `extensions/scarb-prove/src/main.rs:108`. This adds one CLI flag with `default_value_t = ProofFormat::Json` so behavior is preserved for existing callers.

## Use case

Vauban Pay (`vauban-org/vauban-zkpay`) recursive aggregation: a `vauban_zkpay_aggregation` Cairo executable accepts K inner `CairoProof` instances via `--arguments-file`, calls `stwo_cairo_air::verify_cairo` K times, then is itself proven by Stwo to produce a single outer STARK that `VaubanSettlement` verifies on Starknet. Without `cairo_serde` output from `scarb prove`, the K inner proofs cannot be marshaled into the aggregation's args-file without reimplementing the prover offline.

## Behavior

- Default unchanged (`--proof-format json`).
- `--proof-format cairo-serde` writes `["0x...", "0x...", ...]`.
- `scarb verify` already accepts both formats via `cairo_air::utils::ProofFormat` round-trip.

## Compat

Backwards-compatible. No breaking changes.