### PR TITLE
Fix draft release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,20 @@ jobs:
           mv artifacts-dl/checksums/* artifacts/
           ls -lh artifacts/
 
+      - name: Determine release notes start tag
+        run: |
+          if [[ "$RELEASE_TAG" == *-rc* ]]; then
+            # because the release is a release candidate, we want to include pre-releases when determining the start tag for the release notes
+            RELEASE_NOTES_START_TAG=$(gh release list --json tagName --limit 1 --exclude-drafts --jq '.[0].tagName')
+          else
+            # because the release is not a release candidate, we want to exclude pre-releases when determining the start tag for the release notes
+            RELEASE_NOTES_START_TAG=$(gh release list --json tagName --limit 1 --exclude-pre-releases --exclude-drafts --jq '.[0].tagName')
+          fi
+          echo "RELEASE_NOTES_START_TAG=${RELEASE_NOTES_START_TAG}" >> $GITHUB_ENV
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.ref_name }}
+
       - name: Draft GitHub release
         run: |
           gh release create \
@@ -49,7 +63,8 @@ jobs:
             --draft \
             --title "${RELEASE_TAG}" \
             --generate-notes \
-            --verify-tag
+            --verify-tag \
+            --notes-start-tag "${RELEASE_NOTES_START_TAG}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ github.ref_name }}


### PR DESCRIPTION
 #3229
This pull request updates the release workflow to improve how release notes are generated, ensuring they start from the correct tag depending on whether the release is a release candidate or a regular release. The main changes are:

**Release notes generation improvements:**

* Added a step to determine the appropriate `RELEASE_NOTES_START_TAG` by checking if the release is a release candidate (`-rc`). If so, pre-releases are included when finding the start tag; otherwise, only stable releases are considered. (`.github/workflows/release.yml`)
* Updated the GitHub release creation step to use the new `--notes-start-tag "${RELEASE_NOTES_START_TAG}"` argument, ensuring the generated release notes start from the correct previous release. (`.github/workflows/release.yml`)