### PR TITLE
Tests for publish_docs

### DIFF
--- a/scarb/tests/registry_publish.rs
+++ b/scarb/tests/registry_publish.rs
@@ -10,7 +10,7 @@ use scarb_test_support::registry::http::HttpRegistry;
 use scarb_test_support::simple_http_server::HttpPostResponse;
 
 #[test]
-fn publish() {
+fn publish_with_docs() {
     // 200 -> StatusCode::OK
     let registry = HttpRegistry::serve(Some(HttpPostResponse {
         code: 200,
@@ -98,7 +98,7 @@ fn publish() {
 }
 
 #[test]
-fn publish_with_docs() {
+fn publish() {
     // 200 -> StatusCode::OK
     let registry = HttpRegistry::serve(Some(HttpPostResponse {
         code: 200,

--- a/scarb/tests/registry_publish.rs
+++ b/scarb/tests/registry_publish.rs
@@ -98,7 +98,7 @@ fn publish() {
 }
 
 #[test]
-fn publish_without_docs() {
+fn publish_with_docs() {
     // 200 -> StatusCode::OK
     let registry = HttpRegistry::serve(Some(HttpPostResponse {
         code: 200,
@@ -169,7 +169,7 @@ fn publish_without_docs() {
 }
 
 #[test]
-fn auth_token_missing_without_docs() {
+fn auth_token_missing() {
     // 200 -> StatusCode::OK
     let registry = HttpRegistry::serve(
         Some(
@@ -212,7 +212,7 @@ fn auth_token_missing_without_docs() {
 }
 
 #[test]
-fn error_from_registry_without_docs() {
+fn error_from_registry() {
     // 400 -> StatusCode::BAD_REQUEST
     let registry = HttpRegistry::serve(Some(HttpPostResponse {
         code: 400,
@@ -283,7 +283,7 @@ fn error_from_registry_without_docs() {
 }
 
 #[test]
-fn too_many_requests_empty_body_without_docs() {
+fn too_many_requests_empty_body() {
     // Rate limiters and proxies often respond with `429` and no body, which is not valid JSON.
     let registry = HttpRegistry::serve(Some(HttpPostResponse {
         code: 429,

--- a/scarb/tests/registry_publish_docs.rs
+++ b/scarb/tests/registry_publish_docs.rs
@@ -1,0 +1,165 @@
+use std::time::Duration;
+
+use assert_fs::TempDir;
+use expect_test::expect;
+use indoc::indoc;
+
+use scarb_test_support::command::Scarb;
+use scarb_test_support::project_builder::ProjectBuilder;
+use scarb_test_support::registry::http::HttpRegistry;
+use scarb_test_support::simple_http_server::HttpPostResponse;
+
+#[test]
+fn publish_docs() {
+    // 200 -> StatusCode::OK
+    let registry = HttpRegistry::serve(Some(HttpPostResponse {
+        code: 200,
+        message: Some("published".to_string()),
+    }));
+
+    let t = TempDir::new().unwrap();
+    ProjectBuilder::start()
+        .name("bar")
+        .version("1.0.0")
+        .lib_cairo(r#"fn f() -> felt252 { 0 }"#)
+        .build(&t);
+
+    Scarb::quick_command()
+        .arg("publish-docs")
+        .arg("--index")
+        .arg(&registry.url)
+        .env("SCARB_REGISTRY_AUTH_TOKEN", "scrb_supersecrettoken")
+        .current_dir(&t)
+        .timeout(Duration::from_secs(60))
+        .assert()
+        .success()
+        .stdout_eq(indoc! {r#"
+        [..] Packaged [..]
+        [..] Uploading docs for bar v1.0.0 (registry+http[..])
+        [..] Published docs for bar v1.0.0 (registry+http[..])
+        "#});
+
+    let expected = expect![["
+    GET /api/v1/index/config.json
+    accept: */*
+    accept-encoding: gzip, br, deflate
+    host: ...
+    user-agent: ...
+
+    200 OK
+    accept-ranges: bytes
+    content-length: ...
+    content-type: application/json
+    etag: ...
+    last-modified: ...
+
+    ###
+
+    POST /api/v1/docs/bar/1.0.0
+    accept: */*
+    accept-encoding: gzip, br, deflate
+    authorization: Bearer scrb_supersecrettoken
+    content-type: ...
+    host: ...
+    transfer-encoding: chunked
+    user-agent: ...
+
+    200 OK
+    content-type: text/plain; charset=utf-8
+    etag: ...
+    "]];
+    expected.assert_eq(&registry.logs());
+}
+
+#[test]
+fn auth_token_missing() {
+    // 200 -> StatusCode::OK
+    let registry = HttpRegistry::serve(Some(HttpPostResponse {
+        code: 200,
+        message: Some("missing authentication token. help: make sure SCARB_REGISTRY_AUTH_TOKEN environment variable is set"
+                    .to_string())
+    }));
+
+    let t = TempDir::new().unwrap();
+    ProjectBuilder::start()
+        .name("bar")
+        .version("1.0.0")
+        .lib_cairo(r#"fn f() -> felt252 { 0 }"#)
+        .build(&t);
+
+    Scarb::quick_command()
+        .arg("publish-docs")
+        .arg("--index")
+        .arg(&registry.url)
+        .current_dir(&t)
+        .timeout(Duration::from_secs(60))
+        .assert()
+        .failure()
+        .stdout_eq(indoc! {r#"
+        [..] Packaged [..]
+        [..] Uploading docs for bar v1.0.0 (registry+http[..])
+        error: missing authentication token. help: make sure SCARB_REGISTRY_AUTH_TOKEN environment variable is set
+        "#});
+}
+
+#[test]
+fn error_from_registry() {
+    // 400 -> StatusCode::BAD_REQUEST
+    let registry = HttpRegistry::serve(Some(HttpPostResponse {
+        code: 409,
+        message: Some("Docs for 'bar' already exist. Use force to overwrite.".to_string()),
+    }));
+
+    let t = TempDir::new().unwrap();
+    ProjectBuilder::start()
+        .name("bar")
+        .version("1.0.0")
+        .lib_cairo(r#"fn f() -> felt252 { 0 }"#)
+        .build(&t);
+
+    Scarb::quick_command()
+        .arg("publish-docs")
+        .arg("--index")
+        .arg(&registry.url)
+        .env("SCARB_REGISTRY_AUTH_TOKEN", "scrb_supersecrettoken")
+        .current_dir(&t)
+        .timeout(Duration::from_secs(60))
+        .assert()
+        .failure()
+        .stdout_eq(indoc! {r#"
+        [..] Packaged [..]
+        [..] Uploading docs for bar v1.0.0 (registry+http[..])
+        error: upload failed with status code: `409 Conflict`, `Docs for 'bar' already exist. Use force to overwrite.`
+        "#});
+
+    let expected = expect![["
+    GET /api/v1/index/config.json
+    accept: */*
+    accept-encoding: gzip, br, deflate
+    host: ...
+    user-agent: ...
+
+    200 OK
+    accept-ranges: bytes
+    content-length: ...
+    content-type: application/json
+    etag: ...
+    last-modified: ...
+
+    ###
+
+    POST /api/v1/docs/bar/1.0.0
+    accept: */*
+    accept-encoding: gzip, br, deflate
+    authorization: Bearer scrb_supersecrettoken
+    content-type: ...
+    host: ...
+    transfer-encoding: chunked
+    user-agent: ...
+
+    409 Conflict
+    content-type: text/plain; charset=utf-8
+    etag: ...
+    "]];
+    expected.assert_eq(&registry.logs());
+}

--- a/scarb/tests/registry_publish_docs.rs
+++ b/scarb/tests/registry_publish_docs.rs
@@ -104,7 +104,7 @@ fn auth_token_missing() {
 
 #[test]
 fn error_from_registry() {
-    // 400 -> StatusCode::BAD_REQUEST
+    // 409 -> StatusCode::CONFLICT
     let registry = HttpRegistry::serve(Some(HttpPostResponse {
         code: 409,
         message: Some("Docs for 'bar' already exist. Use force to overwrite.".to_string()),


### PR DESCRIPTION
This pull request adds a new test suite for the `publish-docs` functionality and refactors existing tests in `registry_publish.rs` to improve clarity and separation of concerns. The main focus is to provide dedicated tests for documentation publishing and to rename existing tests for better readability.

**New documentation publishing tests:**

* Added a new test file `registry_publish_docs.rs` with comprehensive tests for the `publish-docs` command, including success, authentication failure, and registry error scenarios.

**Test refactoring and renaming:**

* Renamed test functions in `registry_publish.rs` to remove the `_without_docs` suffix, making their purpose clearer and distinguishing them from the new documentation publishing tests. [[1]](diffhunk://#diff-a86108b7d05f3405da1e6b5d381a298a57c8076ef67a1a6b78e81de4348ac701L101-R101) [[2]](diffhunk://#diff-a86108b7d05f3405da1e6b5d381a298a57c8076ef67a1a6b78e81de4348ac701L172-R172) [[3]](diffhunk://#diff-a86108b7d05f3405da1e6b5d381a298a57c8076ef67a1a6b78e81de4348ac701L215-R215) [[4]](diffhunk://#diff-a86108b7d05f3405da1e6b5d381a298a57c8076ef67a1a6b78e81de4348ac701L286-R286)<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>