### PR TITLE
Publish plugins fix

### DIFF
--- a/.github/workflows/publish_plugins.yml
+++ b/.github/workflows/publish_plugins.yml
@@ -1,5 +1,8 @@
 name: Publish Built-in Plugins
 on:
+  release:
+    types:
+      - published
   workflow_dispatch:
     inputs:
       version_tag:
@@ -19,6 +22,9 @@ on:
         required: true
       SLACK_PUBLISH_PLUGINS_FAILURE_WEBHOOK_URL:
         required: true
+
+permissions:
+  contents: read
 
 jobs:
   publish:

--- a/.github/workflows/publish_plugins.yml
+++ b/.github/workflows/publish_plugins.yml
@@ -9,19 +9,6 @@ on:
         required: false
         type: string
         description: Scarb version to publish from.
-  workflow_call:
-    inputs:
-      version_tag:
-        required: false
-        type: string
-        description: Scarb version to publish from.
-    secrets:
-      SCARB_REGISTRY_AUTH_TOKEN:
-        required: true
-      SCARB_DEV_REGISTRY_AUTH_TOKEN:
-        required: true
-      SLACK_PUBLISH_PLUGINS_FAILURE_WEBHOOK_URL:
-        required: true
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,16 +53,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ github.ref_name }}
-
-  publish_plugins:
-    name: publish plugins
-    needs: [ draft ]
-    permissions:
-      contents: read
-    uses: ./.github/workflows/publish_plugins.yml
-    with:
-      version_tag: ${{ github.ref_name }}
-    secrets:
-      SCARB_REGISTRY_AUTH_TOKEN: ${{ secrets.SCARB_REGISTRY_AUTH_TOKEN }}
-      SCARB_DEV_REGISTRY_AUTH_TOKEN: ${{ secrets.SCARB_DEV_REGISTRY_AUTH_TOKEN }}
-      SLACK_PUBLISH_PLUGINS_FAILURE_WEBHOOK_URL: ${{ secrets.SLACK_PUBLISH_PLUGINS_FAILURE_WEBHOOK_URL }}
+          


### PR DESCRIPTION
#3232 
This pull request updates the GitHub Actions workflows related to publishing built-in plugins. The main change is to trigger the `publish_plugins` workflow automatically when a new release is published, instead of invoking it from the `release.yml` workflow. It also adds required permissions to the workflow configuration.

**Workflow automation improvements:**

* The `publish_plugins.yml` workflow is now triggered automatically on GitHub release publication (`release.published`), in addition to manual dispatch, making the plugin publishing process more streamlined.
* The `publish_plugins` job invocation was removed from `release.yml`, so it is no longer triggered as a dependent job after drafting a release.

**Security and configuration:**

* Added explicit `contents: read` permissions to the `publish_plugins.yml` workflow for better security and compliance with GitHub Actions best practices.