### PR TITLE
Abstain from deploying website when a version is a release candidate

### DIFF
--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -18,6 +18,13 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: >
+      github.event_name != 'release' ||
+      (
+        github.event.release.draft == false &&
+        github.event.release.prerelease == false &&
+        !contains(github.event.release.tag_name, '-rc')
+      )
     defaults:
       run:
         working-directory: ./website
@@ -43,6 +50,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    if: needs.build.result == 'success'
     steps:
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
We shouldn't run those if it's a pre-release (rc) - it's not a valid release yet:
https://github.com/software-mansion/scarb/actions/workflows/website-deploy.yml