### PR TITLE
fix confusing error when registry retrurns a non-JSON body

### DIFF
--- a/scarb/src/core/registry/client/http.rs
+++ b/scarb/src/core/registry/client/http.rs
@@ -192,7 +192,7 @@ impl RegistryClient for HttpRegistryClient<'_> {
             StatusCode::OK => RegistryUpload::Success,
             status => {
                 let headers = response.headers().clone();
-                let error_body: serde_json::Value = response.json().await?;
+                let error_body: serde_json::Value = response.json().await.unwrap_or_default();
                 let error_message = error_body
                     .get("error")
                     .and_then(|e| e.as_str())

--- a/scarb/tests/registry_publish.rs
+++ b/scarb/tests/registry_publish.rs
@@ -14,7 +14,7 @@ fn publish() {
     // 200 -> StatusCode::OK
     let registry = HttpRegistry::serve(Some(HttpPostResponse {
         code: 200,
-        message: "published".to_string(),
+        message: Some("published".to_string()),
     }));
 
     let t = TempDir::new().unwrap();
@@ -86,8 +86,8 @@ fn auth_token_missing() {
         Some(
             HttpPostResponse {
                 code: 200,
-                message: "missing authentication token. help: make sure SCARB_REGISTRY_AUTH_TOKEN environment variable is set"
-                    .to_string()
+                message: Some("missing authentication token. help: make sure SCARB_REGISTRY_AUTH_TOKEN environment variable is set"
+                    .to_string())
             }
         ));
 
@@ -126,7 +126,7 @@ fn error_from_registry() {
     // 400 -> StatusCode::BAD_REQUEST
     let registry = HttpRegistry::serve(Some(HttpPostResponse {
         code: 400,
-        message: "Version '1.0.0' of package 'bar' already exists.".to_string(),
+        message: Some("Version '1.0.0' of package 'bar' already exists.".to_string()),
     }));
 
     let t = TempDir::new().unwrap();
@@ -189,4 +189,43 @@ fn error_from_registry() {
     etag: ...
     "]];
     expected.assert_eq(&registry.logs());
+}
+
+#[test]
+fn too_many_requests_empty_body() {
+    // Rate limiters and proxies often respond with `429` and no body, which is not valid JSON.
+    let registry = HttpRegistry::serve(Some(HttpPostResponse {
+        code: 429,
+        message: None,
+    }));
+
+    let t = TempDir::new().unwrap();
+    ProjectBuilder::start()
+        .name("bar")
+        .version("1.0.0")
+        .lib_cairo(r#"fn f() -> felt252 { 0 }"#)
+        .build(&t);
+
+    Scarb::quick_command()
+        .arg("publish")
+        .arg("--index")
+        .arg(&registry.url)
+        .arg("--no-verify")
+        .env("SCARB_REGISTRY_AUTH_TOKEN", "scrb_supersecrettoken")
+        .current_dir(&t)
+        .timeout(Duration::from_secs(60))
+        .assert()
+        .failure()
+        .stdout_eq(indoc! {r#"
+        [..] Packaging bar v1.0.0 ([..])
+        warn: manifest has no readme
+        warn: manifest has no description
+        warn: manifest has no license or license-file
+        warn: manifest has no documentation or homepage or repository
+        see [..]
+        [..]
+        [..] Packaged [..]
+        [..] Uploading bar v1.0.0 (registry+http[..])
+        error: upload failed with status code: `429 Too Many Requests`, `missing error field in the registry response`
+        "#});
 }

--- a/utils/scarb-test-support/src/simple_http_server.rs
+++ b/utils/scarb-test-support/src/simple_http_server.rs
@@ -49,7 +49,7 @@ pub struct HttpLog {
 #[derive(Clone)]
 pub struct HttpPostResponse {
     pub code: u16,
-    pub message: String,
+    pub message: Option<String>,
 }
 
 impl SimpleHttpServer {
@@ -128,15 +128,20 @@ async fn post_handler(post_response: Option<HttpPostResponse>, body: Body) -> im
         ),
         None => (
             StatusCode::INTERNAL_SERVER_ERROR,
-            "POST request received".to_string(),
+            Some("POST request received".to_string()),
         ),
     };
-    let json_response = json!({
-        "status": status_code.as_u16(),
-        "error": message
-    });
 
-    (status_code, json_response.to_string())
+    let body = match message{
+        None => String::new(),
+        Some(message) =>
+            json!({
+                "status": status_code.as_u16(),
+                "error": message
+            }).to_string()
+    };
+
+    (status_code, body)
 }
 
 async fn logger(

--- a/utils/scarb-test-support/src/simple_http_server.rs
+++ b/utils/scarb-test-support/src/simple_http_server.rs
@@ -132,13 +132,13 @@ async fn post_handler(post_response: Option<HttpPostResponse>, body: Body) -> im
         ),
     };
 
-    let body = match message{
+    let body = match message {
         None => String::new(),
-        Some(message) =>
-            json!({
-                "status": status_code.as_u16(),
-                "error": message
-            }).to_string()
+        Some(message) => json!({
+            "status": status_code.as_u16(),
+            "error": message
+        })
+        .to_string(),
     };
 
     (status_code, body)


### PR DESCRIPTION
Fixes #3175

When publishing a package, if the registry's upload endpoint returned an empty body. Scarb tried to parse it as JSON and failed. That parse error hid the real HTTP status, so users saw a confusing message instead of the actual reason:

error: error decoding response body

Caused by:
    expected value at line 1 column 1

## Fix

In publish, I changed `response.json().await?` to `response.json().await.unwrap_or_default()`, so an empty body yields Null instead of aborting. The real status code now reaches the user:

error: upload failed with status code: `429 Too Many Requests`, `missing error field in the registry response`

## Changes

- http.rs: fall back to unwrap_or_default() when parsing the error body.
- simple_http_server.rs: changed HttpPostResponse.message from String to Option<String> so the test mock can send an empty body (None), and added a test for the 429 empty-body case.