### PR TITLE
Use unbounded channels for internal communication in proc-macro-server

### DIFF
--- a/scarb/src/ops/proc_macro_server/connection.rs
+++ b/scarb/src/ops/proc_macro_server/connection.rs
@@ -13,8 +13,8 @@ pub struct Connection {
 
 impl Connection {
     pub fn new() -> Self {
-        let (reader_sender, reader_receiver) = crossbeam_channel::bounded(0);
-        let (writer_sender, writer_receiver) = crossbeam_channel::bounded(0);
+        let (reader_sender, reader_receiver) = crossbeam_channel::unbounded();
+        let (writer_sender, writer_receiver) = crossbeam_channel::unbounded();
 
         let reader = std::thread::spawn(move || {
             let stdin = std::io::stdin();


### PR DESCRIPTION
Related to https://github.com/software-mansion/maat/issues/101

The current flow in proc-macro-server is:
stdin ──▶ reader thread ──bounded(0)──▶ N worker threads ──bounded(0)──▶ writer thread ──▶ stdout

Bounded channels make the whole communication synchronous. When all workers are busy, the reader stops consuming the `stdin`. On the other hand, when `stdout` is full and not being consumed by the LS, workers cannot push their results and free-up. **As a consequence, the throughput of the whole PMS is limited by the rate of consumption on the LS side.**

This paired with some quirks in the LS' event loop results in a deadlock.

A sibling PR in CairoLS https://github.com/software-mansion/cairols/pull/1367 adds another layer of buffering and explains the deadlock.