### PR TITLE
Fix package id source to `std` for builtin plugins if they're patched.

### DIFF
--- a/scarb/src/compiler/plugin/collection.rs
+++ b/scarb/src/compiler/plugin/collection.rs
@@ -12,7 +12,7 @@ use std::vec::IntoIter;
 use super::proc_macro::{DeclaredProcMacroInstances, ProcMacroHostPlugin, ProcMacroInstance};
 use crate::compiler::incremental::PluginFingerprint;
 use crate::compiler::plugin::CairoPlugin;
-use crate::core::PackageId;
+use crate::core::{PackageId, SourceId};
 use crate::{
     compiler::{CairoCompilationUnit, CompilationUnitComponentId, CompilationUnitDependency},
     core::Workspace,
@@ -163,7 +163,7 @@ fn collect_builtin_plugins(
                 continue;
             }
 
-            let package_id = plugin.package.id;
+            let package_id = plugin.package.id.with_source_id(SourceId::for_std());
             let plugin = workspace.config().cairo_plugins().fetch(package_id)?;
             component_suite.add_builtin(plugin)?;
         }

--- a/scarb/tests/test_subcommand.rs
+++ b/scarb/tests/test_subcommand.rs
@@ -2,9 +2,11 @@ use assert_fs::TempDir;
 use indoc::indoc;
 use snapbox::Data;
 
+use scarb_build_metadata::CAIRO_VERSION;
 use scarb_test_support::command::Scarb;
 use scarb_test_support::filesystem::{path_with_temp_dir, write_simple_hello_script};
-use scarb_test_support::project_builder::ProjectBuilder;
+use scarb_test_support::project_builder::{Dep, DepBuilder, ProjectBuilder};
+use scarb_test_support::registry::local::LocalRegistry;
 
 #[test]
 #[cfg_attr(
@@ -89,6 +91,42 @@ fn assert_macros_available() {
     let t = TempDir::new().unwrap();
     ProjectBuilder::start()
         .dev_dep_builtin("assert_macros")
+        .dep_cairo_test()
+        .lib_cairo(indoc! {r#"
+            #[test]
+            fn some() {
+                assert_eq!(1, 1);
+            }
+        "#})
+        .build(&t);
+    Scarb::quick_command()
+        .args(["build", "--test"])
+        .current_dir(&t)
+        .assert()
+        .success();
+}
+
+#[test]
+fn registry_sourced_builtin_assert_macros_available() {
+    let mut registry = LocalRegistry::create();
+    registry.publish(|t| {
+        ProjectBuilder::start()
+            .name("assert_macros")
+            .version(CAIRO_VERSION)
+            .no_core()
+            .manifest_extra(indoc! {r#"
+                [cairo-plugin]
+                builtin = true
+            "#})
+            .build(t);
+    });
+
+    let t = TempDir::new().unwrap();
+    ProjectBuilder::start()
+        .dev_dep(
+            "assert_macros",
+            Dep.version(CAIRO_VERSION).registry(&registry),
+        )
         .dep_cairo_test()
         .lib_cairo(indoc! {r#"
             #[test]


### PR DESCRIPTION
We couldn't compile the tests because scarb tried to load those plugins from registry instead of local setup (which didn't exist on the registry since they're builtin plugins). Now the source is set to std as intended

https://docs.swmansion.com/maat/release-2.20.0-rc.0-0.62.1/starkware-libs/starknet-perpetual-fce7c194f/logs.txt
```[out]    Compiling test(fulfillment_unittest) fulfillment v0.2.0 (/mnt/maat-workbench/workspace/fulfillment/Scarb.toml)
[out] error: compiler plugin could not be loaded `starknet v2.20.0-rc.0`
[out] 
[out] Stack backtrace:
[out]    0: <anyhow::Error>::msg::<alloc::string::String>
[out]    1: anyhow::__private::format_err
[out]    2: <scarb::compiler::plugin::collection::PluginsForComponents>::collect
[out]    3: scarb::compiler::db::build_scarb_root_database
[out]    4: scarb::ops::compile::compile_cairo_unit_inner
[out]    5: std::sys::backtrace::__rust_begin_short_backtrace::<scarb::ops::compile::compile_unit::{closure#0}::{closure#0}, core::result::Result<(), anyhow::Error>>
[out]    6: <std::thread::lifecycle::spawn_unchecked<scarb::ops::compile::compile_unit::{closure#0}::{closure#0}, core::result::Result<(), anyhow::Error>>::{closure#1} as core::ops::function::FnOnce<()>>::call_once::{shim:vtable#0}
[out]    7: <std::sys::thread::unix::Thread>::new::thread_start
[out]    8: start_thread
[out]    9: __clone
[out] error: could not compile `fulfillment` due to 1 previous error and 16 warnings
[out] 
[out] Stack backtrace:
[out]    0: <anyhow::Error>::msg::<alloc::string::String>
[out]    1: std::sys::backtrace::__rust_begin_short_backtrace::<scarb::ops::compile::compile_unit::{closure#0}::{closure#0}, core::result::Result<(), anyhow::Error>>
[out]    2: <std::thread::lifecycle::spawn_unchecked<scarb::ops::compile::compile_unit::{closure#0}::{closure#0}, core::result::Result<(), anyhow::Error>>::{closure#1} as core::ops::function::FnOnce<()>>::call_once::{shim:vtable#0}
[out]    3: <std::sys::thread::unix::Thread>::new::thread_start
[out]    4: start_thread
[out]    5: __clone
Process finished with exit code 1```