### PR TITLE
ci: bind workflow inputs via env before shell

### DIFF
--- a/.github/workflows/_build-release.yml
+++ b/.github/workflows/_build-release.yml
@@ -174,11 +174,16 @@ jobs:
 
       - name: Verify archive
         shell: bash
-        run: |
-          archive=$(find target/verify -name 'scarb-*.zip' -o -name 'scarb-*.tar.gz')
-          cargo xtask verify-archive --archive "$archive" ${{ inputs.full-verify && '--full' || ''}}
         env:
           EXPECTED_VERSION: ${{ inputs.scarb-tag }}
+          FULL_VERIFY: ${{ inputs.full-verify }}
+        run: |
+          archive=$(find target/verify -name 'scarb-*.zip' -o -name 'scarb-*.tar.gz')
+          EXTRA_FLAGS=""
+          if [ "$FULL_VERIFY" = "true" ]; then
+            EXTRA_FLAGS="--full"
+          fi
+          cargo xtask verify-archive --archive "$archive" $EXTRA_FLAGS
 
   checksums:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -122,12 +122,13 @@ jobs:
         shell: bash
         env:
           IS_SCARB_DEV: ${{ !!inputs.is_dev }}
+          IS_DEV: ${{ inputs.is_dev }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           NIGHTLY_TAG=$(cargo xtask get-nightly-version --tag)
           NIGHTLY_VERSION=$(cargo xtask get-nightly-version)
 
-          if [ "${{ inputs.is_dev }}" = "true" ]; then
+          if [ "$IS_DEV" = "true" ]; then
             EXISTING_TAGS=$(gh api repos/software-mansion/scarb-nightlies/tags \
             --paginate \
             --jq '.[] | select(.name | startswith("'"$NIGHTLY_TAG"'")) | .name'

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -4,14 +4,10 @@ on:
   push:
     branches: ["main"]
     paths:
-      - ".github/workflows/_build_release.yml"
-      - ".github/workflows/nightly.yml"
-      - ".github/workflows/release.yml"
+      - ".github/workflows/*.yml"
   pull_request:
     paths:
-      - ".github/workflows/_build_release.yml"
-      - ".github/workflows/nightly.yml"
-      - ".github/workflows/release.yml"
+      - ".github/workflows/*.yml"
 
 permissions: {}
 


### PR DESCRIPTION
## Summary
- Bind `inputs.is_dev` through `env:` before the nightly version shell step.
- Bind `inputs.full-verify` through `env:` before the archive verify shell step (instead of embedding a GitHub expression in the script).
- Same class as GitHub’s documented script-injection guidance for interpolating workflow inputs into `run:` scripts.

## Test plan
- [ ] Nightly/dev version suffix logic unchanged when `is_dev=true`
- [ ] Verify archive still passes `--full` only when `full-verify` is true


Made with [Cursor](https://cursor.com)