### PR TITLE
Check cairo-lang-* versions during release

### DIFF
--- a/.github/workflows/_check-cairo-lang-versions.yml
+++ b/.github/workflows/_check-cairo-lang-versions.yml
@@ -18,8 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
       - name: Fetch scripts/crates_list.sh from the matching Cairo release, or the newest one if it doesn't exist
         id: fetch
@@ -77,11 +79,16 @@ jobs:
           # A crate fails the check if it resolved to more than one version, more
           # than one source, or any source that isn't the crates.io registry
           # (e.g. a leftover git dependency).
-          jq -e '
+          bad=$(jq -c '
             map(select(
               (.versions | length) > 1
               or (.sources | length) > 1
               or (.sources[0] | startswith("registry+") | not)
             ))
-            | length == 0
-          ' <<< "$summary"
+          ' <<< "$summary")
+
+          if [ "$bad" != "[]" ]; then
+            echo "Cairo toolchain crates do not resolve to a single, registry-sourced version in Cargo.lock:"
+            jq . <<< "$bad"
+            exit 1
+          fi

--- a/.github/workflows/_check-cairo-lang-versions.yml
+++ b/.github/workflows/_check-cairo-lang-versions.yml
@@ -1,0 +1,87 @@
+name: Check Cairo-lang Versions
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        required: false
+        type: string
+  workflow_call:
+    inputs:
+      ref:
+        required: false
+        type: string
+
+jobs:
+  check:
+    name: cairo-lang versions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Fetch scripts/crates_list.sh from the matching Cairo release, or the newest one if it doesn't exist
+        id: fetch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REF: ${{ inputs.ref }}
+        run: |
+          tag=$REF
+
+          if ! gh api repos/starkware-libs/cairo/releases/tags/$tag --jq .tag_name >/dev/null 2>&1; then
+            tag=$(gh api repos/starkware-libs/cairo/releases/latest --jq .tag_name)
+          fi
+
+          curl -sSfL "https://raw.githubusercontent.com/starkware-libs/cairo/$tag/scripts/crates_list.sh" -o crates_list.sh
+
+      - name: Parse cairo-lang-* crate names out of it
+        id: parse
+        run: |
+          names=$(grep -oE 'cairo-lang-[a-zA-Z0-9_-]+' crates_list.sh | sort -u)
+          names_json=$(jq -R -s -c 'split("\n") | map(select(length > 0))' <<< "$names")
+
+          echo "names_json=$names_json" >> "$GITHUB_OUTPUT"
+
+      - name: Fail if any of those crates resolve to more than one version, or a non-registry source, in Cargo.lock
+        env:
+          NAMES_JSON: ${{ steps.parse.outputs.names_json }}
+        run: |
+          # The resolved dependency graph exactly as frozen in Cargo.lock (--locked
+          # errors out instead of silently re-resolving if the lock is stale).
+          metadata=$(cargo metadata --locked --format-version=1)
+
+          # Names of local/workspace crates (path dependencies have no `source`).
+          # These are excluded below since they can share a name with an externally
+          # published crate without it meaning anything (e.g. our own cairo-lang-macro).
+          local_names=$(jq -c '[.packages[] | select(.source == null) | .name]' <<< "$metadata")
+
+          # Keep only externally-sourced packages that are in our target crate list
+          # and aren't also a local crate name.
+          candidates=$(jq -c --argjson names "$NAMES_JSON" --argjson local "$local_names" '
+            .packages
+            | map(select(
+                .source != null
+                and (.name as $n | $names | index($n))
+                and (.name as $n | $local | index($n) | not)
+              ))
+          ' <<< "$metadata")
+
+          # Collapse each crate name to the distinct versions/sources it resolved to -
+          # more than one of either means the dependency graph is inconsistent.
+          summary=$(jq -c '
+            group_by(.name)
+            | map({name: .[0].name, versions: (map(.version) | unique), sources: (map(.source) | unique)})
+          ' <<< "$candidates")
+
+          # A crate fails the check if it resolved to more than one version, more
+          # than one source, or any source that isn't the crates.io registry
+          # (e.g. a leftover git dependency).
+          jq -e '
+            map(select(
+              (.versions | length) > 1
+              or (.sources | length) > 1
+              or (.sources[0] | startswith("registry+") | not)
+            ))
+            | length == 0
+          ' <<< "$summary"

--- a/.github/workflows/_check-cairo-lang-versions.yml
+++ b/.github/workflows/_check-cairo-lang-versions.yml
@@ -2,15 +2,7 @@ name: Check Cairo-lang Versions
 
 on:
   workflow_dispatch:
-    inputs:
-      ref:
-        required: false
-        type: string
   workflow_call:
-    inputs:
-      ref:
-        required: false
-        type: string
 
 jobs:
   check:
@@ -23,25 +15,34 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
-      - name: Fetch scripts/crates_list.sh from the matching Cairo release, or the newest one if it doesn't exist
-        id: fetch
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REF: ${{ inputs.ref }}
+      - name: Determine the Cairo release tag
+        id: cairo-tag
         run: |
-          tag=$REF
+          version=$(cargo metadata --locked --format-version=1 \
+            | jq -r '.packages[] | select(.name == "cairo-lang-compiler") | .version')
 
-          if ! gh api repos/starkware-libs/cairo/releases/tags/$tag --jq .tag_name >/dev/null 2>&1; then
-            tag=$(gh api repos/starkware-libs/cairo/releases/latest --jq .tag_name)
-          fi
+          echo "tag=v$version" >> "$GITHUB_OUTPUT"
 
-          curl -sSfL "https://raw.githubusercontent.com/starkware-libs/cairo/$tag/scripts/crates_list.sh" -o crates_list.sh
+      - name: Fetch scripts/crates_list.sh
+        env:
+          TAG: ${{ steps.cairo-tag.outputs.tag }}
+        run: |
+          curl -sSfL "https://raw.githubusercontent.com/starkware-libs/cairo/$TAG/scripts/crates_list.sh" -o crates_list.sh
 
-      - name: Parse cairo-lang-* crate names out of it
+      - name: Parse crate names
         id: parse
         run: |
-          names=$(grep -oE 'cairo-lang-[a-zA-Z0-9_-]+' crates_list.sh | sort -u)
-          names_json=$(jq -R -s -c 'split("\n") | map(select(length > 0))' <<< "$names")
+          # Only eval the CRATES array definition itself, not the rest of the
+          # script, which assumes it's running inside a Cairo checkout.
+          array_def=$(sed -n '/^CRATES=(/,/^)/p' crates_list.sh)
+          eval "$array_def"
+
+          # Registry-pinned crates that aren't part of the Cairo repo's own
+          # release list, but should still resolve to a single registry version.
+          extra_names=(cairo-lang-language-server cairo-lint)
+
+          names_json=$(printf '%s\n' "${CRATES[@]}" "${extra_names[@]}" \
+            | jq -R -s -c 'split("\n") | map(select(length > 0)) | unique')
 
           echo "names_json=$names_json" >> "$GITHUB_OUTPUT"
 
@@ -53,20 +54,9 @@ jobs:
           # errors out instead of silently re-resolving if the lock is stale).
           metadata=$(cargo metadata --locked --format-version=1)
 
-          # Names of local/workspace crates (path dependencies have no `source`).
-          # These are excluded below since they can share a name with an externally
-          # published crate without it meaning anything (e.g. our own cairo-lang-macro).
-          local_names=$(jq -c '[.packages[] | select(.source == null) | .name]' <<< "$metadata")
-
-          # Keep only externally-sourced packages that are in our target crate list
-          # and aren't also a local crate name.
-          candidates=$(jq -c --argjson names "$NAMES_JSON" --argjson local "$local_names" '
+          candidates=$(jq -c --argjson names "$NAMES_JSON" '
             .packages
-            | map(select(
-                .source != null
-                and (.name as $n | $names | index($n))
-                and (.name as $n | $local | index($n) | not)
-              ))
+            | map(select(.name as $n | $names | index($n)))
           ' <<< "$metadata")
 
           # Collapse each crate name to the distinct versions/sources it resolved to -
@@ -83,7 +73,7 @@ jobs:
             map(select(
               (.versions | length) > 1
               or (.sources | length) > 1
-              or (.sources[0] | startswith("registry+") | not)
+              or ((.sources[0] // "") | startswith("registry+") | not)
             ))
           ' <<< "$summary")
 

--- a/.github/workflows/_check-release.yml
+++ b/.github/workflows/_check-release.yml
@@ -85,3 +85,18 @@ jobs:
         run: |
           cargo test -p scarb --profile=ci --test main proc_macro_v1_prebuilt::
           cargo test -p scarb --profile=ci --test main proc_macro_v2_prebuilt::
+
+  ciaro-lang-check:
+    name: ciaro-lang check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Fail if cairo-lang uses wildcard versions in Cargo.toml
+        run: |
+          ! grep -E 'cairo-lang-.*=\s*"\*"' Cargo.toml 
+          
+      - name: Fail if cairo-lang uses direct git dependencies in Cargo.toml
+        run: |
+          ! grep -E 'cairo-lang-.*=\s*\{.*git"' Cargo.toml
+

--- a/.github/workflows/_check-release.yml
+++ b/.github/workflows/_check-release.yml
@@ -86,17 +86,3 @@ jobs:
           cargo test -p scarb --profile=ci --test main proc_macro_v1_prebuilt::
           cargo test -p scarb --profile=ci --test main proc_macro_v2_prebuilt::
 
-  ciaro-lang-check:
-    name: ciaro-lang check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-
-      - name: Fail if cairo-lang uses wildcard versions in Cargo.toml
-        run: |
-          ! grep -E 'cairo-lang-.*=\s*"\*"' Cargo.toml 
-          
-      - name: Fail if cairo-lang uses direct git dependencies in Cargo.toml
-        run: |
-          ! grep -E 'cairo-lang-.*=\s*\{.*git"' Cargo.toml
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,11 @@ jobs:
   check:
     uses: ./.github/workflows/_check-release.yml
 
+  check-cairo-lang-versions:
+    uses: ./.github/workflows/_check-cairo-lang-versions.yml
+    with:
+      ref: ${{ github.ref_name }}
+
   release:
     uses: ./.github/workflows/_build-release.yml
     with:
@@ -21,7 +26,7 @@ jobs:
   draft:
     name: draft release
     runs-on: ubuntu-latest
-    needs: [ check, release ]
+    needs: [ check, check-cairo-lang-versions, release ]
     permissions:
       contents: write
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,6 @@ jobs:
 
   check-cairo-lang-versions:
     uses: ./.github/workflows/_check-cairo-lang-versions.yml
-    with:
-      ref: ${{ github.ref_name }}
 
   release:
     uses: ./.github/workflows/_build-release.yml


### PR DESCRIPTION
## Description:
Adds a release-gate check that fails if any `cairo-lang-*` crate resolves to more than one version, or to a non-registry (e.g. git) source, in `Cargo.lock` — catching leftover `[patch.crates-io]`/git-pinned dependencies from active Cairo development that should have been reverted before release.

- New reusable workflow `_check-cairo-lang-versions.yml`, wired into `release.yml`.
- Crate names to check are fetched from `crates_list.sh` in the matching (or newest stable) `starkware-libs/cairo` release, so the list doesn't need manual upkeep.
- Uses `cargo metadata`, so it checks the actual resolved graph, not just `Cargo.toml` constraints - correctly ignoring local path crates like `cairo-lang-macro`.
- Removes the old, ineffective grep-based check in `_check-release.yml`.

Closes #3231.