### PR TITLE
Docs publish tests

### DIFF
--- a/scarb/tests/registry_publish.rs
+++ b/scarb/tests/registry_publish.rs
@@ -43,6 +43,95 @@ fn publish() {
         see [..]
         [..]
         [..] Packaged [..]
+        [..] Packaged [..]
+        [..] Uploading bar v1.0.0 (registry+http[..])
+        [..] Published bar v1.0.0 (registry+http[..])
+        [..] Uploading docs for bar v1.0.0 (registry+http[..])
+        [..] Published docs for bar v1.0.0 (registry+http[..])
+        "#});
+
+    let expected = expect![["
+    GET /api/v1/index/config.json
+    accept: */*
+    accept-encoding: gzip, br, deflate
+    host: ...
+    user-agent: ...
+
+    200 OK
+    accept-ranges: bytes
+    content-length: ...
+    content-type: application/json
+    etag: ...
+    last-modified: ...
+
+    ###
+
+    POST /api/v1/packages/new
+    accept: */*
+    accept-encoding: gzip, br, deflate
+    authorization: Bearer scrb_supersecrettoken
+    content-type: ...
+    host: ...
+    transfer-encoding: chunked
+    user-agent: ...
+
+    200 OK
+    content-type: text/plain; charset=utf-8
+    etag: ...
+
+    ###
+
+    POST /api/v1/docs/bar/1.0.0
+    accept: */*
+    accept-encoding: gzip, br, deflate
+    authorization: Bearer scrb_supersecrettoken
+    content-type: ...
+    host: ...
+    transfer-encoding: chunked
+    user-agent: ...
+
+    200 OK
+    content-type: text/plain; charset=utf-8
+    etag: ...
+    "]];
+    expected.assert_eq(&registry.logs());
+}
+
+#[test]
+fn publish_without_docs() {
+    // 200 -> StatusCode::OK
+    let registry = HttpRegistry::serve(Some(HttpPostResponse {
+        code: 200,
+        message: Some("published".to_string()),
+    }));
+
+    let t = TempDir::new().unwrap();
+    ProjectBuilder::start()
+        .name("bar")
+        .version("1.0.0")
+        .lib_cairo(r#"fn f() -> felt252 { 0 }"#)
+        .build(&t);
+
+    Scarb::quick_command()
+        .arg("publish")
+        .arg("--index")
+        .arg(&registry.url)
+        .arg("--no-verify")
+        .arg("--no-docs")
+        .env("SCARB_REGISTRY_AUTH_TOKEN", "scrb_supersecrettoken")
+        .current_dir(&t)
+        .timeout(Duration::from_secs(60))
+        .assert()
+        .success()
+        .stdout_eq(indoc! {r#"
+        [..] Packaging bar v1.0.0 ([..])
+        warn: manifest has no readme
+        warn: manifest has no description
+        warn: manifest has no license or license-file
+        warn: manifest has no documentation or homepage or repository
+        see [..]
+        [..]
+        [..] Packaged [..]
         [..] Uploading bar v1.0.0 (registry+http[..])
         [..] Published bar v1.0.0 (registry+http[..])
         "#});
@@ -80,7 +169,7 @@ fn publish() {
 }
 
 #[test]
-fn auth_token_missing() {
+fn auth_token_missing_without_docs() {
     // 200 -> StatusCode::OK
     let registry = HttpRegistry::serve(
         Some(
@@ -103,6 +192,7 @@ fn auth_token_missing() {
         .arg("--index")
         .arg(&registry.url)
         .arg("--no-verify")
+        .arg("--no-docs")
         .current_dir(&t)
         .timeout(Duration::from_secs(60))
         .assert()
@@ -122,7 +212,7 @@ fn auth_token_missing() {
 }
 
 #[test]
-fn error_from_registry() {
+fn error_from_registry_without_docs() {
     // 400 -> StatusCode::BAD_REQUEST
     let registry = HttpRegistry::serve(Some(HttpPostResponse {
         code: 400,
@@ -141,6 +231,7 @@ fn error_from_registry() {
         .arg("--index")
         .arg(&registry.url)
         .arg("--no-verify")
+        .arg("--no-docs")
         .env("SCARB_REGISTRY_AUTH_TOKEN", "scrb_supersecrettoken")
         .current_dir(&t)
         .timeout(Duration::from_secs(60))
@@ -192,7 +283,7 @@ fn error_from_registry() {
 }
 
 #[test]
-fn too_many_requests_empty_body() {
+fn too_many_requests_empty_body_without_docs() {
     // Rate limiters and proxies often respond with `429` and no body, which is not valid JSON.
     let registry = HttpRegistry::serve(Some(HttpPostResponse {
         code: 429,
@@ -211,6 +302,7 @@ fn too_many_requests_empty_body() {
         .arg("--index")
         .arg(&registry.url)
         .arg("--no-verify")
+        .arg("--no-docs")
         .env("SCARB_REGISTRY_AUTH_TOKEN", "scrb_supersecrettoken")
         .current_dir(&t)
         .timeout(Duration::from_secs(60))

--- a/utils/scarb-test-support/src/registry/http.rs
+++ b/utils/scarb-test-support/src/registry/http.rs
@@ -41,7 +41,8 @@ impl HttpRegistry {
             "version": 1,
             "upload": format!("{url}api/v1/packages/new"),
             "dl": format!("{url}{{package}}-{{version}}.tar.zst"),
-            "index": format!("{url}index/{{prefix}}/{{package}}.json")
+            "index": format!("{url}index/{{prefix}}/{{package}}.json"),
+            "docs-upload": format!("{url}api/v1/docs/{{package}}/{{version}}"),
         });
         local
             .t

--- a/utils/scarb-test-support/src/simple_http_server.rs
+++ b/utils/scarb-test-support/src/simple_http_server.rs
@@ -63,6 +63,13 @@ impl SimpleHttpServer {
             .fallback_service(ServeDir::new(dir))
             .route(
                 "/api/v1/packages/new",
+                post({
+                    let post_response = post_response.clone();
+                    move |body| post_handler(post_response.clone(), body)
+                }),
+            )
+            .route(
+                "/api/v1/docs/{package}/{version}",
                 post(move |body| post_handler(post_response.clone(), body)),
             )
             .layer(middleware::from_fn(set_etag))


### PR DESCRIPTION
This pull request adds support for publishing package documentation to the registry and updates the test infrastructure to handle this new feature. It introduces new test cases for publishing with and without documentation, updates the mock registry to support documentation upload endpoints, and adapts existing tests to cover scenarios where documentation is not published.

**New test cases for documentation publishing:**

* Added a test (`publish`) that verifies the publishing flow now includes uploading and publishing documentation (`docs`) for a package, and checks the expected HTTP interactions with the registry, including the new `/api/v1/docs/{package}/{version}` endpoint.

**Test infrastructure updates:**

* Updated the mock registry in `HttpRegistry` to include a `docs-upload` endpoint in the index configuration, supporting the new documentation upload feature.
* Modified the simple HTTP server to handle POST requests to `/api/v1/docs/{package}/{version}` for simulating documentation uploads in tests.

**Adaptation of existing tests for "no-docs" mode:**

* Added the `--no-docs` argument to several test cases and renamed them (e.g., `auth_token_missing_without_docs`, `error_from_registry_without_docs`, `too_many_requests_empty_body_without_docs`) to explicitly test scenarios where documentation is not uploaded during publishing. [[1]](diffhunk://#diff-a86108b7d05f3405da1e6b5d381a298a57c8076ef67a1a6b78e81de4348ac701L83-R172) [[2]](diffhunk://#diff-a86108b7d05f3405da1e6b5d381a298a57c8076ef67a1a6b78e81de4348ac701R195) [[3]](diffhunk://#diff-a86108b7d05f3405da1e6b5d381a298a57c8076ef67a1a6b78e81de4348ac701L125-R215) [[4]](diffhunk://#diff-a86108b7d05f3405da1e6b5d381a298a57c8076ef67a1a6b78e81de4348ac701R234) [[5]](diffhunk://#diff-a86108b7d05f3405da1e6b5d381a298a57c8076ef67a1a6b78e81de4348ac701L195-R286) [[6]](diffhunk://#diff-a86108b7d05f3405da1e6b5d381a298a57c8076ef67a1a6b78e81de4348ac701R305)<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>