### PR TITLE
Trigger maat experiments on release branch PRs

### DIFF
--- a/.github/workflows/release-experiment.yml
+++ b/.github/workflows/release-experiment.yml
@@ -1,0 +1,42 @@
+name: Trigger Release Experiment
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - 'main'
+
+# Supported branch partterns:
+# release/1.2.3, release/v1.2.3, release-1.2.3, release-v1.2.3
+
+jobs:
+  dispatch-experiment:
+    if: startsWith(github.head_ref, 'release/') || startsWith(github.head_ref, 'release-')
+    runs-on: ubuntu-latest
+
+    steps: 
+      - name: Extract version from branch name
+        env:
+          RAW_REF: ${{ github.head_ref }}
+        run: |
+          VERSION=${RAW_REF}
+
+          # Strip 'release/' or 'release-' prefix from the branch name to get the version
+          VERSION=${VERSION#release/}
+          VERSION=${VERSION#release-}
+
+          # Strip 'v' prefix from the version if it exists
+          VERSION=${VERSION#v}
+
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+
+      - name: Trigger Release Experiment
+        env:
+          GH_TOKEN: ${{ secrets.MAAT_EXPERIMENTS_DISPATCH_TOKEN }}
+        run: |
+          gh workflow run experiment.yml \
+            --repo software-mansion/maat \
+            --ref main \
+            -f workspace="release" \
+            -f scarb="$VERSION" \
+            -f notify_team="true"


### PR DESCRIPTION

## [Task](https://github.com/software-mansion/maat/issues/115)
--- 
This pull request introduces a new GitHub Actions workflow to automate the process of triggering release experiments when a pull request is opened or updated for a release branch. The workflow extracts the version from the branch name and dispatches an experiment workflow in the `maat` repository.

**New GitHub Actions workflow for release branches:**

* Added `.github/workflows/release-experiment.yml` to trigger an experiment workflow when a pull request targets the `main` branch and the source branch name matches release patterns (e.g., `release/1.2.3`, `release-v1.2.3`). The workflow extracts the version from the branch name and triggers the `experiment.yml` workflow in the `software-mansion/maat` repository, passing the version and other parameters.
