### PR TITLE
Docs publish

### DIFF
--- a/scarb/src/bin/scarb/args.rs
+++ b/scarb/src/bin/scarb/args.rs
@@ -198,9 +198,10 @@ pub enum Command {
     ProcMacroServer,
     /// Upload a package to the registry.
     #[command(after_help = "\
-        This command will create distributable, compressed `.tar.zst` archive containing source \
-        code of the package in `target/package` directory (using `scarb package`) and upload it \
-        to a registry.
+        This command will create a distributable, compressed `.tar.zst` archive \
+        containing the package's source code in the `target/package` directory \
+        (using `scarb package`), generate its documentation, and upload both to a \
+        registry. Use `--no-docs` to skip documentation generation and upload.
     ")]
     Publish(PublishArgs),
     /// Checks a package to catch common mistakes and improve your Cairo code.

--- a/scarb/src/bin/scarb/args.rs
+++ b/scarb/src/bin/scarb/args.rs
@@ -562,6 +562,10 @@ pub struct PublishArgs {
     /// Do not error on `cairo-version` mismatch.
     #[arg(long, env = "SCARB_IGNORE_CAIRO_VERSION")]
     pub ignore_cairo_version: bool,
+
+    /// Do not generate and upload documentation.
+    #[arg(long, env = "SCARB_PUBLISH_NO_DOCS")]
+    pub no_docs: bool,
 }
 
 /// Arguments accepted by the `lint` command.

--- a/scarb/src/bin/scarb/commands/publish.rs
+++ b/scarb/src/bin/scarb/commands/publish.rs
@@ -29,6 +29,7 @@ pub fn run(args: PublishArgs, config: &Config) -> Result<()> {
             features: features_opts,
             ignore_cairo_version: args.ignore_cairo_version,
         },
+        docs: !args.no_docs,
     };
 
     ops::publish(package.id, &ops, &ws)

--- a/scarb/src/core/registry/client/http.rs
+++ b/scarb/src/core/registry/client/http.rs
@@ -215,6 +215,80 @@ impl RegistryClient for HttpRegistryClient<'_> {
         };
         Ok(result)
     }
+
+    async fn supports_publish_docs(&self) -> Result<bool> {
+        Ok(self.index_config.load().await?.docs_upload.is_some())
+    }
+
+    async fn publish_docs(
+        &self,
+        package: PackageId,
+        tarball: LockedFile,
+        force: bool,
+    ) -> Result<RegistryUpload> {
+        let auth_token = env::var("SCARB_REGISTRY_AUTH_TOKEN").map_err(|_| {
+            anyhow!(
+                "missing authentication token. \
+            help: make sure SCARB_REGISTRY_AUTH_TOKEN environment variable is set"
+            )
+        })?;
+
+        let index_config = self.index_config.load().await?;
+        let mut docs_upload_url = match &index_config.docs_upload {
+            Some(url) => url.expand(package.into())?,
+            None => {
+                return Ok(RegistryUpload::Failure(anyhow!(
+                    "registry does not support docs upload"
+                )));
+            }
+        };
+
+        if force {
+            docs_upload_url.set_query(Some("force=true"));
+        }
+
+        let file = tarball.into_async();
+
+        let file_part = Part::stream(Body::from(file.try_clone().await?))
+            .file_name(format!("docs_{}_{}", package.name, package.version));
+        let form = Form::new().part("file", file_part);
+
+        let response = self
+            .config
+            .online_http()?
+            .post(docs_upload_url)
+            .header(AUTHORIZATION, format!("Bearer {auth_token}"))
+            .multipart(form)
+            .send()
+            .await?;
+
+        let result = match response.status() {
+            StatusCode::OK => RegistryUpload::Success,
+            status => {
+                let headers = response.headers().clone();
+                let error_body: serde_json::Value = response.json().await.unwrap_or_default();
+                let error_message = error_body
+                    .get("error")
+                    .and_then(|e| e.as_str())
+                    .unwrap_or("missing error field in the registry response");
+
+                let trace_id = headers
+                    .get("x-cloud-trace-context")
+                    .and_then(|v| v.to_str().ok());
+
+                let error_message = match trace_id {
+                    Some(id) => format!(
+                        "upload failed with status code: `{status}`, `{error_message}` (trace-id: {id:?})"
+                    ),
+                    None => {
+                        format!("upload failed with status code: `{status}`, `{error_message}`",)
+                    }
+                };
+                RegistryUpload::Failure(anyhow!(error_message))
+            }
+        };
+        Ok(result)
+    }
 }
 
 impl HttpCacheKey {

--- a/scarb/src/core/registry/client/local.rs
+++ b/scarb/src/core/registry/client/local.rs
@@ -4,7 +4,7 @@ use std::io::{BufReader, BufWriter, Seek, SeekFrom};
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 
-use anyhow::{Context, Error, Result, ensure};
+use anyhow::{Context, Error, Result, anyhow, ensure};
 use async_trait::async_trait;
 use tokio::task::spawn_blocking;
 use tracing::trace;
@@ -158,6 +158,21 @@ impl RegistryClient for LocalRegistryClient<'_> {
         spawn_blocking(move || publish_impl(summary, tarball, records_path, dl_path))
             .await
             .with_context(|| format!("failed to publish package: {package}"))?
+    }
+
+    async fn supports_publish_docs(&self) -> Result<bool> {
+        Ok(false)
+    }
+
+    async fn publish_docs(
+        &self,
+        _package: PackageId,
+        _tarball: LockedFile,
+        _force: bool,
+    ) -> Result<RegistryUpload> {
+        Ok(RegistryUpload::Failure(anyhow!(
+            "local registry does not support docs upload"
+        )))
     }
 }
 

--- a/scarb/src/core/registry/client/mod.rs
+++ b/scarb/src/core/registry/client/mod.rs
@@ -98,4 +98,19 @@ pub trait RegistryClient: Send + Sync {
     /// The client is free to use information within `package` to send to the registry.
     /// Package source is not required to match the registry the package is published to.
     async fn publish(&self, package: Package, tarball: LockedFile) -> Result<RegistryUpload>;
+
+    /// State whether documentation can be published to this registry.
+    async fn supports_publish_docs(&self) -> Result<bool> {
+        Ok(false)
+    }
+
+    /// Publish documentation for a package to this registry.
+    ///    
+    /// This function can only be called if [`RegistryClient::supports_publish_docs`] returns `true`.
+    async fn publish_docs(
+        &self,
+        package: PackageId,
+        tarball: LockedFile,
+        force: bool,
+    ) -> Result<RegistryUpload>;
 }

--- a/scarb/src/core/registry/index/config.rs
+++ b/scarb/src/core/registry/index/config.rs
@@ -15,6 +15,7 @@ use crate::core::registry::index::{BaseUrl, TemplateUrl};
 ///   "dl": "https://example.com/api/v1/download/{package}/{version}",
 ///   "upload": "https://example.com/api/v1/packages/new",
 ///   "index": "https://example.com/index/{prefix}/{package}.json"
+///   "docs-upload": "https://example.com/api/v1/docs/{package}/{version}"
 /// }
 /// ```
 ///
@@ -48,6 +49,11 @@ pub struct IndexConfig {
     ///
     /// If this is `None`, the registry does not support package uploads.
     pub upload: Option<Url>,
+
+    /// Docs upload endpoint for all docs.
+    ///
+    /// If this is `None`, the registry does not support docs uploads.
+    pub docs_upload: Option<TemplateUrl>,
 }
 
 impl IndexConfig {
@@ -87,6 +93,9 @@ mod tests {
             upload: Some("https://example.com/api/v1/packages/new".parse().unwrap()),
             dl: TemplateUrl::new("https://example.com/api/v1/download/{package}/{version}"),
             index: TemplateUrl::new("https://example.com/index/{prefix}/{package}.json"),
+            docs_upload: Some(TemplateUrl::new(
+                "https://example.com/api/v1/docs/{package}/{version}",
+            )),
         };
 
         let actual: IndexConfig = serde_json::from_str(
@@ -95,7 +104,8 @@ mod tests {
               "api": "https://example.com/api/v1",
               "upload": "https://example.com/api/v1/packages/new",
               "dl": "https://example.com/api/v1/download/{package}/{version}",
-              "index": "https://example.com/index/{prefix}/{package}.json"
+              "index": "https://example.com/index/{prefix}/{package}.json",
+              "docs-upload": "https://example.com/api/v1/docs/{package}/{version}"
             }"#,
         )
         .unwrap();

--- a/scarb/src/core/registry/index/config.rs
+++ b/scarb/src/core/registry/index/config.rs
@@ -14,7 +14,7 @@ use crate::core::registry::index::{BaseUrl, TemplateUrl};
 ///   "api": "https://example.com/api/v1",
 ///   "dl": "https://example.com/api/v1/download/{package}/{version}",
 ///   "upload": "https://example.com/api/v1/packages/new",
-///   "index": "https://example.com/index/{prefix}/{package}.json"
+///   "index": "https://example.com/index/{prefix}/{package}.json",
 ///   "docs-upload": "https://example.com/api/v1/docs/{package}/{version}"
 /// }
 /// ```

--- a/scarb/src/ops/docs.rs
+++ b/scarb/src/ops/docs.rs
@@ -79,7 +79,7 @@ pub fn package_docs_one(package_id: &PackageId, ws: &Workspace<'_>) -> Result<Lo
     ws.config().ui().print(Status::new(
         "Packaged",
         &format!(
-            "DOCS {} files, {:.1} ({:.1} compressed)",
+            "docs {} files, {:.1} ({:.1} compressed)",
             HumanCount(num_files as u64),
             HumanBytes(uncompressed_size),
             HumanBytes(compressed_size),

--- a/scarb/src/ops/docs.rs
+++ b/scarb/src/ops/docs.rs
@@ -6,6 +6,7 @@ use anyhow::{Context, Result};
 use camino::Utf8Path;
 use camino::Utf8PathBuf;
 use scarb_ui::HumanBytes;
+use scarb_ui::HumanCount;
 use scarb_ui::components::Status;
 use std::fs::File;
 use std::io::Seek;
@@ -44,6 +45,19 @@ fn tar(src: &Utf8Path, dst: &mut File) -> Result<()> {
     Ok(())
 }
 
+fn dir_stats(src: &Utf8Path) -> Result<(usize, u64)> {
+    let mut count = 0;
+    let mut size = 0;
+    for entry in walkdir::WalkDir::new(src) {
+        let entry = entry?;
+        if entry.file_type().is_file() {
+            count += 1;
+            size += entry.metadata()?.len();
+        }
+    }
+    Ok((count, size))
+}
+
 pub fn package_docs_one(package_id: &PackageId, ws: &Workspace<'_>) -> Result<LockedFile> {
     let docs_path = generate_docs(package_id, ws)?;
 
@@ -53,19 +67,20 @@ pub fn package_docs_one(package_id: &PackageId, ws: &Workspace<'_>) -> Result<Lo
     let mut dst = target_dir.create_rw(&filename, "docs tarball", ws.config())?;
 
     tar(&docs_path, &mut dst)?;
-    let uncompressed_size = 0; //TODO(hakiers)
 
     dst.seek(SeekFrom::Start(0))?;
     let dst_metadata = dst
         .metadata()
         .with_context(|| format!("failed to get metadata for {}", dst.path()))?;
+
+    let (num_files, uncompressed_size) = dir_stats(&docs_path)?;
     let compressed_size = dst_metadata.len();
 
     ws.config().ui().print(Status::new(
         "Packaged",
         &format!(
-            "docs for {} (uncompressed size: {}, compressed size: {})",
-            package_id.name,
+            "DOCS {} files, {:.1} ({:.1} compressed)",
+            HumanCount(num_files as u64),
             HumanBytes(uncompressed_size),
             HumanBytes(compressed_size),
         ),

--- a/scarb/src/ops/docs.rs
+++ b/scarb/src/ops/docs.rs
@@ -1,0 +1,75 @@
+use crate::core::PackageId;
+use crate::core::Workspace;
+use crate::flock::LockedFile;
+use crate::ops::subcommands::execute_external_subcommand_and_wait;
+use anyhow::{Context, Result};
+use camino::Utf8Path;
+use camino::Utf8PathBuf;
+use scarb_ui::HumanBytes;
+use scarb_ui::components::Status;
+use std::fs::File;
+use std::io::Seek;
+use std::io::SeekFrom;
+
+fn generate_docs(pkg_id: &PackageId, ws: &Workspace<'_>) -> Result<Utf8PathBuf> {
+    let docs_target = ws.target_dir().path_unchecked().to_owned();
+    let config = ws.config();
+    let args = vec![
+        "--build".into(),
+        "--disable-remote-linking".into(),
+        "--package".into(),
+        pkg_id.name.to_string().into(),
+    ];
+
+    execute_external_subcommand_and_wait("doc", &args, None, config, Some(docs_target.clone()))?;
+
+    let docs_path = docs_target
+        .join("doc")
+        .join(pkg_id.name.to_string())
+        .join("book");
+    Ok(docs_path)
+}
+
+fn tar(src: &Utf8Path, dst: &mut File) -> Result<()> {
+    const COMPRESSION_LEVEL: i32 = 22;
+    let encoder = zstd::stream::Encoder::new(dst, COMPRESSION_LEVEL)?;
+
+    let mut tar = tar::Builder::new(encoder);
+    tar.append_dir_all(".", src)
+        .with_context(|| format!("failed to append directory all for {}", src))?;
+
+    let encoder = tar.into_inner()?;
+
+    encoder.finish()?;
+    Ok(())
+}
+
+pub fn package_docs_one(package_id: &PackageId, ws: &Workspace<'_>) -> Result<LockedFile> {
+    let docs_path = generate_docs(package_id, ws)?;
+
+    let filename = format!("docs.{}", package_id.tarball_name());
+    let target_dir = ws.target_dir().child("doc");
+
+    let mut dst = target_dir.create_rw(&filename, "docs tarball", ws.config())?;
+
+    tar(&docs_path, &mut dst)?;
+    let uncompressed_size = 0; //TODO(hakiers)
+
+    dst.seek(SeekFrom::Start(0))?;
+    let dst_metadata = dst
+        .metadata()
+        .with_context(|| format!("failed to get metadata for {}", dst.path()))?;
+    let compressed_size = dst_metadata.len();
+
+    ws.config().ui().print(Status::new(
+        "Packaged",
+        &format!(
+            "docs for {} (uncompressed size: {}, compressed size: {})",
+            package_id.name,
+            HumanBytes(uncompressed_size),
+            HumanBytes(compressed_size),
+        ),
+    ));
+
+    Ok(dst)
+}

--- a/scarb/src/ops/mod.rs
+++ b/scarb/src/ops/mod.rs
@@ -5,6 +5,7 @@
 pub use cache::*;
 pub use clean::*;
 pub use compile::*;
+pub use docs::*;
 pub use expand::*;
 pub use fmt::*;
 pub use manifest::*;
@@ -21,6 +22,7 @@ pub use workspace::*;
 mod cache;
 mod clean;
 mod compile;
+mod docs;
 mod expand;
 mod fmt;
 mod lockfile;

--- a/scarb/src/ops/publish.rs
+++ b/scarb/src/ops/publish.rs
@@ -76,12 +76,20 @@ pub fn publish(package_id: PackageId, opts: &PublishOpts, ws: &Workspace<'_>) ->
 
                 // Upload docs if they were generated and the registry supports it.
                 if let Some(docs_tarball) = docs_tarball {
+                    ws.config().ui().print(Status::new(
+                        "Uploading",
+                        &format!("DOCS for {}", dest_package_id),
+                    ));
+
                     let upload_docs = registry_client
                         .publish_docs(package_id, docs_tarball, false)
                         .await;
                     match upload_docs {
                         Ok(RegistryUpload::Success) => {
-                            ws.config().ui().print(Status::new("Published", "docs"));
+                            ws.config().ui().print(Status::new(
+                                "Published",
+                                format!("DOCS for {}", dest_package_id).as_str(),
+                            ));
                         }
                         Ok(RegistryUpload::Failure(e)) | Err(e) => return Err(e),
                     }

--- a/scarb/src/ops/publish.rs
+++ b/scarb/src/ops/publish.rs
@@ -14,6 +14,7 @@ use super::PackageOpts;
 pub struct PublishOpts {
     pub index_url: Url,
     pub package_opts: PackageOpts,
+    pub docs: bool,
 }
 
 #[tracing::instrument(level = "debug", skip(opts, ws))]
@@ -43,7 +44,20 @@ pub fn publish(package_id: PackageId, opts: &PublishOpts, ws: &Workspace<'_>) ->
         "publishing packages is not supported by registry: {source_id}"
     );
 
+    let supports_publish_docs = ws
+        .config()
+        .tokio_handle()
+        .block_on(registry_client.supports_publish_docs())
+        .with_context(|| {
+            format!("failed to check if registry supports publishing docs: {source_id}")
+        })?;
+
     let tarball = ops::package_one(package_id, &opts.package_opts, ws)?;
+    let docs_tarball = if opts.docs && supports_publish_docs {
+        Some(ops::package_docs_one(&package_id, ws)?)
+    } else {
+        None
+    };
 
     let dest_package_id = package_id.with_source_id(source_id);
 
@@ -59,6 +73,19 @@ pub fn publish(package_id: PackageId, opts: &PublishOpts, ws: &Workspace<'_>) ->
                     "Published",
                     format!("{}", dest_package_id).as_str(),
                 ));
+
+                // Upload docs if they were generated and the registry supports it.
+                if let Some(docs_tarball) = docs_tarball {
+                    let upload_docs = registry_client
+                        .publish_docs(package_id, docs_tarball, false)
+                        .await;
+                    match upload_docs {
+                        Ok(RegistryUpload::Success) => {
+                            ws.config().ui().print(Status::new("Published", "docs"));
+                        }
+                        Ok(RegistryUpload::Failure(e)) | Err(e) => return Err(e),
+                    }
+                }
                 Ok(())
             }
             Ok(RegistryUpload::Failure(e)) => Err(e),

--- a/scarb/src/ops/publish.rs
+++ b/scarb/src/ops/publish.rs
@@ -78,7 +78,7 @@ pub fn publish(package_id: PackageId, opts: &PublishOpts, ws: &Workspace<'_>) ->
                 if let Some(docs_tarball) = docs_tarball {
                     ws.config().ui().print(Status::new(
                         "Uploading",
-                        &format!("DOCS for {}", dest_package_id),
+                        &format!("docs for {}", dest_package_id),
                     ));
 
                     let upload_docs = registry_client
@@ -88,7 +88,7 @@ pub fn publish(package_id: PackageId, opts: &PublishOpts, ws: &Workspace<'_>) ->
                         Ok(RegistryUpload::Success) => {
                             ws.config().ui().print(Status::new(
                                 "Published",
-                                format!("DOCS for {}", dest_package_id).as_str(),
+                                format!("docs for {}", dest_package_id).as_str(),
                             ));
                         }
                         Ok(RegistryUpload::Failure(e)) | Err(e) => return Err(e),

--- a/scarb/src/ops/subcommands.rs
+++ b/scarb/src/ops/subcommands.rs
@@ -12,7 +12,7 @@ use tracing::debug;
 
 use crate::core::{Config, Package, ScriptDefinition, Workspace};
 use crate::ops;
-use crate::process::exec_replace;
+use crate::process::{exec, exec_replace};
 use crate::subcommands::{EXTERNAL_CMD_PREFIX, SCARB_MANIFEST_PATH_ENV, get_env_vars};
 use itertools::Itertools;
 use scarb_fs_utils::is_executable;
@@ -112,6 +112,30 @@ pub fn execute_test_subcommand(
             Some(env),
         )
     }
+}
+
+/// Prepare environment and execute an external subcommand, waiting for it to finish.
+#[tracing::instrument(level = "debug", skip(config))]
+pub fn execute_external_subcommand_and_wait(
+    cmd: &str,
+    args: &[OsString],
+    custom_env: Option<HashMap<OsString, OsString>>,
+    config: &Config,
+    target_dir: Option<Utf8PathBuf>,
+) -> Result<()> {
+    let subcommand_dirs = SubcommandDirs::try_from(config)?;
+    let Some(cmd) = find_external_subcommand(cmd, &subcommand_dirs)? else {
+        bail!("no such command: `{cmd}`");
+    };
+
+    let mut cmd = Command::new(cmd);
+    cmd.args(args);
+    cmd.envs(get_env_vars(config, target_dir)?);
+    if let Some(env) = custom_env {
+        cmd.envs(env);
+    }
+
+    exec(&mut cmd, config)
 }
 
 /// Find an external subcommand executable.


### PR DESCRIPTION
# Task [744] (https://github.com/software-mansion/scarbs.xyz/issues/744)
This pull request adds support for publishing package documentation (`docs`) to registries that support it. It introduces the ability to generate, package, and upload documentation as part of the `publish` workflow, with the option to skip documentation publishing if desired. The changes include updates to the registry client interface, documentation packaging logic, and command-line arguments.

**Documentation publishing support:**

* Added a new `no_docs` flag to `PublishArgs` and corresponding logic to allow skipping documentation generation and upload during publish (`scarb/src/bin/scarb/args.rs`, `scarb/src/bin/scarb/commands/publish.rs`). [[1]](diffhunk://#diff-0c3465788eee3aebfefc42543e57620353b7bbab8130baec5934144a8c0312efR565-R568) [[2]](diffhunk://#diff-6ed25c6ed933af837452bfc11d4a259ca57158e416e7a7811a944d996977bccaR32)
* Introduced a new `docs` field to `PublishOpts` and integrated logic to check if the registry supports documentation publishing and to generate/package docs if enabled (`scarb/src/ops/publish.rs`). [[1]](diffhunk://#diff-b80dc135c615dc0963e7addccc756ae77eab1b158a6a86ac073e274350f2f111R17) [[2]](diffhunk://#diff-b80dc135c615dc0963e7addccc756ae77eab1b158a6a86ac073e274350f2f111R47-R60) [[3]](diffhunk://#diff-b80dc135c615dc0963e7addccc756ae77eab1b158a6a86ac073e274350f2f111R76-R96)

**Registry client interface and implementation:**

* Extended the `RegistryClient` trait with `supports_publish_docs` and `publish_docs` methods, and implemented them for both HTTP and local registry clients (`scarb/src/core/registry/client/mod.rs`, `scarb/src/core/registry/client/http.rs`, `scarb/src/core/registry/client/local.rs`). [[1]](diffhunk://#diff-03494a21a1d69a64057fbba8a2d76831ea46977490adf62c91ef711f54dbd3e4R101-R115) [[2]](diffhunk://#diff-da0094f24b76063d735487287ac3c94aa241d1318bc653b9baecf908c05b0f93R218-R291) [[3]](diffhunk://#diff-0ca8f86c1c34b7bb1fc6294a136273ad79cdbdcb970d116e2e05b21a8a52eb14R162-R176)

**Documentation packaging logic:**

* Added a new `docs` module with logic to generate documentation via an external subcommand, tar and compress the output, and report statistics (`scarb/src/ops/docs.rs`, `scarb/src/ops/mod.rs`). [[1]](diffhunk://#diff-705d1d119484afd3d5c1b5ebddf81a9224effc2f5bab4530730a8562e6d5df1dR1-R90) [[2]](diffhunk://#diff-fd546004cfcc6c3d8c0b750333a9c0d61d02f128674dc86cadc314a72b9c7a59R8) [[3]](diffhunk://#diff-fd546004cfcc6c3d8c0b750333a9c0d61d02f128674dc86cadc314a72b9c7a59R25)
* Added a helper to execute external subcommands and wait for completion (`scarb/src/ops/subcommands.rs`). [[1]](diffhunk://#diff-113a5c217fb7a02d8e94cb151c12af2767898a4785ca0970b1508b9f5f8e9810L15-R15) [[2]](diffhunk://#diff-113a5c217fb7a02d8e94cb151c12af2767898a4785ca0970b1508b9f5f8e9810R117-R140)

**Registry index configuration:**

* Updated the registry index configuration to support a `docs-upload` endpoint, including serialization/deserialization and tests (`scarb/src/core/registry/index/config.rs`). [[1]](diffhunk://#diff-3af0d749db14e72993d436a0ee6c503740a9f5b838baca3f6a1f11aae38c69a6R18) [[2]](diffhunk://#diff-3af0d749db14e72993d436a0ee6c503740a9f5b838baca3f6a1f11aae38c69a6R52-R56) [[3]](diffhunk://#diff-3af0d749db14e72993d436a0ee6c503740a9f5b838baca3f6a1f11aae38c69a6R96-R98) [[4]](diffhunk://#diff-3af0d749db14e72993d436a0ee6c503740a9f5b838baca3f6a1f11aae38c69a6L98-R108)

( [[1]](diffhunk://#diff-0c3465788eee3aebfefc42543e57620353b7bbab8130baec5934144a8c0312efR565-R568) [[2]](diffhunk://#diff-6ed25c6ed933af837452bfc11d4a259ca57158e416e7a7811a944d996977bccaR32) [[3]](diffhunk://#diff-b80dc135c615dc0963e7addccc756ae77eab1b158a6a86ac073e274350f2f111R17) [[4]](diffhunk://#diff-b80dc135c615dc0963e7addccc756ae77eab1b158a6a86ac073e274350f2f111R47-R60) [[5]](diffhunk://#diff-b80dc135c615dc0963e7addccc756ae77eab1b158a6a86ac073e274350f2f111R76-R96) [[6]](diffhunk://#diff-03494a21a1d69a64057fbba8a2d76831ea46977490adf62c91ef711f54dbd3e4R101-R115) [[7]](diffhunk://#diff-da0094f24b76063d735487287ac3c94aa241d1318bc653b9baecf908c05b0f93R218-R291) [[8]](diffhunk://#diff-0ca8f86c1c34b7bb1fc6294a136273ad79cdbdcb970d116e2e05b21a8a52eb14R162-R176) [[9]](diffhunk://#diff-705d1d119484afd3d5c1b5ebddf81a9224effc2f5bab4530730a8562e6d5df1dR1-R90) [[10]](diffhunk://#diff-fd546004cfcc6c3d8c0b750333a9c0d61d02f128674dc86cadc314a72b9c7a59R8) [[11]](diffhunk://#diff-fd546004cfcc6c3d8c0b750333a9c0d61d02f128674dc86cadc314a72b9c7a59R25) [[12]](diffhunk://#diff-113a5c217fb7a02d8e94cb151c12af2767898a4785ca0970b1508b9f5f8e9810L15-R15) [[13]](diffhunk://#diff-113a5c217fb7a02d8e94cb151c12af2767898a4785ca0970b1508b9f5f8e9810R117-R140) [[14]](diffhunk://#diff-3af0d749db14e72993d436a0ee6c503740a9f5b838baca3f6a1f11aae38c69a6R18) [[15]](diffhunk://#diff-3af0d749db14e72993d436a0ee6c503740a9f5b838baca3f6a1f11aae38c69a6R52-R56) [[16]](diffhunk://#diff-3af0d749db14e72993d436a0ee6c503740a9f5b838baca3f6a1f11aae38c69a6R96-R98) [[17]](diffhunk://#diff-3af0d749db14e72993d436a0ee6c503740a9f5b838baca3f6a1f11aae38c69a6L98-R108) )Part of #744

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>