### PR TITLE
Add cairo-lang check to workflow

### DIFF
--- a/.github/workflows/_check-cairo-lang-versions.yml
+++ b/.github/workflows/_check-cairo-lang-versions.yml
@@ -77,11 +77,16 @@ jobs:
           # A crate fails the check if it resolved to more than one version, more
           # than one source, or any source that isn't the crates.io registry
           # (e.g. a leftover git dependency).
-          jq -e '
+          bad=$(jq -c '
             map(select(
               (.versions | length) > 1
               or (.sources | length) > 1
               or (.sources[0] | startswith("registry+") | not)
             ))
-            | length == 0
-          ' <<< "$summary"
+          ' <<< "$summary")
+
+          if [ "$bad" != "[]" ]; then
+            echo "Cairo toolchain crates do not resolve to a single, registry-sourced version in Cargo.lock:"
+            jq . <<< "$bad"
+            exit 1
+          fi

--- a/.github/workflows/_check-cairo-lang-versions.yml
+++ b/.github/workflows/_check-cairo-lang-versions.yml
@@ -1,0 +1,87 @@
+name: Check Cairo-lang Versions
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        required: false
+        type: string
+  workflow_call:
+    inputs:
+      ref:
+        required: false
+        type: string
+
+jobs:
+  check:
+    name: cairo-lang versions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Fetch scripts/crates_list.sh from the matching Cairo release, or the newest one if it doesn't exist
+        id: fetch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REF: ${{ inputs.ref }}
+        run: |
+          tag=$REF
+
+          if ! gh api repos/starkware-libs/cairo/releases/tags/$tag --jq .tag_name >/dev/null 2>&1; then
+            tag=$(gh api repos/starkware-libs/cairo/releases/latest --jq .tag_name)
+          fi
+
+          curl -sSfL "https://raw.githubusercontent.com/starkware-libs/cairo/$tag/scripts/crates_list.sh" -o crates_list.sh
+
+      - name: Parse cairo-lang-* crate names out of it
+        id: parse
+        run: |
+          names=$(grep -oE 'cairo-lang-[a-zA-Z0-9_-]+' crates_list.sh | sort -u)
+          names_json=$(jq -R -s -c 'split("\n") | map(select(length > 0))' <<< "$names")
+
+          echo "names_json=$names_json" >> "$GITHUB_OUTPUT"
+
+      - name: Fail if any of those crates resolve to more than one version, or a non-registry source, in Cargo.lock
+        env:
+          NAMES_JSON: ${{ steps.parse.outputs.names_json }}
+        run: |
+          # The resolved dependency graph exactly as frozen in Cargo.lock (--locked
+          # errors out instead of silently re-resolving if the lock is stale).
+          metadata=$(cargo metadata --locked --format-version=1)
+
+          # Names of local/workspace crates (path dependencies have no `source`).
+          # These are excluded below since they can share a name with an externally
+          # published crate without it meaning anything (e.g. our own cairo-lang-macro).
+          local_names=$(jq -c '[.packages[] | select(.source == null) | .name]' <<< "$metadata")
+
+          # Keep only externally-sourced packages that are in our target crate list
+          # and aren't also a local crate name.
+          candidates=$(jq -c --argjson names "$NAMES_JSON" --argjson local "$local_names" '
+            .packages
+            | map(select(
+                .source != null
+                and (.name as $n | $names | index($n))
+                and (.name as $n | $local | index($n) | not)
+              ))
+          ' <<< "$metadata")
+
+          # Collapse each crate name to the distinct versions/sources it resolved to -
+          # more than one of either means the dependency graph is inconsistent.
+          summary=$(jq -c '
+            group_by(.name)
+            | map({name: .[0].name, versions: (map(.version) | unique), sources: (map(.source) | unique)})
+          ' <<< "$candidates")
+
+          # A crate fails the check if it resolved to more than one version, more
+          # than one source, or any source that isn't the crates.io registry
+          # (e.g. a leftover git dependency).
+          jq -e '
+            map(select(
+              (.versions | length) > 1
+              or (.sources | length) > 1
+              or (.sources[0] | startswith("registry+") | not)
+            ))
+            | length == 0
+          ' <<< "$summary"

--- a/.github/workflows/_check-release.yml
+++ b/.github/workflows/_check-release.yml
@@ -85,3 +85,18 @@ jobs:
         run: |
           cargo test -p scarb --profile=ci --test main proc_macro_v1_prebuilt::
           cargo test -p scarb --profile=ci --test main proc_macro_v2_prebuilt::
+
+  ciaro-lang-check:
+    name: ciaro-lang check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Fail if cairo-lang uses wildcard versions in Cargo.toml
+        run: |
+          ! grep -E 'cairo-lang-.*=\s*"\*"' Cargo.toml 
+          
+      - name: Fail if cairo-lang uses direct git dependencies in Cargo.toml
+        run: |
+          ! grep -E 'cairo-lang-.*=\s*\{.*git"' Cargo.toml
+

--- a/.github/workflows/_check-release.yml
+++ b/.github/workflows/_check-release.yml
@@ -86,17 +86,3 @@ jobs:
           cargo test -p scarb --profile=ci --test main proc_macro_v1_prebuilt::
           cargo test -p scarb --profile=ci --test main proc_macro_v2_prebuilt::
 
-  ciaro-lang-check:
-    name: ciaro-lang check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-
-      - name: Fail if cairo-lang uses wildcard versions in Cargo.toml
-        run: |
-          ! grep -E 'cairo-lang-.*=\s*"\*"' Cargo.toml 
-          
-      - name: Fail if cairo-lang uses direct git dependencies in Cargo.toml
-        run: |
-          ! grep -E 'cairo-lang-.*=\s*\{.*git"' Cargo.toml
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,11 @@ jobs:
   check:
     uses: ./.github/workflows/_check-release.yml
 
+  check-cairo-lang-versions:
+    uses: ./.github/workflows/_check-cairo-lang-versions.yml
+    with:
+      ref: ${{ github.ref_name }}
+
   release:
     uses: ./.github/workflows/_build-release.yml
     with:
@@ -21,7 +26,7 @@ jobs:
   draft:
     name: draft release
     runs-on: ubuntu-latest
-    needs: [ check, release ]
+    needs: [ check, check-cairo-lang-versions, release ]
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
#3231 
This pull request introduces a new workflow to ensure that all `cairo-lang-*` crates used in the project resolve to a single, registry-sourced version in `Cargo.lock`. It integrates this check into the release process to catch dependency inconsistencies early and prevent accidental use of multiple versions or non-registry sources for these critical crates.

**Dependency consistency enforcement:**

* Added a new workflow file, `.github/workflows/_check-cairo-lang-versions.yml`, which fetches the list of `cairo-lang-*` crates from the appropriate Cairo release and verifies that each resolves to a single version and source in `Cargo.lock`, failing the workflow if any inconsistencies are found.
* Integrated the new `check-cairo-lang-versions` job into the main release workflow (`.github/workflows/release.yml`), ensuring it runs alongside existing checks before a release is drafted. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R15-R19) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L24-R29)
